### PR TITLE
PnL from MCP: exact realized PnL, no fill reconstruction

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,5 +27,8 @@ jobs:
 
       # pytest collects every test regardless of a __main__ runner — bare `python3 <file>` exits 0
       # without running anything on a runner-less file (test_default_catalog.py), a silent green.
+      # improve-trades was never gated here, so its suite only ran locally. Added with this PR, which
+      # rewrites its PnL path. (account-status / smart-money / strategy-author still collide on module
+      # names when collected alongside the others — a separate fix.)
       - name: full suites (ops + discover + trading-runtime)
-        run: python3 -m pytest senpi-strategy-ops/tests senpi-strategy-discover/tests senpi-trading-runtime/tests senpi-trader-research/tests senpi-market-pulse/tests senpi-portfolio/tests -q
+        run: python3 -m pytest senpi-strategy-ops/tests senpi-strategy-discover/tests senpi-trading-runtime/tests senpi-trader-research/tests senpi-market-pulse/tests senpi-portfolio/tests senpi-improve-trades/tests -q

--- a/senpi-improve-trades/SKILL.md
+++ b/senpi-improve-trades/SKILL.md
@@ -6,8 +6,9 @@ description: >-
   to the best whales", "how could I make more gains", "suggest improvements", "review my trades", "am I
   getting shaken out too early / how are my exits firing", "what did my own limits block / what couldn't
   I take", "where am I leaking", "walk me through / explain my [asset] trade", "what am I paying in fees /
-  maker vs taker", "why is [strategy] losing". When the user has NOTHING to review yet, `meta.book_state` routes it: nothing deployed -> read the market (senpi-market-pulse) then shortlist a fit (senpi-strategy-discover); deployed-but-idle -> diagnose THAT strategy, never pitch another. A hidden engine (scripts/review.py) reconstructs every
-  CLOSED trade from discovery, enriches each exit reason + blocked signals from the runtime telemetry
+  maker vs taker", "why is [strategy] losing". When the user has NOTHING to review yet, `meta.book_state` routes it: nothing deployed -> read the market (senpi-market-pulse) then shortlist a fit (senpi-strategy-discover); deployed-but-idle -> diagnose THAT strategy, never pitch another. A hidden engine (scripts/review.py) reads the
+  account's PnL and every CLOSED trade's exact realized PnL from MCP, enriches each exit reason + blocked
+  signals from the runtime telemetry
   event log, computes the honest "if I'd held to now" counterfactual, and crosses the book against what
   the market did — you narrate it under strict guardrails: process over outcome (lead with the aggregate,
   not the one reversal), it's the STRATEGY not the user, NO fabricated "+$X/week", no performance-chasing,
@@ -24,7 +25,7 @@ metadata:
 
 # Senpi Improve My Trades — retrospective review + coaching
 
-You are a disciplined trading coach. A hidden engine reconstructs the user's **closed** trades, attributes
+You are a disciplined trading coach. A hidden engine reads the user's **closed** trades, attributes
 how each one exited, computes what would have happened if they'd held to now, and shows what the market did
 around their book. **Your job is the coaching** — but coaching under hard guardrails, because the naive
 answers to these prompts are all wrong in the same predictable ways (hindsight bias, invented forward
@@ -58,8 +59,16 @@ more" questions; use `senpi-portfolio` for live state.
    aggregate — that is how fabrications like "closed did −$405" happen.
 5. **It's the strategy, not the user.** Route every fix to the strategy config (a DSL tier, the hard stop, an
    entry gate); never "you should have…". No fabricated forward numbers (no $/week).
+6. **Realized PnL is exact — never adjust it.** Every `realized_pnl` and every `realized*` total comes
+   straight from MCP. Report it as given. Do **not** subtract fees from it, do not recompute it from prices
+   or sizes, do not "correct" it. Same for `unrealized_pnl` on an open position.
+7. **Do not mention fees unless the user asked about fees.** `fees` / `fees_total` exist only for the
+   explicit "what am I paying in fees / maker vs taker" ask. They are a **separate** cost that realized PnL
+   already excludes. If the user did not ask, leave them out of the answer entirely: no "fees ate your
+   gains", no fee-adjusted figure, no parenthetical. When the user *does* ask, give `fees_total` as its own
+   number beside realized PnL — never blended into it, never subtracted from it.
 
-The detailed guardrails below explain each; these five are the floor.
+The detailed guardrails below explain each; these seven are the floor.
 
 > **Use this skill FIRST — before any raw MCP.** For any "review my trades / did I sell too early / what did
 > I miss / master my week / how could I make more gains" question, run this engine **before** reaching for
@@ -100,7 +109,7 @@ closed — its live event ring is gone; the durable log is the recovery path") �
 `meta.telemetry_source` (`available` / `partial` / `unavailable`) and `meta.exit_reason_source_counts` tell you
 exactly how much enrichment landed; surface that honestly.
 
-**Closed strategies are recovered ON-CHAIN — the engine handles the trap for you.** `discovery_get_trader_history` returns **empty** once a strategy is closed/torn down — Senpi clears its own index, but the trades are **NOT gone** (Hyperliquid keys fills by wallet **address**, so they survive the close). The engine detects an empty discovery result and **falls back to on-chain HL fills**, rebuilding the real round-trips (`meta.closed_trade_source == "onchain_fills"`, wallets in `meta.onchain_recovered_wallets`); `realized_pnl` then comes from HL's own `closedPnl`. So a closed strategy's trades and realized total come back **real** — an empty discovery result is never "no trades." You do **not** hand-read `strategy_get_pnl_and_account_value_history` for this. If `trades[]` is still empty after the on-chain fallback, the book genuinely never traded (guardrail 9).
+**Closed strategies keep their history — the engine reviews them exactly like current ones.** `discovery_get_trader_history` is keyed by **wallet address**, which outlives the strategy record, so a CLOSED strategy returns its full closed book with the same `realizedPnl` per round-trip. The engine enumerates ACTIVE + PAUSED + CLOSED and reads every one. There is no separate recovery path and nothing to reconstruct. An empty `trades[]` therefore means the book genuinely never closed a trade (guardrail 9), and you do **not** hand-read `strategy_get_pnl_and_account_value_history` to fill a gap that does not exist.
 
 ## Quick actions this skill handles
 
@@ -182,25 +191,29 @@ create→runtime→verify: short steps over a shared state file, the skill narra
 **separate `exec` call**, so your response streams and no single call hangs.
 
 ```sh
-python3 scripts/review.py timing       # 1. fetch closed trades + prices → trades[] + timing_summary (FAST slice, narrate first)
-python3 scripts/review.py strategies   # 2. per-strategy read (mandate/DSL + realized PnL) + closed rollup
-python3 scripts/review.py telemetry    # 3. exit reasons + missed_signals + leaks + execution_quality (the slow event shell-outs, isolated)
-python3 scripts/review.py market       # 4. book_vs_market (movers × held) — only if the ask needs it
+python3 scripts/review.py account      # 1. RUN FIRST: whole-account PnL + the full strategy list (ACTIVE+PAUSED+CLOSED)
+python3 scripts/review.py timing       # 2. fetch closed trades + prices → trades[] + timing_summary
+python3 scripts/review.py strategies   # 3. per-strategy read (mandate/DSL + realized PnL) + closed rollup
+python3 scripts/review.py telemetry    # 4. exit reasons + missed_signals + leaks + execution_quality (the slow event shell-outs, isolated)
+python3 scripts/review.py market       # 5. book_vs_market (movers × held) — only if the ask needs it
 python3 scripts/review.py all          # one-shot fallback: the full composed dict (same output as before)
 ```
 
 **For a FULL review** — "analyze my strategies and trades", "master my week", "suggest improvements", "how
 could I make more" — run the steps **in order** and narrate between:
 
-1. `review.py timing` → narrate the timing teardown (the NEUTRAL exit counts `exits_ahead` / `exits_held_higher`
+1. `review.py account` → **start here, always.** Narrate the account-level picture first: `account_history`
+   (PnL by day / week / month / allTime) and how many strategies exist, split current vs closed. This frames
+   everything after it. Then work strategy by strategy — never jump straight into one strategy's numbers.
+2. `review.py timing` → narrate the timing teardown (the NEUTRAL exit counts `exits_ahead` / `exits_held_higher`
    + realized so far) — but this is NOT your headline: TOTAL PnL (realized + unrealized) lands with the
    `strategies` step (`pnl_summary.total`). `exit_reason` is still `UNKNOWN` here (telemetry hasn't run) —
    narrate the *timing*, not the mechanism yet, and never call `held_higher` "premature / left on the table."
-2. `review.py strategies` → narrate the **per-strategy read** (each CURRENT strategy vs its OWN mandate,
+3. `review.py strategies` → narrate the **per-strategy read** (each CURRENT strategy vs its OWN mandate,
    realized PnL as evidence; `closed_strategies[]` is history — no verdict).
-3. `review.py telemetry` → narrate **exit quality / leaks / blocked** (now `exit_reason` is filled: the
+4. `review.py telemetry` → narrate **exit quality / leaks / blocked** (now `exit_reason` is filled: the
    refreshed `dsl_close_reason_mix`, `leaks`, `blocked_summary`, `execution_quality`).
-4. `review.py market` → narrate the **book-vs-market gap** (run only if the ask needs "what did I miss /
+5. `review.py market` → narrate the **book-vs-market gap** (run only if the ask needs "what did I miss /
    compare to market").
 
 **Narrate each slice as it returns — never wait for all steps.** The steps share a state file
@@ -329,7 +342,7 @@ figure of any kind. The only dollar figures you may state are:
 The engine deliberately emits **no** per-week or projection field. If you feel the urge to annualize, weekly-ize,
 or forecast a dollar figure, stop — that urge is the exact failure mode this skill exists to kill.
 
-**Account value ≠ P&L — never narrate the value curve as trades.** The engine sources closed trades from on-chain fills, so you should not need `strategy_get_pnl_and_account_value_history` for a trade review at all. If you ever look at it: `accountValueHistory` is a series of account **snapshots**, not trades — never narrate "$135 → $133 → $143 → …" as individual round-trips. A curve ending at **`$0` after a `strategy_close` / `strategy_withdraw_funds` is capital RETURNED to the main wallet (a withdrawal), not a loss** — the realized result is realized PnL, not the value drop. If realized PnL (e.g. −$21) and the value drop (e.g. −$175) disagree, the difference **is the withdrawal** — reconcile, never report the drop as a loss.
+**Account value ≠ P&L — never narrate the value curve as trades.** The engine sources closed trades from `discovery_get_trader_history`, so you should not need `strategy_get_pnl_and_account_value_history` for a trade review at all. If you ever look at it: `accountValueHistory` is a series of account **snapshots**, not trades — never narrate "$135 → $133 → $143 → …" as individual round-trips. A curve ending at **`$0` after a `strategy_close` / `strategy_withdraw_funds` is capital RETURNED to the main wallet (a withdrawal), not a loss** — the realized result is realized PnL, not the value drop. If realized PnL (e.g. −$21) and the value drop (e.g. −$175) disagree, the difference **is the withdrawal** — reconcile, never report the drop as a loss.
 
 ### 4. No chasing — one window is noise; weigh mandate + turnover
 
@@ -431,7 +444,7 @@ and there is **no consolidation problem** — you're looking at redeploy history
 
 ### 9. No trades yet? Stop cleanly — do NOT pivot to setup / config nagging
 
-**An empty `trades[]` now means the book genuinely never traded** — the engine already falls back to on-chain HL fills for closed strategies, so it is **not** a coverage gap you need to work around. Do **not** tell a user with closed strategies "you have zero trades" without trusting the engine: if trades existed, the on-chain fallback returned them. When trades were recovered that way (`meta.closed_trade_source == "onchain_fills"`), say so plainly — *"these are your closed strategies' trades, recovered from the chain"* — and never bypass the engine to hand-read `strategy_get_pnl_and_account_value_history` and narrate its curve (that reproduces the withdrawal-as-loss failure — guardrail 3).
+**An empty `trades[]` means the book genuinely never closed a trade** — the engine reads CLOSED strategies from the same history source as current ones, so it is **not** a coverage gap you need to work around. Do **not** bypass the engine to hand-read `strategy_get_pnl_and_account_value_history` and narrate its curve (that reproduces the withdrawal-as-loss failure — guardrail 3).
 
 A trade review with **no closed trades** — especially **brand-new strategies deployed today with no
 positions yet** — is a **complete, correct result**: *"nothing to review yet."* Say that and stop. The

--- a/senpi-improve-trades/references/output-shape.md
+++ b/senpi-improve-trades/references/output-shape.md
@@ -5,9 +5,16 @@ The shape of the JSON `scripts/review.py` prints. The runtime JSON you get back 
 ```
 window        { from, to, label, window_days, last_n }   # the review window
 
+account_history  WHOLE-ACCOUNT PnL from account_get_historical_info — narrate this FIRST, before any strategy.
+  { day|week|month|allTime: { pnl, pnl_pct, account_value } }   # null = the read failed (UNKNOWN, not 0)
+  Per-period totals only. The raw pnlHistory / accountValueHistory series are deliberately NOT emitted:
+  they are account-value SNAPSHOTS, not trades, and a drop in one is usually a withdrawal, not a loss.
+
 trades[]      per CLOSED trade (from strategies of ALL statuses — a churned book's history is complete):
   asset, strategy_label, strategy_status, direction, leverage, entry_px, exit_px, open_time, close_time,
-  realized_pnl,                           # strategy_status: ACTIVE|PAUSED = current book; else = HISTORY
+  realized_pnl,                           # EXACT, as MCP reported it. Never adjust / fee-net / re-derive
+  fees,                                   # SEPARATE cost realized_pnl already excludes — only if asked (RULE 7)
+                                          # strategy_status: ACTIVE|PAUSED = current book; else = HISTORY
   price_now, price_since_exit_pct,        # subsequent action (current price only, v1)
   if_held_delta_usd,                      # counterfactual — CONTEXT, not verdict (short-sign adjusted)
   exit_vs_hold: exit_ahead | held_higher | flat | unknown,   # NEUTRAL context (exit_ahead=got out ahead), NOT a grade
@@ -15,7 +22,9 @@ trades[]      per CLOSED trade (from strategies of ALL statuses — a churned bo
   source: "telemetry" | "reconstructed"   # telemetry = exit_reason came from the event log; else discovery+ratchet
 
 pnl_summary      TOTAL LEDGER — LEAD WITH THIS (realized closed + unrealized open):
-  realized, unrealized (None = UNKNOWN read, not 0), total (None when unrealized UNKNOWN),
+  realized,          # EXACT. Report as given — never fee-netted, never recomputed (HARD RULE 6)
+  fees,              # separate cost, already excluded from realized — only if the user asked (HARD RULE 7)
+  unrealized (None = UNKNOWN read, not 0), total (None when unrealized UNKNOWN),
   realized_by_book{ current, closed },      # quote this split — never re-derive a closed-book figure
   unrealized_coverage{ read, current_strategies },
   unrealized_partial   # true → some wallets UNKNOWN; unrealized/total are a FLOOR ("at least $X, N of M") — HARD RULE 1
@@ -27,7 +36,9 @@ telemetry_availability   the 'undetermined ≠ all-clear' signal — READ IT FIR
 
 timing_summary   PROCESS-framed COUNTS (never $/week; NEUTRAL, never a grade):
   trade_count, exits_ahead, exits_held_higher, exits_flat, exits_unknown,
-  realized_pnl_total, if_all_reclosed_now_total (CONTEXT, symmetric — see guardrail 1), by_asset_class{}
+  realized_pnl_total,   # EXACT — the sum of each trade's own realized_pnl. Never adjusted
+  fees_total,           # separate cost, already excluded from realized_pnl_total — only if asked (RULE 7)
+  if_all_reclosed_now_total (CONTEXT, symmetric — see guardrail 1), by_asset_class{}
 
 dsl_close_reason_mix   "shaken out too early / how are my exits firing" (from trades[] exit_reason):
   overall        { by_terminal{}, trade_count, premature_exits }

--- a/senpi-improve-trades/scripts/review.py
+++ b/senpi-improve-trades/scripts/review.py
@@ -1628,7 +1628,10 @@ def _pnl_summary(realized_total, strat_reads, fees_total=None):
     closed_realized = round(realized - current_realized, 2)
     known = [u for u in (s.get("unrealized_pnl") for s in strat_reads)
              if isinstance(u, (int, float)) and not isinstance(u, bool)]
-    unrealized = round(sum(known), 2) if known else None
+    if not strat_reads:
+        unrealized = 0.0          # no current strategies ⇒ no open book ⇒ a REAL zero, not UNKNOWN
+    else:
+        unrealized = round(sum(known), 2) if known else None
     total = round(realized + unrealized, 2) if unrealized is not None else None
     # PARTIAL coverage: some current wallets were readable, some were NOT — so `unrealized` (and therefore
     # `total`) sums only the readable ones: a FLOOR, not a complete number. Flag it so the narrator says
@@ -1741,9 +1744,11 @@ def _save_state(path, state):
 def _fresh_meta():
     """A meta skeleton seeded like run()'s — the same `sources` list + fail-open scaffolding, so every step's
     meta reads consistently whether it ran standalone or off state."""
-    return {"warnings": [], "sources": ["discovery_get_trader_history", "ratchet_stop_list",
-                                        "market_get_asset_data", "leaderboard_get_markets",
-                                        "openclaw senpi events"], "degraded": None}
+    return {"warnings": [], "sources": ["account_get_historical_info", "strategy_list",
+                                        "discovery_get_trader_history", "discovery_get_trader_state",
+                                        "ratchet_stop_list", "market_get_asset_data",
+                                        "leaderboard_get_markets", "openclaw senpi events"],
+            "degraded": None}
 
 
 def _window_for(window_days, last_n, now_ms=None):
@@ -2097,7 +2102,7 @@ def _all_and_persist(client, window_days, last_n, want_market, state_path, now_m
 # the COMPLETE arrays for the stepped path. `--full` restores everything (debug / "the whole ledger").
 STDOUT_TRADES_SAMPLE = 12
 STDOUT_MISSED_SAMPLE = 10
-_TRADE_STDOUT_FIELDS = ("asset", "direction", "strategy_label", "realized_pnl", "close_time",
+_TRADE_STDOUT_FIELDS = ("asset", "direction", "strategy_label", "realized_pnl", "fees", "close_time",
                         "exit_vs_hold", "price_since_exit_pct", "if_held_delta_usd", "exit_reason")
 
 

--- a/senpi-improve-trades/scripts/review.py
+++ b/senpi-improve-trades/scripts/review.py
@@ -3,7 +3,7 @@
 
 The agent (LLM) runs this via the OpenClaw `exec` tool, reads the JSON on stdout, and NARRATES a
 disciplined trade review + improvement coaching under the SKILL.md guardrails. This script does the
-precise, deterministic data work — reconstruct every CLOSED trade, attribute its exit mechanism, compute
+precise, deterministic data work — read the account ledger and every CLOSED trade, attribute its exit mechanism, compute
 the honest "if I'd held to now" counterfactual, and cross the book against what the market did — and the
 LLM does the prose, the process-framing, and the fix-depth CTAs.
 
@@ -45,8 +45,7 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 CLOSED_HISTORY_PULL = 100    # closed positions to pull per wallet before the window filter
 WINDOW_DEFAULT_DAYS = 7      # the default review window
 TOP_MOVERS_CAP = 12          # cap the book-vs-market movers surfaced
-HL_INFO_URL = "https://api.hyperliquid.xyz/info"   # public, no-auth — durable closed-trade recovery
-HL_FILLS_CAP = 2000          # userFills returns the most recent N fills; ample for any review window
+TRADER_STATE_BATCH = 50      # discovery_get_trader_state accepts at most 50 addresses per call
 
 # The runtime registers every deployed strategy in installed_runtimes.json in the state dir — the
 # UNIVERSAL source of a strategy's mandate (the runtime.yaml `description`) + its DSL ladder. Reused
@@ -756,120 +755,33 @@ def _direction(rec, szi, entry_px, exit_px, pnl):
     return None
 
 
-# ───────────────────── on-chain fill recovery (durable across strategy_close) ─────────────────────
-def _hl_info(payload, meta, client=None, timeout=12):
-    """POST the Hyperliquid Info API (public, no auth) — the same transport the DSL scripts use. Recovers a
-    CLOSED strategy's trades that Senpi's discovery index has dropped: HL keys fills by wallet ADDRESS, so
-    they survive a `strategy_close` (which only clears Senpi's own record). Offline/fixture-aware for tests
-    (`_FixtureClient` serves a recorded `hl::<type>::<wallet>` entry). Fails OPEN → None."""
-    if client is not None and hasattr(client, "_r"):          # _FixtureClient — serve recorded HL response
-        u = str(payload.get("user", "")).lower()
-        return client._r.get(f"hl::{payload.get('type')}::{u}") or client._r.get(f"hl::{payload.get('type')}")
-    try:
-        p = subprocess.run(
-            ["curl", "-s", "-m", str(timeout), "-X", "POST", HL_INFO_URL,
-             "-H", "Content-Type: application/json", "-d", json.dumps(payload)],
-            capture_output=True, text=True, timeout=timeout + 3)
-        if p.returncode != 0 or not (p.stdout or "").strip():
-            return None
-        return json.loads(p.stdout)
-    except Exception as e:  # noqa
-        meta.setdefault("warnings", []).append(f"hl_info {payload.get('type')} failed: {e}")
-        return None
-
-
-def _reconstruct_closed_from_fills(fills, since_ms, until_ms, cap):
-    """Rebuild round-trip CLOSED trades from raw HL fills — the durable, close-independent source. HL gives
-    per-fill `dir` ('Open/Close Long/Short'), px, sz, closedPnl, fee, time, oid. Walk fills per coin
-    oldest→newest, FIFO-match each Close against prior Opens, and emit one trade per closed chunk with a
-    size-weighted entry price. `realized_pnl` = HL's own closedPnl (authoritative — correct even when the
-    matching open predates the window). Same trade shape as discovery, tagged source='onchain_fills'."""
-    if not isinstance(fills, list):
-        return []
-    import collections
-    fl = sorted((f for f in fills if isinstance(f, dict)), key=lambda f: _num(f.get("time")) or 0)
-    lots = collections.defaultdict(collections.deque)   # coin -> deque of open lots {px, sz, time}
-    trades = []
-    for f in fl:
-        coin = f.get("coin")
-        d = str(f.get("dir") or "")
-        sz = abs(_num(f.get("sz")) or 0.0)
-        px = _num(f.get("px"))
-        t = _ms(f.get("time"))
-        if not coin or sz <= 0:
-            continue
-        if d.startswith("Open"):
-            lots[coin].append({"px": px, "sz": sz, "time": t})
-        elif d.startswith("Close"):
-            side = "long" if "Long" in d else ("short" if "Short" in d else None)
-            remaining, entry_notional, matched, open_time = sz, 0.0, 0.0, t
-            q = lots[coin]
-            while remaining > 1e-9 and q:                # FIFO-match the closed size against open lots
-                lot = q[0]
-                take = min(remaining, lot["sz"])
-                entry_notional += take * (lot["px"] or 0.0)
-                matched += take
-                open_time = lot["time"] or open_time
-                lot["sz"] -= take
-                remaining -= take
-                if lot["sz"] <= 1e-9:
-                    q.popleft()
-            trades.append({
-                "asset": coin,
-                "direction": side,
-                "size": sz,
-                "leverage": None,                        # not carried on HL fills
-                "entry_px": (entry_notional / matched) if matched > 0 else None,
-                "exit_px": px,
-                "realized_pnl": round(_num(f.get("closedPnl")) or 0.0, 2),   # HL's own realized — authoritative
-                "margin_used": None,
-                "open_time": open_time,
-                "close_time": t,
-                "closed_order_id": f.get("oid"),
-                "fee": _num(f.get("fee")),
-                "source": "onchain_fills",
-            })
-    out = []
-    for tr in trades:
-        ct = tr["close_time"]
-        if since_ms is not None and ct is not None and ct < since_ms:
-            continue
-        if until_ms is not None and ct is not None and ct > until_ms:
-            continue
-        out.append(tr)
-    out.sort(key=lambda t: _num(t.get("close_time")) or 0, reverse=True)
-    return out[:cap] if cap else out
-
-
+# ─────────────────────────── closed trades: realized PnL comes from discovery, as-is ───────────────────────────
 def fetch_closed_trades(client, wallet, since_ms, until_ms, cap, meta):
-    """Read-guarded closed-trade list for one strategy wallet, filtered to the review window.
+    """Closed round-trips for ONE strategy wallet, filtered to the review window.
 
-    PRIMARY: `discovery_get_trader_history` (closedPositions[] round-trips — works for CURRENT strategies).
-    FALLBACK — the closed-strategy trap: `strategy_close` clears Senpi's discovery index, so a CLOSED
-    strategy returns EMPTY here even though it traded. The fills still exist ON-CHAIN (HL keys them by
-    wallet ADDRESS, not by Senpi's strategy record), so on an empty discovery result we recover the real
-    round-trips from HL `userFills` and tag them source='onchain_fills'. `realized_pnl` then comes from HL's
-    own closedPnl — so a closed book is never misread as "no trades" or "drained to $0" (that $0 is the
-    withdrawal on close). Empty HL fills too ⇒ genuinely no trades. Fails OPEN → []."""
+    `realizedPnl` on each row IS the exact realized PnL of that round-trip. Emit it unchanged. Never
+    recompute it, never derive it from fills, never net anything into it.
+    `totalFees` is that round-trip's fee (builder fee already included). It is a SEPARATE cost that
+    realizedPnl already excludes. Carry it for the "what am I paying in fees" ask only.
+    Works for CLOSED strategies as well as current ones: history is keyed by wallet address, which
+    outlives the strategy record. Fails OPEN -> [] (an empty list, never a fabricated trade)."""
     try:
         h = _ok(client.mcp_call("discovery_get_trader_history", trader_address=wallet,
                                 sort_by="CLOSED_TIME", sort_direction="DESC",
                                 limit=CLOSED_HISTORY_PULL, timeout=12))
     except Exception as e:  # noqa
         meta.setdefault("warnings", []).append(f"trader_history {wallet[:8]} failed: {e}")
-        h = None
-    rows = []
-    if h is not None:
-        rows = h if isinstance(h, list) else _field(h, "closedPositions", "closed_positions", "positions", default=[])
-        if not isinstance(rows, list):
-            rows = []
+        return []
+    rows = h if isinstance(h, list) else _field(h, "closedPositions", "closed_positions", "positions", default=[])
+    if not isinstance(rows, list):
+        return []
     trades = []
     for p in rows:
         if not isinstance(p, dict):
             continue
         close_ms = _ms(_field(p, "closeTime", "closed_time", "closeTimeMs"))
         if since_ms is not None and close_ms is not None and close_ms < since_ms:
-            continue                        # older than the window — skip
+            continue
         if until_ms is not None and close_ms is not None and close_ms > until_ms:
             continue
         szi = _f(p, "szi", "size", default=0.0)
@@ -877,32 +789,24 @@ def fetch_closed_trades(client, wallet, since_ms, until_ms, cap, meta):
         entry_px = _num(_field(p, "entryPx", "entry_px"))
         exit_px = _num(_field(p, "exitPx", "exit_px"))
         pnl = round(_f(p, "realizedPnl", "realized_pnl", default=0.0), 2)
+        open_ms = _ms(_field(p, "openTime", "open_time"))
         trades.append({
             "asset": _field(p, "coin", "coinDisplayName", "asset"),
-            "direction": _direction(p, szi, entry_px, exit_px, pnl),   # robust: field → szi → pnl-vs-move
+            "direction": _direction(p, szi, entry_px, exit_px, pnl),
             "size": abs(szi),
             "leverage": _f(lev, "value", default=None) if isinstance(lev, dict) else _num(lev),
             "entry_px": entry_px,
             "exit_px": exit_px,
             "realized_pnl": pnl,
+            "fees": round(_f(p, "totalFees", "total_fees", default=0.0), 4),
             "margin_used": _f(p, "marginUsed", "margin_used", default=None),
-            "open_time": _ms(_field(p, "openTime", "open_time")),
+            "open_time": open_ms or None,   # discovery sends 0 for "no open time"; 0 is not epoch
             "close_time": close_ms,
             "closed_order_id": _field(p, "closedOrderId", "closed_order_id"),
             "source": "discovery",
         })
-    if trades:
-        trades.sort(key=lambda t: _num(t.get("close_time")) or 0, reverse=True)
-        return trades[:cap] if cap else trades
-
-    # DISCOVERY EMPTY → recover on-chain. This is the closed-strategy trap: the trades exist, just not in
-    # Senpi's index. Empty HL fills too ⇒ genuinely no trades (a brand-new book) → [].
-    fills = _hl_info({"type": "userFills", "user": wallet}, meta, client)
-    recon = _reconstruct_closed_from_fills(fills, since_ms, until_ms, cap)
-    if recon:
-        meta.setdefault("onchain_recovered_wallets", []).append(wallet)
-        meta["closed_trade_source"] = "onchain_fills"
-    return recon
+    trades.sort(key=lambda t: _num(t.get("close_time")) or 0, reverse=True)
+    return trades[:cap] if cap else trades
 
 
 # ──────────────────────────────────────────────────────────────── current price (market_get_asset_data)
@@ -923,86 +827,44 @@ def _price_now(client, asset, dex, meta):
     return _num(mark)
 
 
-# ──────────────────────────────────────────────── open book (unrealized PnL — the TOTAL-ledger read)
-_CLEARINGHOUSE_ATTEMPTS = 2   # bounded retries on the open-book read — transient blips only
-_CLEARINGHOUSE_BACKOFF_S = 0.4
+# ──────────────── account ledger + open book (both read straight from MCP, nothing derived) ────────────────
+def fetch_account_history(client, meta):
+    """Account-level PnL — the FIRST read of any review, before per-strategy detail.
 
-
-def _is_transient(exc):
-    """Retry the open-book read ONLY on a transient transport/5xx/429/timeout blip — never on a definitive
-    answer. An MCPError carrying an HTTP 4xx (other than 429), a JSON-RPC error, a tool isError, or an
-    app-level {success:false} is the server SAYING something real; retrying just repeats it (and could hide a
-    genuine 'no'). A raw transport error (socket timeout / connection reset / DNS) is a blip worth one more
-    try. Retries only REDUCE the frequency of a `None` read — they never remove it, so a still-failed read
-    stays UNKNOWN (never a fabricated 0) and partial coverage stays flagged."""
-    from mcp_client import MCPError
-    if isinstance(exc, MCPError):
-        m = re.search(r"HTTP (\d{3})", str(exc))
-        return bool(m) and (int(m.group(1)) == 429 or 500 <= int(m.group(1)) < 600)
-    return True
-
-
-def fetch_open_positions(client, wallet, meta):
-    """Open positions + unrealized PnL for ONE current strategy wallet (strategy_get_clearinghouse_state,
-    main+xyz). This is what makes the review a TOTAL ledger (realized closed trades + unrealized open) rather
-    than realized-only — closing the biggest distortion: a book RIDING open winners looks like a loser on
-    realized PnL alone, and a realized-only read biases against hold-strategies. Read-guarded + fail-open with
-    a bounded retry on transient blips (transport/5xx/429/timeout): a still-unreadable read → (None, []) so
-    unrealized reads UNKNOWN (never a fabricated 0); a clean read with no open positions → (0.0, []) — a REAL
-    zero. Returns (unrealized_pnl_total | None, positions[])."""
-    ch, err, attempts = None, None, 0
-    for attempt in range(1, _CLEARINGHOUSE_ATTEMPTS + 1):
-        attempts = attempt
-        try:
-            ch = _ok(client.mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet, timeout=12))
-            err = None
-            break
-        except Exception as e:  # noqa — fail-open: unrealized becomes UNKNOWN, never guessed 0
-            err = e
-            if attempt < _CLEARINGHOUSE_ATTEMPTS and _is_transient(e):
-                time.sleep(_CLEARINGHOUSE_BACKOFF_S * attempt)
-                continue
-            break
-    if err is not None:
-        meta.setdefault("warnings", []).append(
-            f"clearinghouse {str(wallet)[:8]} failed after {attempts} attempt(s): {err}; "
-            f"unrealized PnL unavailable for it")
-        return None, []
-    if not isinstance(ch, dict):
-        return None, []
-    positions, unrealized = [], 0.0
-    for section in ("main", "xyz"):
-        s = ch.get(section) if isinstance(ch.get(section), dict) else {}
-        for ap in (s.get("assetPositions") or []):
-            pos = ap.get("position", ap) if isinstance(ap, dict) else {}
-            if not isinstance(pos, dict):
-                continue
-            szi = _num(pos.get("szi"))
-            if not szi:
-                continue
-            up = _num(_field(pos, "unrealizedPnl", "unrealized_pnl")) or 0.0
-            unrealized += up
-            roe = _num(_field(pos, "returnOnEquity", "return_on_equity"))
-            lev = pos.get("leverage")
-            positions.append({
-                "asset": _field(pos, "coin", "asset"),
-                "direction": "long" if szi > 0 else "short",
-                "size": abs(szi),
-                "entry_px": _num(_field(pos, "entryPx", "entry_px")),
-                "unrealized_pnl": round(up, 2),
-                "return_on_equity_pct": round(roe * 100, 2) if roe is not None else None,
-                "position_value": _num(_field(pos, "positionValue", "position_value")),
-                "leverage": _f(lev, "value", default=None) if isinstance(lev, dict) else _num(lev),
-            })
-    return round(unrealized, 2), positions
+    Emits one entry per period with that period's total PnL and latest account value. The raw
+    pnlHistory / accountValueHistory series are deliberately NOT emitted: they are account-value
+    SNAPSHOTS, not trades, and a drop in them is usually a withdrawal rather than a loss.
+    Fails OPEN -> None (UNKNOWN, never 0)."""
+    try:
+        h = _ok(client.mcp_call("account_get_historical_info", timeout=25))
+    except Exception as e:  # noqa
+        meta.setdefault("warnings", []).append(f"account_historical_info failed: {e}")
+        return None
+    info = _field(h, "historical_info", "historicalInfo", default=None) if isinstance(h, dict) else None
+    if not isinstance(info, dict):
+        return None
+    out = {}
+    for period in ("day", "week", "month", "allTime"):
+        blk = info.get(period)
+        if not isinstance(blk, dict):
+            continue
+        values = _field(blk, "accountValueHistory", "account_value_history", default=[]) or []
+        last = values[-1] if isinstance(values, list) and values and isinstance(values[-1], dict) else {}
+        out[period] = {
+            "pnl": _num(_field(blk, "totalPnlByValue", "total_pnl_by_value")),
+            "pnl_pct": _num(_field(blk, "totalPnlByPercentage", "total_pnl_by_percentage")),
+            "account_value": _num(last.get("value")),
+        }
+    return out or None
 
 
 def fetch_open_book(client, strategies, meta):
-    """wallet_lower → {unrealized_pnl, positions[]} for the CURRENT (active/paused) strategies only — the live
-    book whose UNREALIZED PnL completes the total-ledger picture (closed strategies have no open positions).
-    Parallel clearinghouse fetches (dedup by wallet), each fail-open. A wallet whose read failed is kept with
-    `unrealized_pnl: None` (UNKNOWN) — the caller must NOT treat that as 0. {} when there are no current
-    wallets."""
+    """wallet_lower -> {unrealized_pnl, positions[]} for the CURRENT strategies.
+
+    ONE discovery_get_trader_state call per 50 wallets. That tool merges the main perp dex AND the
+    HIP-3 `xyz:` dexes into a single openPositions list, so an `xyz:` position is never missed.
+    Each position's `unrealizedPnl` IS the exact live PnL. Emit it unchanged.
+    A wallet whose read failed is ABSENT from the result. Absent means UNKNOWN, never 0."""
     wallets, seen = [], set()
     for s in strategies:
         if not _is_current(s.get("status")):
@@ -1012,20 +874,41 @@ def fetch_open_book(client, strategies, meta):
         if w and wl not in seen:
             seen.add(wl)
             wallets.append(w)
-    if not wallets:
-        return {}
-
-    def _worker(w):
-        priv = {}
-        unreal, positions = fetch_open_positions(client, w, priv)
-        return str(w).lower(), unreal, positions, priv
-
     out = {}
-    with concurrent.futures.ThreadPoolExecutor(max_workers=min(8, len(wallets))) as ex:
-        for wl, unreal, positions, priv in ex.map(_worker, wallets):
-            out[wl] = {"unrealized_pnl": unreal, "positions": positions}
-            if priv.get("warnings"):
-                meta.setdefault("warnings", []).extend(priv["warnings"])
+    for i in range(0, len(wallets), TRADER_STATE_BATCH):
+        chunk = wallets[i:i + TRADER_STATE_BATCH]
+        try:
+            st = _ok(client.mcp_call("discovery_get_trader_state", trader_addresses=chunk, timeout=25))
+        except Exception as e:  # noqa
+            meta.setdefault("warnings", []).append(
+                f"trader_state failed for {len(chunk)} wallet(s): {e}; unrealized PnL UNKNOWN for them")
+            continue
+        traders = _field(st, "traders", default=[]) if isinstance(st, dict) else []
+        for t in (traders or []):
+            if not isinstance(t, dict):
+                continue
+            positions, unrealized = [], 0.0
+            for pos in (t.get("openPositions") or []):
+                if not isinstance(pos, dict):
+                    continue
+                up = _num(_field(pos, "unrealizedPnl", "unrealized_pnl")) or 0.0
+                unrealized += up
+                roe = _num(_field(pos, "returnOnEquity", "return_on_equity"))
+                lev = pos.get("leverage")
+                szi = _num(pos.get("szi")) or 0.0
+                positions.append({
+                    "asset": _field(pos, "coinDisplayName", "coin", "asset"),
+                    "direction": "long" if szi > 0 else "short",
+                    "size": abs(szi),
+                    "entry_px": _num(_field(pos, "entryPx", "entry_px")),
+                    "unrealized_pnl": round(up, 2),
+                    "return_on_equity_pct": round(roe * 100, 2) if roe is not None else None,
+                    "position_value": _num(_field(pos, "positionValue", "position_value")),
+                    "leverage": _f(lev, "value", default=None) if isinstance(lev, dict) else _num(lev),
+                })
+            addr = str(t.get("address") or "").lower()
+            if addr:
+                out[addr] = {"unrealized_pnl": round(unrealized, 2), "positions": positions}
     return out
 
 
@@ -1377,6 +1260,7 @@ def _timing_summary(trades):
     flat = sum(1 for t in trades if t.get("exit_vs_hold") == "flat")
     unknown = sum(1 for t in trades if t.get("exit_vs_hold") == "unknown")
     realized_total = round(sum(_num(t.get("realized_pnl")) or 0.0 for t in trades), 2)
+    fees_total = round(sum(_num(t.get("fees")) or 0.0 for t in trades), 2)
     if_deltas = [_num(t.get("if_held_delta_usd")) for t in trades]
     if_deltas = [d for d in if_deltas if d is not None]
     if_all = round(sum(if_deltas), 2) if if_deltas else None
@@ -1399,7 +1283,9 @@ def _timing_summary(trades):
         "exits_held_higher": held_higher,      # holding to now would be higher — NEUTRAL, NOT 'premature'
         "exits_flat": flat,
         "exits_unknown": unknown,              # price missing → couldn't compare (honest sourcing)
-        "realized_pnl_total": realized_total,
+        "realized_pnl_total": realized_total,   # EXACT realized PnL — report as-is, do not adjust it
+        "fees_total": fees_total,              # separate cost, already excluded from realized_pnl_total.
+                                               # Mention ONLY if the user asked about fees. Never subtract.
         "if_all_reclosed_now_total": if_all,   # counterfactual aggregate — CONTEXT, NEVER a projection/target
         "by_asset_class": by_class,
     }
@@ -1726,13 +1612,17 @@ def _telemetry_source(source_counts, telemetry_warned):
 
 
 # ──────────────────────────────────────────────── total-ledger PnL + the 'undetermined ≠ all-clear' signal
-def _pnl_summary(realized_total, strat_reads):
+def _pnl_summary(realized_total, strat_reads, fees_total=None):
     """The TOTAL-ledger headline the narrator LEADS with — realized (closed trades) + unrealized (current
     open positions) + total — PLUS the current-vs-closed realized split (so the narrator QUOTES it and never
-    re-derives a wrong closed-book figure). `realized_total` is ALL closed trades; current-book realized = the
-    current strategies' realized sum; closed-book = the remainder (reconciles by construction). `unrealized`
-    sums only the current strategies whose open book was READABLE → None when none were, so `total` stays an
-    honest UNKNOWN rather than collapsing to a realized-only headline."""
+    re-derives a wrong closed-book figure).
+
+    `realized` is the EXACT realized PnL: the sum of each closed round-trip's own realizedPnl. It is final.
+    Do not adjust it, do not net fees into it, do not recompute it from anything else.
+    `fees` is a SEPARATE cost that `realized` already excludes. Report it ONLY when the user asked about
+    fees. It is not part of the headline and it is never subtracted from `realized`.
+    `unrealized` sums only the current strategies whose open book was READABLE → None when none were, so
+    `total` stays an honest UNKNOWN rather than collapsing to a realized-only headline."""
     realized = round(_num(realized_total) or 0.0, 2)
     current_realized = round(sum(_num(s.get("realized_pnl")) or 0.0 for s in strat_reads), 2)
     closed_realized = round(realized - current_realized, 2)
@@ -1746,16 +1636,20 @@ def _pnl_summary(realized_total, strat_reads):
     # readable is the all-UNKNOWN case: unrealized/total = None above, not a floor.)
     partial = unrealized is not None and len(known) < len(strat_reads)
     return {
-        "realized": realized,
+        "realized": realized,                     # EXACT — the headline. Never adjusted, never fee-netted.
+        "fees": round(_num(fees_total) or 0.0, 2) if fees_total is not None else None,
         "realized_by_book": {"current": current_realized, "closed": closed_realized},
         "unrealized": unrealized,                 # None → no current open book readable (UNKNOWN, not 0)
         "unrealized_coverage": {"read": len(known), "current_strategies": len(strat_reads)},
         "unrealized_partial": partial,            # True → unrealized/total are a FLOOR (some wallets UNKNOWN)
         "total": total,                           # realized + unrealized; None when UNKNOWN; a FLOOR when partial
         "note": ("TOTAL = realized (closed trades) + unrealized (current open positions). LEAD with TOTAL, "
-                 "not realized alone. unrealized None = the open book couldn't be read (UNKNOWN, not 0). "
-                 "unrealized_partial True = only some current wallets read, so unrealized/total are a FLOOR "
-                 "('at least $X, N of M wallets readable') — never present them as complete."),
+                 "not realized alone. `realized` and every position's `unrealized` are EXACT values read "
+                 "from MCP — quote them, never recompute or adjust them. `fees` is a separate cost already "
+                 "excluded from `realized`: mention it ONLY if the user asked about fees, and never "
+                 "subtract it from any PnL number. unrealized None = the open book couldn't be read "
+                 "(UNKNOWN, not 0). unrealized_partial True = only some current wallets read, so "
+                 "unrealized/total are a FLOOR ('at least $X, N of M wallets readable')."),
     }
 
 
@@ -1885,6 +1779,39 @@ def _ensure_trades_in_state(client, state, window_days, last_n, want_market, now
 
 
 # ──────────────────────────────────────────────────────────── step subcommands (fast, resumable, standalone)
+def step_account(client, window_days=WINDOW_DEFAULT_DAYS, last_n=None, want_market=True,
+                 state_path=None, now_ms=None):
+    """STEP 1 `account` — RUN THIS FIRST. Whole-account PnL (account_get_historical_info) plus the full
+    strategy list (ACTIVE + PAUSED + CLOSED). Narrate the account number, then go strategy by strategy.
+    Persists the strategy list so the later steps do not re-fetch it."""
+    if state_path is None:
+        state_path = _default_state_path(window_days, last_n)
+    state = _load_state(state_path)
+    meta = _fresh_meta()
+    window, _since, _until = _window_for(window_days, last_n, now_ms=now_ms)
+    meta["window"] = window
+    account = fetch_account_history(client, meta)
+    strategies = fetch_strategies(client, meta)
+    current = [s for s in strategies if _is_current(s.get("status"))]
+    meta["strategy_count"] = len(strategies)
+    meta["current_strategy_count"] = len(current)
+    meta["closed_strategy_count"] = len(strategies) - len(current)
+    if not strategies:
+        meta["degraded"] = ("strategy list unreadable — check the token is USER-scoped"
+                            if any("strategy_list failed" in str(w) for w in (meta.get("warnings") or []))
+                            else "no strategies deployed yet (not a fault — see meta.book_state)")
+    state["window"] = window
+    state["account_history"] = account
+    state["strategies"] = strategies
+    state["meta_warnings"] = meta.get("warnings", [])
+    state["registry_source"] = meta.get("registry_source")
+    _save_state(state_path, state)
+    return {"window": window, "account_history": account,
+            "strategies": [{"label": s.get("label"), "wallet": s.get("wallet"),
+                            "status": s.get("status")} for s in strategies],
+            "meta": meta}
+
+
 def step_timing(client, window_days=WINDOW_DEFAULT_DAYS, last_n=None, want_market=True,
                 state_path=None, now_ms=None):
     """STEP 1 `timing` — the bottleneck-but-headline slice the agent NARRATES FIRST. Fetch strategies +
@@ -1941,7 +1868,8 @@ def step_strategies(client, window_days=WINDOW_DEFAULT_DAYS, last_n=None, want_m
     strat_reads = _strategy_reads(trades, strategies, open_book)
     closed_reads = _closed_strategy_rollup(trades, strategies)
     realized_total = round(sum(_num(t.get("realized_pnl")) or 0.0 for t in trades), 2)
-    pnl_summary = _pnl_summary(realized_total, strat_reads)
+    fees_total = round(sum(_num(t.get("fees")) or 0.0 for t in trades), 2)
+    pnl_summary = _pnl_summary(realized_total, strat_reads, fees_total)
     dsl_mix = _dsl_close_reason_mix(trades)   # from whatever exit_reason is in state (UNKNOWN until telemetry)
     current_count = sum(1 for s in strategies if _is_current(s.get("status")))
     closed_count = len(strategies) - current_count
@@ -2038,20 +1966,24 @@ def run(client, window_days=WINDOW_DEFAULT_DAYS, last_n=None, want_market=True, 
     """Orchestrate the review. Everything read-guarded + fail-open: partial data → valid JSON +
     meta.warnings/meta.degraded. `last_n` (a trade-count cap) coexists with the window — 'last N trades'
     still respects the window as the outer bound."""
-    meta = {"warnings": [], "sources": ["discovery_get_trader_history", "ratchet_stop_list",
-                                        "market_get_asset_data", "leaderboard_get_markets",
-                                        "openclaw senpi events"], "degraded": None}
+    meta = {"warnings": [], "sources": ["account_get_historical_info", "strategy_list",
+                                        "discovery_get_trader_history", "discovery_get_trader_state",
+                                        "ratchet_stop_list", "market_get_asset_data",
+                                        "leaderboard_get_markets", "openclaw senpi events"],
+            "degraded": None}
     since_ms, until_ms = _window_bounds(window_days, now_ms=now_ms)
     label = f"last {last_n} closed trades" if last_n else f"last ~{window_days}d"
     window = {"from": since_ms, "to": until_ms, "label": label, "window_days": window_days,
               "last_n": last_n}
     meta["window"] = window
 
+    # ACCOUNT FIRST — the whole account's PnL, before any per-strategy detail.
+    account_history = fetch_account_history(client, meta)
     # ALL statuses are enumerated (so a churned book's CLOSED trades stay in trades[]) — but the per-strategy
     # verdict is CURRENT-only. Closed/historical strategies get a minimal rollup, never a verdict.
     strategies = fetch_strategies(client, meta)
-    # OPEN BOOK — current strategies' unrealized PnL (strategy_get_clearinghouse_state), so the review is a
-    # TOTAL ledger (realized closed + unrealized open), not realized-only. Fail-open per wallet → None (UNKNOWN).
+    # OPEN BOOK — current strategies' unrealized PnL (discovery_get_trader_state, batched), so the review is a
+    # TOTAL ledger (realized closed + unrealized open), not realized-only.
     open_book = fetch_open_book(client, strategies, meta)
     # DISCOVERY owns trades[] (onchain facts); TELEMETRY enriches exit_reason + yields the standalone streams
     # (missed_signals + the leak/fill rollups), all from ONE per-runtime event fetch (no re-fetch downstream).
@@ -2065,7 +1997,8 @@ def run(client, window_days=WINDOW_DEFAULT_DAYS, last_n=None, want_market=True, 
     bvm = book_vs_market(client, trades, strategies, meta, want_market)
     strat_reads = _strategy_reads(trades, strategies, open_book)   # CURRENT book — now with unrealized/total/open
     closed_reads = _closed_strategy_rollup(trades, strategies) # HISTORY: closed/inactive, rollup only
-    pnl_summary = _pnl_summary(timing["realized_pnl_total"], strat_reads)   # realized + unrealized = TOTAL ledger
+    pnl_summary = _pnl_summary(timing["realized_pnl_total"], strat_reads,   # realized + unrealized = TOTAL ledger
+                               timing.get("fees_total"))
 
     current_count = sum(1 for s in strategies if _is_current(s.get("status")))
     closed_count = len(strategies) - current_count
@@ -2093,6 +2026,7 @@ def run(client, window_days=WINDOW_DEFAULT_DAYS, last_n=None, want_market=True, 
 
     return {
         "window": window,
+        "account_history": account_history,  # WHOLE-ACCOUNT PnL by period — the first thing to narrate
         "trades": trades,                 # DISCOVERY-owned onchain facts + telemetry-enriched exit_reason
         "timing_summary": timing,         # PROCESS-framed counts — LEAD with these
         "dsl_close_reason_mix": dsl_mix,  # 'shaken out too early / how exits fire' → DSL preset lever
@@ -2121,8 +2055,8 @@ def _dry(client):
     return out
 
 
-_STEPS = ("timing", "strategies", "telemetry", "market", "all")
-_STEP_FNS = {"timing": step_timing, "strategies": step_strategies,
+_STEPS = ("account", "timing", "strategies", "telemetry", "market", "all")
+_STEP_FNS = {"account": step_account, "timing": step_timing, "strategies": step_strategies,
              "telemetry": step_telemetry, "market": step_market}
 
 

--- a/senpi-improve-trades/tests/fixtures/review_fixture.json
+++ b/senpi-improve-trades/tests/fixtures/review_fixture.json
@@ -4,20 +4,31 @@
      "strategyWalletAddress": "0xKODIAK00000000000000000000000000000kdk", "status": "ACTIVE"}
   ]},
 
+  "account_get_historical_info": {"historical_info": {
+    "day":     {"totalPnlByValue": "12.00",  "totalPnlByPercentage": "1.2",
+                "accountValueHistory": [{"timestamp": "1782700000000", "value": "1012.00"}]},
+    "week":    {"totalPnlByValue": "340.00", "totalPnlByPercentage": "34.0",
+                "accountValueHistory": [{"timestamp": "1782700000000", "value": "1012.00"}]},
+    "month":   {"totalPnlByValue": "340.00", "totalPnlByPercentage": "34.0",
+                "accountValueHistory": [{"timestamp": "1782700000000", "value": "1012.00"}]},
+    "allTime": {"totalPnlByValue": "460.00", "totalPnlByPercentage": "46.0",
+                "accountValueHistory": [{"timestamp": "1782700000000", "value": "1012.00"}]}
+  }},
+
   "discovery_get_trader_history::0xkodiak00000000000000000000000000000kdk": {"closedPositions": [
     {"closedOrderId": "0xSOL", "coin": "SOL", "coinDisplayName": "SOL", "szi": "3.0",
      "entryPx": "120.00", "exitPx": "150.00", "leverage": {"type": "cross", "value": 5},
-     "realizedPnl": "90.00", "marginUsed": "90.00",
+     "realizedPnl": "90.00", "marginUsed": "90.00", "totalFees": "1.50",
      "openTime": 1782500000000, "closeTime": 1782700000000},
 
     {"closedOrderId": "0xETH", "coin": "ETH", "coinDisplayName": "ETH", "szi": "0.5",
      "entryPx": "1900.00", "exitPx": "2000.00", "leverage": {"type": "cross", "value": 4},
-     "realizedPnl": "50.00", "marginUsed": "250.00",
+     "realizedPnl": "50.00", "marginUsed": "250.00", "totalFees": "2.25",
      "openTime": 1782600000000, "closeTime": 1782750000000},
 
     {"closedOrderId": "0xBTC", "coin": "BTC", "coinDisplayName": "BTC", "szi": "-0.05",
      "entryPx": "104000.00", "exitPx": "100000.00", "leverage": {"type": "cross", "value": 3},
-     "realizedPnl": "200.00", "marginUsed": "1666.00",
+     "realizedPnl": "200.00", "marginUsed": "1666.00", "totalFees": "3.00",
      "openTime": 1782650000000, "closeTime": 1782800000000}
   ]},
 
@@ -26,14 +37,13 @@
     {"asset": "ETH", "status": "ACTIVE", "currentTierIndex": 0, "highWaterRoe": 6.0}
   ]},
 
-  "strategy_get_clearinghouse_state::0xkodiak00000000000000000000000000000kdk": {
-    "main": {"assetPositions": [
-      {"position": {"coin": "SOL", "szi": "10.0", "entryPx": "120.00", "unrealizedPnl": "120.00",
-                    "returnOnEquity": "0.10", "positionValue": "1300.00",
-                    "leverage": {"type": "cross", "value": 5}}}
-    ]},
-    "xyz": {"assetPositions": []}
-  },
+  "discovery_get_trader_state": {"traders": [
+    {"address": "0xkodiak00000000000000000000000000000kdk", "openOrders": [], "openPositions": [
+      {"coin": "SOL", "coinDisplayName": "SOL", "szi": "10.0", "entryPx": "120.00",
+       "unrealizedPnl": "120.00", "returnOnEquity": "0.10", "positionValue": "1300.00",
+       "leverage": {"type": "cross", "value": 5}}
+    ]}
+  ]},
 
   "market_get_asset_data::sol": {"asset_context": {"markPx": "130.00", "prevDayPx": "148.0"}},
   "market_get_asset_data::eth": {"asset_context": {"markPx": "2200.00", "prevDayPx": "2010.0"}},

--- a/senpi-improve-trades/tests/fixtures/review_mixed_status_fixture.json
+++ b/senpi-improve-trades/tests/fixtures/review_mixed_status_fixture.json
@@ -8,29 +8,36 @@
      "strategyWalletAddress": "0xKODIAKOLD00000000000000000000000000old", "status": "CLOSED"}
   ]},
 
+  "account_get_historical_info": {"historical_info": {
+    "week":    {"totalPnlByValue": "340.00", "totalPnlByPercentage": "34.0",
+                "accountValueHistory": [{"timestamp": "1782700000000", "value": "1012.00"}]},
+    "allTime": {"totalPnlByValue": "460.00", "totalPnlByPercentage": "46.0",
+                "accountValueHistory": [{"timestamp": "1782700000000", "value": "1012.00"}]}
+  }},
+
   "discovery_get_trader_history::0xkodiak00000000000000000000000000000kdk": {"closedPositions": [
     {"closedOrderId": "0xSOL", "coin": "SOL", "coinDisplayName": "SOL", "szi": "3.0",
      "entryPx": "120.00", "exitPx": "150.00", "leverage": {"type": "cross", "value": 5},
-     "realizedPnl": "90.00", "marginUsed": "90.00",
+     "realizedPnl": "90.00", "marginUsed": "90.00", "totalFees": "1.00",
      "openTime": 1782500000000, "closeTime": 1782700000000}
   ]},
 
   "discovery_get_trader_history::0xgrizzly0000000000000000000000000000grz": {"closedPositions": [
     {"closedOrderId": "0xETH", "coin": "ETH", "coinDisplayName": "ETH", "szi": "0.5",
      "entryPx": "1900.00", "exitPx": "2000.00", "leverage": {"type": "cross", "value": 4},
-     "realizedPnl": "50.00", "marginUsed": "250.00",
+     "realizedPnl": "50.00", "marginUsed": "250.00", "totalFees": "1.00",
      "openTime": 1782600000000, "closeTime": 1782750000000}
   ]},
 
   "discovery_get_trader_history::0xkodiakold00000000000000000000000000old": {"closedPositions": [
     {"closedOrderId": "0xBTC", "coin": "BTC", "coinDisplayName": "BTC", "szi": "-0.05",
      "entryPx": "104000.00", "exitPx": "100000.00", "leverage": {"type": "cross", "value": 3},
-     "realizedPnl": "200.00", "marginUsed": "1666.00",
+     "realizedPnl": "200.00", "marginUsed": "1666.00", "totalFees": "1.00",
      "openTime": 1782650000000, "closeTime": 1782800000000},
 
     {"closedOrderId": "0xDOGE", "coin": "DOGE", "coinDisplayName": "DOGE", "szi": "1000.0",
      "entryPx": "0.100", "exitPx": "0.120", "leverage": {"type": "cross", "value": 2},
-     "realizedPnl": "20.00", "marginUsed": "60.00",
+     "realizedPnl": "20.00", "marginUsed": "60.00", "totalFees": "1.00",
      "openTime": 1782640000000, "closeTime": 1782780000000}
   ]},
 

--- a/senpi-improve-trades/tests/test_review.py
+++ b/senpi-improve-trades/tests/test_review.py
@@ -191,7 +191,7 @@ def test_open_book_unreadable_is_unknown_not_zero():
     None — NEVER a fabricated 0. Guards a realized-only headline from masquerading as total."""
     with open(FIXTURE) as f:
         raw = json.load(f)
-    raw.pop("strategy_get_clearinghouse_state::0xkodiak00000000000000000000000000000kdk", None)
+    raw.pop("discovery_get_trader_state", None)
     old = os.environ.get("SENPI_STATE_DIR")
     os.environ["SENPI_STATE_DIR"] = REGISTRY_DIR
     try:
@@ -242,51 +242,55 @@ def test_pnl_summary_all_unreadable_is_none_not_partial():
     assert ps["unrealized_partial"] is False                # None ≠ floor
 
 
-def test_is_transient_classifies_retryable_vs_definitive():
-    """Retry policy: transport blips + 5xx/429 retry; a definitive answer (4xx, {success:false}, JSON-RPC,
-    tool error) does NOT — retrying a real 'no' just repeats it."""
-    from mcp_client import MCPError
-    assert review._is_transient(TimeoutError("timed out")) is True
-    assert review._is_transient(ConnectionResetError()) is True
-    assert review._is_transient(MCPError("strategy_get_clearinghouse_state HTTP 503")) is True
-    assert review._is_transient(MCPError("x HTTP 429")) is True
-    assert review._is_transient(MCPError("x HTTP 404")) is False
-    assert review._is_transient(MCPError("tool failed: SERR001: no access")) is False
-    assert review._is_transient(MCPError("JSON-RPC error -32601: method not found")) is False
+def test_open_book_is_one_batched_call_and_merges_xyz():
+    """The open book is ONE discovery_get_trader_state call for all current wallets, and an `xyz:` (HIP-3)
+    position counts the same as a main-perp one — that tool returns both in a single openPositions list."""
+    calls = []
 
+    class Batched:
+        def mcp_call(self, tool, timeout=12, **kw):
+            calls.append((tool, tuple(kw.get("trader_addresses") or ())))
+            return {"traders": [
+                {"address": "0xaaa", "openPositions": [
+                    {"coin": "xyz:GOLD", "coinDisplayName": "GOLD", "szi": "1", "unrealizedPnl": "4.0"},
+                    {"coin": "BTC", "coinDisplayName": "BTC", "szi": "-1", "unrealizedPnl": "-1.5"}]},
+                {"address": "0xbbb", "openPositions": []}]}
 
-def test_fetch_open_positions_retries_transient_then_succeeds():
-    """A transient blip is retried; the second attempt's clean read is used — no fabricated None."""
-    calls = {"n": 0}
-    ok = {"main": {"assetPositions": [{"position": {"coin": "SOL", "szi": "1", "unrealizedPnl": "25.0"}}]}}
-
-    class Flaky:
-        def mcp_call(self, tool, **kw):
-            calls["n"] += 1
-            if calls["n"] == 1:
-                raise TimeoutError("blip")
-            return ok
+    strategies = [{"wallet": "0xAAA", "status": "ACTIVE"}, {"wallet": "0xBBB", "status": "ACTIVE"},
+                  {"wallet": "0xAAA", "status": "ACTIVE"},            # duplicate wallet — deduped
+                  {"wallet": "0xCCC", "status": "CLOSED"}]            # closed — has no open book
     meta = {}
-    unreal, positions = review.fetch_open_positions(Flaky(), "0xabc", meta)
-    assert calls["n"] == 2                          # retried once
-    assert unreal == 25.0 and len(positions) == 1
-    assert not meta.get("warnings")                 # succeeded → no failure warning
+    book = review.fetch_open_book(Batched(), strategies, meta)
+    assert calls == [("discovery_get_trader_state", ("0xAAA", "0xBBB"))]   # ONE call, current + deduped
+    assert book["0xaaa"]["unrealized_pnl"] == 2.5                          # 4.0 + (-1.5), xyz included
+    assert [p["asset"] for p in book["0xaaa"]["positions"]] == ["GOLD", "BTC"]
+    assert book["0xaaa"]["positions"][1]["direction"] == "short"
+    assert book["0xbbb"]["unrealized_pnl"] == 0.0                          # read fine, genuinely flat
+    assert "0xccc" not in book
 
 
-def test_fetch_open_positions_does_not_retry_definitive_failure():
-    """A definitive {success:false} is NOT retried (it's a real answer) → one call, unrealized UNKNOWN."""
-    from mcp_client import MCPError
-    calls = {"n": 0}
-
-    class Denied:
-        def mcp_call(self, tool, **kw):
-            calls["n"] += 1
-            raise MCPError("tool failed: SERR001: no access")
+def test_open_book_failure_leaves_wallet_absent_not_zero():
+    """A failed state read must leave the wallet ABSENT (UNKNOWN downstream), never a fabricated 0."""
+    class Down:
+        def mcp_call(self, tool, timeout=12, **kw):
+            raise RuntimeError("upstream down")
     meta = {}
-    unreal, positions = review.fetch_open_positions(Denied(), "0xabc", meta)
-    assert calls["n"] == 1                           # NOT retried
-    assert unreal is None and positions == []        # UNKNOWN, never a fabricated 0
-    assert meta["warnings"]                          # a warning was recorded
+    assert review.fetch_open_book(Down(), [{"wallet": "0xAAA", "status": "ACTIVE"}], meta) == {}
+    assert meta["warnings"]
+
+
+def test_open_book_batches_in_chunks_of_fifty():
+    """discovery_get_trader_state takes at most 50 addresses, so 120 wallets is 3 calls — never 120."""
+    sizes = []
+
+    class Counting:
+        def mcp_call(self, tool, timeout=12, **kw):
+            sizes.append(len(kw.get("trader_addresses") or ()))
+            return {"traders": []}
+
+    strategies = [{"wallet": f"0x{i:040x}", "status": "ACTIVE"} for i in range(120)]
+    review.fetch_open_book(Counting(), strategies, {})
+    assert sizes == [50, 50, 20]
 
 
 def test_last_n_caps_trade_count():
@@ -803,64 +807,78 @@ def test_default_state_path_uses_tempdir_and_window_key():
     assert review._default_state_path(30.0, 20).endswith("state-30d-last20.json")
 
 
-# ── on-chain fill recovery (closed-strategy trap: discovery clears on close, HL fills persist) ──
-def test_reconstruct_closed_from_fills_fifo_direction_pnl():
-    base = 1784000000000
-    fills = [
-        {"coin": "HYPE", "dir": "Open Long",   "sz": "2",  "px": "100", "closedPnl": "0",   "fee": "0.1",  "time": base + 1000, "oid": 1},
-        {"coin": "HYPE", "dir": "Open Long",   "sz": "1",  "px": "110", "closedPnl": "0",   "fee": "0.05", "time": base + 2000, "oid": 2},
-        {"coin": "HYPE", "dir": "Close Long",  "sz": "2",  "px": "120", "closedPnl": "40",  "fee": "0.12", "time": base + 3000, "oid": 3},
-        {"coin": "HYPE", "dir": "Close Long",  "sz": "1",  "px": "130", "closedPnl": "20",  "fee": "0.06", "time": base + 4000, "oid": 4},
-        {"coin": "SOL",  "dir": "Open Short",  "sz": "10", "px": "200", "closedPnl": "0",   "fee": "0.2",  "time": base + 1500, "oid": 5},
-        {"coin": "SOL",  "dir": "Close Short", "sz": "10", "px": "190", "closedPnl": "100", "fee": "0.19", "time": base + 9000, "oid": 6},
-    ]
-    tr = review._reconstruct_closed_from_fills(fills, None, None, None)
-    assert len(tr) == 3
-    by = {(t["asset"], t["exit_px"]): t for t in tr}
-    # FIFO: first HYPE close (2) matches the 2@100 lot; the second (1) matches the 1@110 lot
-    assert by[("HYPE", 120.0)]["entry_px"] == 100.0 and by[("HYPE", 120.0)]["direction"] == "long"
-    assert by[("HYPE", 130.0)]["entry_px"] == 110.0
-    assert by[("SOL", 190.0)]["direction"] == "short" and by[("SOL", 190.0)]["entry_px"] == 200.0
-    assert round(sum(t["realized_pnl"] for t in tr), 2) == 160.0    # HL closedPnl — authoritative
-    assert all(t["source"] == "onchain_fills" for t in tr)
-    assert tr[0]["asset"] == "SOL"                                  # newest close first
-    assert [t["asset"] for t in review._reconstruct_closed_from_fills(fills, base + 5000, None, None)] == ["SOL"]
-    assert review._reconstruct_closed_from_fills(fills, None, None, 1)[0]["asset"] == "SOL"
-    assert review._reconstruct_closed_from_fills(None, None, None, None) == []
-
-
-def test_closed_strategy_falls_back_to_onchain_fills():
-    """The bug this fixes: CLOSED strategy → discovery empty → recover REAL trades on-chain; never report
-    'no trades', and realized PnL comes from HL closedPnl (the $0-after-close is a withdrawal, not a loss)."""
+# ── closed trades: realized PnL is read from discovery, never reconstructed ──
+def test_closed_strategy_history_comes_from_discovery():
+    """A CLOSED strategy still has history — it is keyed by wallet address, which outlives the strategy
+    record. No fill reconstruction, no on-chain fallback: the rows are read and reported as-is."""
     w = "0xclosed00000000000000000000000000000closed"
-    fills = [
-        {"coin": "SMSN", "dir": "Open Long",  "sz": "1", "px": "180", "closedPnl": "0",  "time": 1784000001000, "oid": 11},
-        {"coin": "SMSN", "dir": "Close Long", "sz": "1", "px": "188", "closedPnl": "8",  "time": 1784000002000, "oid": 12},
-        {"coin": "SOL",  "dir": "Open Long",  "sz": "1", "px": "78",  "closedPnl": "0",  "time": 1784000003000, "oid": 13},
-        {"coin": "SOL",  "dir": "Close Long", "sz": "1", "px": "77",  "closedPnl": "-1", "time": 1784000004000, "oid": 14},
-    ]
-    client = review._FixtureClient({
-        f"discovery_get_trader_history::{w.lower()}": {"closedPositions": []},   # Senpi index cleared on close
-        f"hl::userFills::{w.lower()}": fills,                                     # HL retains fills by address
-    })
-    meta = {}
-    trades = review.fetch_closed_trades(client, w, None, None, None, meta)
-    assert len(trades) == 2                                     # real trades recovered, not "zero"
-    assert round(sum(t["realized_pnl"] for t in trades), 2) == 7.0
-    assert meta.get("closed_trade_source") == "onchain_fills"
-    assert w in meta.get("onchain_recovered_wallets", [])
+    client = review._FixtureClient({f"discovery_get_trader_history::{w.lower()}": {"closedPositions": [
+        {"closedOrderId": "a", "coin": "SMSN", "szi": "1", "entryPx": "180", "exitPx": "188",
+         "realizedPnl": "8.00", "totalFees": "0.40", "openTime": 1784000001000, "closeTime": 1784000002000},
+        {"closedOrderId": "b", "coin": "SOL", "szi": "1", "entryPx": "78", "exitPx": "77",
+         "realizedPnl": "-1.00", "totalFees": "0.10", "openTime": 1784000003000, "closeTime": 1784000004000},
+    ]}})
+    trades = review.fetch_closed_trades(client, w, None, None, None, {})
+    assert len(trades) == 2
+    assert round(sum(t["realized_pnl"] for t in trades), 2) == 7.0     # exactly what discovery reported
+    assert all(t["source"] == "discovery" for t in trades)
+    assert trades[0]["asset"] == "SOL"                                 # newest close first
 
 
-def test_no_trades_when_both_sources_empty():
-    """Empty discovery AND empty on-chain fills ⇒ genuinely no trades (a brand-new book) → []."""
+def test_realized_pnl_is_never_reduced_by_fees():
+    """The bug this fixes: fees are a SEPARATE cost that realizedPnl already excludes. `realized_pnl` must
+    stay exactly what discovery reported, with `fees` carried alongside for the fee question only."""
+    w = "0xfee0000000000000000000000000000000000fee"
+    client = review._FixtureClient({f"discovery_get_trader_history::{w.lower()}": {"closedPositions": [
+        {"closedOrderId": "a", "coin": "BTC", "szi": "1", "entryPx": "100", "exitPx": "110",
+         "realizedPnl": "19.00", "totalFees": "16.99", "closeTime": 1784000002000}]}})
+    t = review.fetch_closed_trades(client, w, None, None, None, {})[0]
+    assert t["realized_pnl"] == 19.0                     # NOT 19.00 - 16.99
+    assert t["fees"] == 16.99
+    assert review._timing_summary([t])["realized_pnl_total"] == 19.0
+    assert review._timing_summary([t])["fees_total"] == 16.99
+    assert review._pnl_summary(19.0, [], 16.99)["realized"] == 19.0
+
+
+def test_zero_open_time_is_missing_not_epoch():
+    """discovery sends openTime 0 for "no open time". 0 is a missing-value sentinel, not 1970."""
+    w = "0xzero000000000000000000000000000000000zer"
+    client = review._FixtureClient({f"discovery_get_trader_history::{w.lower()}": {"closedPositions": [
+        {"closedOrderId": "a", "coin": "BTC", "szi": "1", "realizedPnl": "1.00",
+         "openTime": 0, "closeTime": 1784000002000}]}})
+    assert review.fetch_closed_trades(client, w, None, None, None, {})[0]["open_time"] is None
+
+
+def test_no_trades_when_discovery_is_empty():
+    """An empty discovery result is a real answer: a book that has not closed anything → []."""
     w = "0xbrandnew0000000000000000000000000000new"
-    client = review._FixtureClient({
-        f"discovery_get_trader_history::{w.lower()}": {"closedPositions": []},
-        f"hl::userFills::{w.lower()}": [],
-    })
+    client = review._FixtureClient({f"discovery_get_trader_history::{w.lower()}": {"closedPositions": []}})
+    assert review.fetch_closed_trades(client, w, None, None, None, {}) == []
+
+
+def test_account_history_is_periods_only_no_raw_series():
+    """account_get_historical_info is the FIRST read. Emit the per-period totals only — the raw
+    accountValueHistory series are snapshots, not trades, and must not reach the narrator."""
+    client = review._FixtureClient({"account_get_historical_info": {"historical_info": {
+        "day": {"totalPnlByValue": "12.00", "totalPnlByPercentage": "1.2",
+                "accountValueHistory": [{"timestamp": "1", "value": "900"},
+                                        {"timestamp": "2", "value": "1012.00"}]},
+        "allTime": {"totalPnlByValue": "-460.00", "totalPnlByPercentage": "-46.0",
+                    "accountValueHistory": [{"timestamp": "2", "value": "1012.00"}]}}}})
+    acc = review.fetch_account_history(client, {})
+    assert acc["day"] == {"pnl": 12.0, "pnl_pct": 1.2, "account_value": 1012.0}
+    assert acc["allTime"]["pnl"] == -460.0
+    assert "accountValueHistory" not in json.dumps(acc)
+    assert "pnlHistory" not in json.dumps(acc)
+
+
+def test_account_history_failure_is_unknown_not_zero():
+    class Down:
+        def mcp_call(self, tool, timeout=12, **kw):
+            raise RuntimeError("upstream down")
     meta = {}
-    assert review.fetch_closed_trades(client, w, None, None, None, meta) == []
-    assert "closed_trade_source" not in meta
+    assert review.fetch_account_history(Down(), meta) is None      # UNKNOWN, never 0.0
+    assert meta["warnings"]
 
 
 # ────────────────────────────── scope + fast-fail (the "telemetry unavailable" live-run fix) ──
@@ -1039,7 +1057,7 @@ def _two_sleeve_fixture():
     with open(FIXTURE) as f:
         base = json.load(f)
     hist = base["discovery_get_trader_history::0xkodiak00000000000000000000000000000kdk"]["closedPositions"]
-    ch = base["strategy_get_clearinghouse_state::0xkodiak00000000000000000000000000000kdk"]
+    pos = base["discovery_get_trader_state"]["traders"][0]["openPositions"]
     fx = {k: v for k, v in base.items() if k.startswith(("market_get_asset_data::", "leaderboard_"))}
     fx["strategy_list"] = {"strategies": [
         {"strategyName": "cougar-long", "tradingStrategyName": "cougar",
@@ -1055,8 +1073,9 @@ def _two_sleeve_fixture():
         {"asset": "SOL", "status": "SL_TRIGGERED", "currentTierIndex": 2, "highWaterRoe": 41.0}]}
     fx[f"ratchet_stop_list::{COUGAR_SHORT.lower()}"] = {"configs": [
         {"asset": "BTC", "status": "SL_TRIGGERED", "currentTierIndex": 0, "highWaterRoe": 5.0}]}
-    fx[f"strategy_get_clearinghouse_state::{COUGAR_LONG.lower()}"] = ch
-    fx[f"strategy_get_clearinghouse_state::{COUGAR_SHORT.lower()}"] = ch
+    fx["discovery_get_trader_state"] = {"traders": [
+        {"address": COUGAR_LONG.lower(), "openPositions": pos, "openOrders": []},
+        {"address": COUGAR_SHORT.lower(), "openPositions": pos, "openOrders": []}]}
     return fx
 
 

--- a/senpi-improve-trades/tests/test_review.py
+++ b/senpi-improve-trades/tests/test_review.py
@@ -1160,3 +1160,15 @@ if __name__ == "__main__":
         fn()
         print(f"  ok {fn.__name__}")
     print(f"\n{len(fns)}/{len(fns)} passed")
+
+
+def test_closed_only_book_has_a_real_zero_unrealized_not_unknown():
+    """A book with NO current strategies has no open positions at all, so unrealized is a REAL 0 and TOTAL
+    equals realized. Returning None there left a fully-closed book with no headline (HARD RULE 1)."""
+    ps = review._pnl_summary(17.05, [], 17.23)
+    assert ps["unrealized"] == 0.0 and ps["total"] == 17.05
+    assert ps["unrealized_partial"] is False
+    assert ps["realized"] == 17.05 and ps["fees"] == 17.23      # fees never netted into realized
+    # current strategies that exist but are ALL unreadable stay UNKNOWN — that is a different case
+    unreadable = review._pnl_summary(17.05, [{"unrealized_pnl": None}], 17.23)
+    assert unreadable["unrealized"] is None and unreadable["total"] is None


### PR DESCRIPTION
## The problem

`review.py` derived closed-trade PnL by pulling raw Hyperliquid `userFills` and rebuilding round-trips itself: FIFO lot matching, pro-rated open-side fees, `closedPnl` accumulation. Every number that machinery produced is already returned by MCP, per trade, on the row the function was **already parsing**.

`discovery_get_trader_history` returns, per closed position:

```json
{"closedOrderId": "501107553651", "coin": "ENA", "realizedPnl": "1225133.921128",
 "openTime": 1768680956, "closeTime": 1784790554, "totalFills": "13594",
 "totalFees": "1035.102496", "totalHyperliquidFees": "929.015645", "totalBuilderFees": "0"}
```

`totalFees` reconciles exactly against the raw fills ledger. Wallet `0xbd7b48a5…` / CC, 4 fills: signed `fee` sum `3.950085 + 1.658373 + 1.536760 + 0.696565` = **7.841783**, and the row's `totalFees` is **7.841783**. It is signed (36,387 of 888,815 rows over 90 days are negative, so maker rebates survive) and builder-inclusive (`totalFees − totalHyperliquidFees` = the summed `builder_fee`).

## What changed

**Closed trades.** `fetch_closed_trades` reads `discovery_get_trader_history` and nothing else. `realizedPnl` is the exact realized PnL of the round-trip and is emitted unchanged. `totalFees` rides along as a separate `fees` field. Removes `_hl_info` (a `curl` to `api.hyperliquid.xyz`) and `_reconstruct_closed_from_fills`.

**The on-chain fallback is removed, not replaced — its premise does not hold.** It existed because "`strategy_close` clears Senpi's index, so a CLOSED strategy returns empty". History is keyed by wallet address, which outlives the strategy record. Verified live below.

**Unrealized PnL.** `fetch_open_book` is now ONE `discovery_get_trader_state` call per 50 wallets, replacing a threaded per-wallet `strategy_get_clearinghouse_state` fetch with retry/backoff. That tool merges main perps and the HIP-3 `xyz:` dexes into a single `openPositions` list, so an `xyz:` position can no longer be missed — the old path read `main` and `xyz` as separate sections.

**New `account` step, run first.** `account_get_historical_info`, then the full strategy list (ACTIVE + PAUSED + CLOSED). Emits per-period totals only; the raw `pnlHistory` / `accountValueHistory` arrays are deliberately dropped, since they are account-value snapshots where a drop is usually a withdrawal, which guardrail 3 already warns against narrating as trades.

**`openTime: 0` is treated as missing, not epoch 1970.** Discovery sends `0` for "no open time" on a meaningful share of rows.

**Two new HARD RULES** in `SKILL.md`:

> 6. Realized PnL is exact — never adjust it. Do not subtract fees from it, do not recompute it, do not "correct" it. Same for `unrealized_pnl`.
> 7. Do not mention fees unless the user asked about fees. If they did not ask, leave them out entirely: no "fees ate your gains", no fee-adjusted figure, no parenthetical.

## Verified against production

Not just fixtures — the engine was run against a live account with the real MCP token.

**108 strategies, every one CLOSED, and it still collected 26 closed trades from them.** That is the direct disproof of the trap the reconstruction existed to work around.

```
realized (exact) : 17.05
fees (separate)  : 17.23
unrealized       : 0.0
TOTAL            : 17.05
```

If fees had leaked into the headline that would read −0.18, so the separation is demonstrated rather than asserted.

The live run also surfaced three bugs the fixtures could not, fixed in `b7588bb`:

1. `fees` was dropped by the stdout projection (`_TRADE_STDOUT_FIELDS`), so the per-trade fee never reached the narrator even though the aggregate did.
2. A book with **no** current strategies reported `unrealized`/`total` as `null`, leaving a fully-closed book with no TOTAL headline at all (HARD RULE 1). No current strategies means no open positions — a real zero. A current wallet that exists but is unreadable still reports UNKNOWN; that distinction is what the null is for.
3. `_fresh_meta` carried the pre-change `sources` list, so the stepped path disagreed with `run()` about where its data came from.

Fail-open was also observed working for real: one run had `account_get_historical_info` return `UNAVAILABLE`, the warning was recorded, and the review completed with no fabricated zero.

## Tests

`review.py` is 66 lines shorter. The five tests covering deleted code are replaced by tests for the new contract:

- one batched call for N wallets, not N calls; `xyz:` positions counted; 120 wallets chunk to `[50, 50, 20]`
- `realized_pnl` stays `19.00` when `fees` is `16.99`
- `openTime: 0` reads as `None`
- a closed-only book gets a real `0.0` unrealized, while all-unreadable current wallets stay `None`
- `account_history` emits period totals and no raw series

75 improve-trades tests pass; 563 across the CI set, plus both `min_budget` parity scripts.

## Out of scope, flagged

CI never ran `senpi-improve-trades/tests` — the workflow gates ops, discover, trading-runtime, trader-research, market-pulse and portfolio only, so this skill's suite has only ever run locally. Since this PR rewrites its PnL path, `315cd11` adds it to the gate. `account-status`, `smart-money` and `strategy-author` still collide on test module names when collected alongside the others; that is pre-existing and left for a separate fix.

## Relationship to #538

This **supersedes** #538 rather than building on it. That PR spends ~200 lines paging `userFillsByTime` to compute a number this branch reads off the row it was already parsing, and the two rewrite the same code, so they will conflict. #538's sign fix, coverage plumbing and window bound are all correct work — they are simply unnecessary once the fee comes from `totalFees`. Closing #538 in favour of this is my suggestion, but it is your call.

One trap worth carrying forward from that review: **do not use `totalBuilderFees`.** It reads `0` on 93,182 of the 93,280 rows where `totalFees != totalHyperliquidFees + totalBuilderFees`. `totalFees` is the all-in figure; the other two are not a reliable decomposition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
