### PR TITLE
senpi-portfolio: PR #481 review follow-ups — zero-price guard, spot bucket, live-shape fixture, loud reconcile

### DIFF
--- a/senpi-portfolio/SKILL.md
+++ b/senpi-portfolio/SKILL.md
@@ -83,7 +83,7 @@ Every dollar is in exactly one of **three buckets** — and the #1 mistake is co
 
 | Bucket | What it is | Engine field |
 |---|---|---|
-| **Idle in embedded** | Truly free cash in the main wallet — HL USDC + EVM USDC. Deploy it into a strategy or withdraw it to your bank. | `totals.idle_in_embedded` |
+| **Idle in embedded** | Truly free cash in the main wallet — HL perps USDC + HL spot USDC + EVM USDC (all three legs; the funding waterfall deploys from all of them). Deploy it into a strategy or withdraw it to your bank. | `totals.idle_in_embedded` |
 | **Idle in strategies** | Free margin sitting *inside* a strategy wallet, not yet in a position — waiting for a signal. | `totals.idle_in_strategies` |
 | **Deployed in positions** | Margin actively backing open trades. | `totals.deployed_in_positions` |
 
@@ -724,8 +724,9 @@ Show strategy wallet addresses in short form (`0x35d1...acb1`) unless asked for 
 - **A strategy's closed-history read failed** → `closed.realized_pnl` is `null` + a `meta.warnings`
   entry (`trader_history … failed/returned no data`). Report realized PnL as **unavailable** for that
   strategy — never as `$0`.
-- **`totals.reconciles == false`** → the per-wallet sum and the portfolio aggregate disagree; surface
-  it and trust the per-wallet (live) figures.
+- **`totals.reconciles == false`** → the per-wallet sum and the portfolio aggregate disagree; the engine
+  also appends a `TOTALS DO NOT RECONCILE` entry to `meta.warnings` quoting both figures and the gap.
+  STOP and re-run first (see above); if it persists, surface it and trust the per-wallet (live) figures.
 - **Never** report `total_withdrawable` as embedded idle, never skip a wallet, never skip the CTAs.
 
 ## Skill Attribution

--- a/senpi-portfolio/scripts/portfolio.py
+++ b/senpi-portfolio/scripts/portfolio.py
@@ -1127,6 +1127,13 @@ def enrich_market(client, strategies, meta):
 
 
 # ──────────────────────────────────────────────────────────────── taxonomy + signals
+def _reconcile_tolerance(grand_total):
+    """THE reconciliation tolerance — the single definition behind the `reconciles` flag in BOTH totals
+    builders (compute / _money_totals) and the warning that quotes it. Inlining the formula at each site
+    is how the warning ends up quoting a stale tolerance while the flag uses the real one."""
+    return max(2.0, 0.01 * (grand_total or 0.0))
+
+
 def _warn_if_not_reconciled(totals, meta):
     """A `reconciles: false` must land in meta.warnings like every other failure mode in this file —
     a reader scanning warnings and seeing [] next to a silent mismatch never triggers SKILL.md's
@@ -1137,7 +1144,7 @@ def _warn_if_not_reconciled(totals, meta):
     pbal = totals.get("portfolio_total_balance_usd")
     grand = totals.get("grand_total_usd") or 0.0
     gap = round(abs((pbal or 0.0) - grand), 2)
-    tol = round(max(2.0, 0.01 * grand), 2)
+    tol = round(_reconcile_tolerance(grand), 2)
     meta.setdefault("warnings", []).append(
         f"TOTALS DO NOT RECONCILE — the portfolio aggregate (${pbal:,.2f}) and the per-wallet grand "
         f"total (${grand:,.2f}) disagree by ${gap:,.2f} (tolerance ${tol:,.2f}): a bucket is missing or "
@@ -1183,7 +1190,7 @@ def compute(embedded, strategies, portfolio_totals, meta=None):
     }
     # reconciliation flag — surfaces silent drift between the two sources
     pbal = portfolio_totals.get("total_balance_usd")
-    totals["reconciles"] = (pbal is None) or (abs(pbal - grand_total) <= max(2.0, 0.01 * grand_total))
+    totals["reconciles"] = (pbal is None) or (abs(pbal - grand_total) <= _reconcile_tolerance(grand_total))
     _warn_if_not_reconciled(totals, meta)
 
     net = round(gross_long - gross_short, 2)
@@ -1525,7 +1532,7 @@ def _money_totals(embedded, strategies, portfolio_totals, meta=None):
         "portfolio_total_withdrawable": portfolio_totals.get("total_withdrawable"),
     }
     pbal = portfolio_totals.get("total_balance_usd")
-    totals["reconciles"] = (pbal is None) or (abs(pbal - grand_total) <= max(2.0, 0.01 * grand_total))
+    totals["reconciles"] = (pbal is None) or (abs(pbal - grand_total) <= _reconcile_tolerance(grand_total))
     _warn_if_not_reconciled(totals, meta)
     return totals
 

--- a/senpi-portfolio/scripts/portfolio.py
+++ b/senpi-portfolio/scripts/portfolio.py
@@ -644,6 +644,8 @@ def fetch_embedded(client, meta):
             # Live GetPortfolioV3 uses `balanceInUSD` (+ `formattedBalance`/`tokenPriceInUSD`) —
             # without it every token read $0 and evm_usdc was always [].
             amt = _f(tb, "usdValue", "usd_value", "amountUsd", "balanceUsd", "balanceInUSD", "amount", default=0.0)
+            # `== 0.0` (not a missing-key test) is DELIBERATE: a present-and-zero amount is this API's
+            # zero-as-missing sentinel (#537), same convention as the `or 1.0` price guard below.
             if amt == 0.0:
                 raw = _f(tb, "formattedBalance", "amount", default=0.0)
                 # `or 1.0`: a PRESENT-and-zero price is this API's zero-as-missing sentinel (see #537),

--- a/senpi-portfolio/scripts/portfolio.py
+++ b/senpi-portfolio/scripts/portfolio.py
@@ -15,7 +15,7 @@ WHY THIS EXISTS — the balance-bucket trap:
 Agents conflate `total_withdrawable` (free margin sitting INSIDE strategy wallets) with "idle cash in
 the main embedded wallet." They are different buckets. This engine computes three structurally
 separate pools so the agent never mixes them:
-  1. idle_in_embedded   = total_usdc_in_hyperliquid + EVM token_balances   (truly free; deploy or withdraw)
+  1. idle_in_embedded   = total_in_hyperliquid + HL spot USDC + EVM token_balances   (truly free; deploy or withdraw)
   2. idle_in_strategies = sum of each strategy wallet's `withdrawable`      (in a strategy, not a position)
   3. deployed           = margin backing open positions
 Grand total = idle_in_embedded + idle_in_strategies + deployed.
@@ -646,13 +646,18 @@ def fetch_embedded(client, meta):
             amt = _f(tb, "usdValue", "usd_value", "amountUsd", "balanceUsd", "balanceInUSD", "amount", default=0.0)
             if amt == 0.0:
                 raw = _f(tb, "formattedBalance", "amount", default=0.0)
-                price = _f(tb, "tokenPriceInUSD", default=1.0)
+                # `or 1.0`: a PRESENT-and-zero price is this API's zero-as-missing sentinel (see #537),
+                # and raw × 0 would make the balance invisible — the exact bug this path exists to fix.
+                price = _f(tb, "tokenPriceInUSD", default=1.0) or 1.0
                 amt = raw * price
             chain = _field(tb, "chain", "network", "chainName", default="EVM")
             if amt:
                 out["evm_usdc"].append({"chain": chain, "usd": round(amt, 2)})
                 evm += amt
-    out["idle_total"] = round((out["idle_hl_usdc"] or 0.0) + evm, 2)
+    # spot_usd is the HL SPOT USDC bucket — deployable like the perps balance (the funding waterfall is
+    # perps + spot + EVM), and NOT inside total_in_hyperliquid. Omitting it under-reported idle_total by
+    # exactly the spot balance, quietly enough to hide under the reconciliation tolerance.
+    out["idle_total"] = round((out["idle_hl_usdc"] or 0.0) + (out["spot_usd"] or 0.0) + evm, 2)
     portfolio_totals = {
         "total_balance_usd": _f(p, "total_balance_usd", default=None),
         "total_allocated_in_strategy": _f(p, "total_allocated_in_strategy", default=None),
@@ -1122,7 +1127,25 @@ def enrich_market(client, strategies, meta):
 
 
 # ──────────────────────────────────────────────────────────────── taxonomy + signals
-def compute(embedded, strategies, portfolio_totals):
+def _warn_if_not_reconciled(totals, meta):
+    """A `reconciles: false` must land in meta.warnings like every other failure mode in this file —
+    a reader scanning warnings and seeing [] next to a silent mismatch never triggers SKILL.md's
+    "STOP and re-run on reconciles: false" rule. Names the two figures and the gap so the narrator
+    can quote what disagreed."""
+    if meta is None or totals.get("reconciles") is not False:
+        return
+    pbal = totals.get("portfolio_total_balance_usd")
+    grand = totals.get("grand_total_usd") or 0.0
+    gap = round(abs((pbal or 0.0) - grand), 2)
+    tol = round(max(2.0, 0.01 * grand), 2)
+    meta.setdefault("warnings", []).append(
+        f"TOTALS DO NOT RECONCILE — the portfolio aggregate (${pbal:,.2f}) and the per-wallet grand "
+        f"total (${grand:,.2f}) disagree by ${gap:,.2f} (tolerance ${tol:,.2f}): a bucket is missing or "
+        f"double-counted. STOP and re-run before narrating any dollar figure (SKILL.md); if it "
+        f"persists, trust the per-wallet (live) figures and say the aggregate disagrees.")
+
+
+def compute(embedded, strategies, portfolio_totals, meta=None):
     idle_strat = round(sum(_num(s.get("idle_withdrawable")) or 0.0 for s in strategies), 2)
     deployed = round(sum(_num(s.get("deployed")) or 0.0 for s in strategies), 2)
     idle_emb = embedded.get("idle_total") or 0.0
@@ -1161,6 +1184,7 @@ def compute(embedded, strategies, portfolio_totals):
     # reconciliation flag — surfaces silent drift between the two sources
     pbal = portfolio_totals.get("total_balance_usd")
     totals["reconciles"] = (pbal is None) or (abs(pbal - grand_total) <= max(2.0, 0.01 * grand_total))
+    _warn_if_not_reconciled(totals, meta)
 
     net = round(gross_long - gross_short, 2)
     exposure = {
@@ -1332,7 +1356,7 @@ def run(client, want_market=True):
     strategies = fetch_strategies(client, meta)
     if want_market and strategies:
         enrich_market(client, strategies, meta)
-    totals, exposure, signals = compute(embedded, strategies, portfolio_totals)
+    totals, exposure, signals = compute(embedded, strategies, portfolio_totals, meta)
     meta["strategy_count"] = len(strategies)
     meta.setdefault("has_multi_wallet_strategy", False)   # default; group_strategies flips it to True
     # A STRATEGY IS ALL ITS WALLETS — re-unite the per-wallet rows into one entry per real strategy.
@@ -1481,7 +1505,7 @@ def fetch_strategy_money(client, meta):
     return strategies
 
 
-def _money_totals(embedded, strategies, portfolio_totals):
+def _money_totals(embedded, strategies, portfolio_totals, meta=None):
     """The three-bucket money map — the SAME classification compute() does, over money-lite strategy rows
     (which carry idle_withdrawable / deployed / account_value). idle_in_embedded / idle_in_strategies /
     deployed_in_positions + grand_total_usd + reconciles. No exposure/signals here (those need the full
@@ -1502,6 +1526,7 @@ def _money_totals(embedded, strategies, portfolio_totals):
     }
     pbal = portfolio_totals.get("total_balance_usd")
     totals["reconciles"] = (pbal is None) or (abs(pbal - grand_total) <= max(2.0, 0.01 * grand_total))
+    _warn_if_not_reconciled(totals, meta)
     return totals
 
 
@@ -1568,7 +1593,7 @@ def step_money(client, want_market=True, state_path=None):
     meta = _fresh_meta()
     embedded, portfolio_totals = fetch_embedded(client, meta)
     strategies = fetch_strategy_money(client, meta)
-    totals = _money_totals(embedded, strategies, portfolio_totals)
+    totals = _money_totals(embedded, strategies, portfolio_totals, meta)
     meta["strategy_count"] = len(strategies)
     if not strategies and not embedded.get("address"):
         meta["degraded"] = "no wallet data — check the token is USER-scoped"
@@ -1628,7 +1653,7 @@ def step_positions(client, want_market=True, state_path=None):
             meta["warnings"].append(w)
     if want_market and strategies:
         enrich_market(client, strategies, meta)
-    totals, exposure, signals = compute(embedded, strategies, portfolio_totals)
+    totals, exposure, signals = compute(embedded, strategies, portfolio_totals, meta)
     _carry_provenance(meta, state)   # same restore as `step_strategies` — see _carry_provenance
     meta["strategy_count"] = len(strategies)
     meta.setdefault("has_multi_wallet_strategy", False)

--- a/senpi-portfolio/tests/fixtures/portfolio_fixture.json
+++ b/senpi-portfolio/tests/fixtures/portfolio_fixture.json
@@ -9,7 +9,7 @@
     "total_withdrawable": 2461.98,
     "total_in_hyperliquid": 0,
     "total_spot_usd_in_hyperliquid": 0,
-    "token_balances": [{"symbol": "USDC", "chain": "Base", "usdValue": 1.51}]
+    "token_balances": [{"tokenSymbol": "USDC", "tokenAddress": "0x833589fcd6edb6e8f4c7c32d4f71b54bda02913", "formattedBalance": "1.510231", "balanceInUSD": 1.5099873, "tokenPriceInUSD": 0.9998, "chainId": 8453}]
   }},
   "strategy_list": {"strategies": [
     {"strategyName": "cub-long", "tradingStrategyName": "cub", "strategyMetadata": {"skillName": "cub", "skillVersion": "1.0.0"}, "strategyWalletAddress": "0xlong0000000000000000000000000000000long", "status": "ACTIVE", "totalFunded": 1739, "totalWithdrawn": 0},

--- a/senpi-portfolio/tests/fixtures/portfolio_fixture.json
+++ b/senpi-portfolio/tests/fixtures/portfolio_fixture.json
@@ -9,7 +9,7 @@
     "total_withdrawable": 2461.98,
     "total_in_hyperliquid": 0,
     "total_spot_usd_in_hyperliquid": 0,
-    "token_balances": [{"tokenSymbol": "USDC", "tokenAddress": "0x833589fcd6edb6e8f4c7c32d4f71b54bda02913", "formattedBalance": "1.510231", "balanceInUSD": 1.5099873, "tokenPriceInUSD": 0.9998, "chainId": 8453}]
+    "token_balances": [{"tokenSymbol": "USDC", "tokenAddress": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913", "formattedBalance": "1.510231", "balanceInUSD": 1.5099873, "tokenPriceInUSD": 0.9998, "chainId": 8453}]
   }},
   "strategy_list": {"strategies": [
     {"strategyName": "cub-long", "tradingStrategyName": "cub", "strategyMetadata": {"skillName": "cub", "skillVersion": "1.0.0"}, "strategyWalletAddress": "0xlong0000000000000000000000000000000long", "status": "ACTIVE", "totalFunded": 1739, "totalWithdrawn": 0},

--- a/senpi-portfolio/tests/test_portfolio.py
+++ b/senpi-portfolio/tests/test_portfolio.py
@@ -861,7 +861,7 @@ def test_embedded_evm_usdc_reads_balanceInUSD():
             "total_in_hyperliquid": 0, "total_spot_usd_in_hyperliquid": 0,
             "token_balances": [{
                 "tokenSymbol": "USDC",
-                "tokenAddress": "0x833589fcd6edb6e8f4c7c32d4f71b54bda02913",
+                "tokenAddress": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
                 "formattedBalance": "7.984101",
                 "balanceInUSD": 7.983940679251919,
                 "chainId": 8453}]}},

--- a/senpi-portfolio/tests/test_portfolio.py
+++ b/senpi-portfolio/tests/test_portfolio.py
@@ -892,6 +892,102 @@ def test_embedded_evm_usdc_falls_back_to_formattedBalance_times_price():
     assert res["totals"]["idle_in_embedded"] == 5.0
 
 
+def test_embedded_evm_usdc_survives_a_present_and_zero_price():
+    """Regression (PR #481 review): `_f` returns the first PRESENT numeric key, so `tokenPriceInUSD: 0`
+    yielded price 0.0 and raw × 0 == 0 made the balance invisible again — the exact failure the
+    balanceInUSD fix closed. Zero-as-missing is a known shape on this API (#537 coerces the same `0`
+    sentinels to None); a present-and-zero price must fall back to 1.0, never multiply the balance away."""
+    fixture = {
+        "user_get_me": {"wallets": [
+            {"walletType": "embedded", "walletAddress": "0xembed00000000000000000000000000000000ed"}]},
+        "account_get_portfolio": {"portfolio": {
+            "total_balance_usd": 93.95, "total_allocated_in_strategy": 0, "total_withdrawable": 0,
+            "total_in_hyperliquid": 0, "total_spot_usd_in_hyperliquid": 0,
+            "token_balances": [{
+                "tokenSymbol": "USDC",
+                "formattedBalance": "93.95",
+                "tokenPriceInUSD": 0,
+                "chainId": 8453}]}},
+        "strategy_list": {"strategies": []},
+    }
+    res = portfolio.run(portfolio._FixtureClient(fixture), want_market=False)
+    assert res["embedded_wallet"]["evm_usdc"] == [{"chain": "EVM", "usd": 93.95}]
+    assert res["totals"]["idle_in_embedded"] == 93.95
+
+
+def test_embedded_idle_counts_the_hl_spot_bucket():
+    """Regression (PR #481 review, follow-up 1): `spot_usd` was read and never added, so idle_total
+    omitted the HL spot USDC bucket — the funding waterfall is perps + spot + EVM. On the review's live
+    payload that under-reported embedded idle by $1.81, quietly enough to hide under the reconciliation
+    tolerance. All three legs must sum: 135.21 (perps) + 1.81 (spot) + 93.95 (EVM) = 230.97."""
+    fixture = {
+        "user_get_me": {"wallets": [
+            {"walletType": "embedded", "walletAddress": "0xembed00000000000000000000000000000000ed"}]},
+        "account_get_portfolio": {"portfolio": {
+            "total_balance_usd": 230.97, "total_allocated_in_strategy": 0, "total_withdrawable": 0,
+            "total_in_hyperliquid": 135.21, "total_spot_usd_in_hyperliquid": 1.81,
+            "token_balances": [{
+                "tokenSymbol": "USDC",
+                "formattedBalance": "93.953021",
+                "balanceInUSD": 93.9511,
+                "chainId": 8453}]}},
+        "strategy_list": {"strategies": []},
+    }
+    res = portfolio.run(portfolio._FixtureClient(fixture), want_market=False)
+    e = res["embedded_wallet"]
+    assert e["spot_usd"] == 1.81
+    assert e["idle_total"] == 230.97                       # perps + SPOT + EVM — spot no longer dropped
+    assert res["totals"]["idle_in_embedded"] == 230.97
+    assert res["totals"]["reconciles"] is True
+
+
+def test_canonical_fixture_token_balances_use_the_live_shape():
+    """Regression (PR #481 review, follow-up 2): the shared fixture carried `{symbol, chain, usdValue}` —
+    a token_balances shape GetPortfolioV3 does not return — so the suite proved the parser reads the
+    fixture, not the API, and the always-empty evm_usdc bug shipped green. Every entry must carry the
+    live field names (`tokenSymbol`/`balanceInUSD`/`chainId`) and none of the invented ones."""
+    with open(FIXTURE) as f:
+        tbs = json.load(f)["account_get_portfolio"]["portfolio"]["token_balances"]
+    assert tbs, "the canonical fixture must exercise the token_balances parser"
+    for tb in tbs:
+        assert "tokenSymbol" in tb and "balanceInUSD" in tb and "chainId" in tb
+        for invented in ("symbol", "chain", "usdValue"):
+            assert invented not in tb, f"fixture regressed to the invented `{invented}` field"
+
+
+def test_reconcile_mismatch_is_a_loud_warning_not_a_silent_flag():
+    """Regression (PR #481 review, follow-up 3): `totals.reconciles == false` emitted no meta.warnings
+    entry — the ONLY failure mode in the engine that stayed silent — so a reader scanning warnings saw []
+    next to a mismatch and SKILL.md's "STOP and re-run on reconciles: false" rule never fired. Both
+    totals builders (run()/`positions` and the `money` step) must append the warning, naming the gap."""
+    fixture = {
+        "user_get_me": {"wallets": [
+            {"walletType": "embedded", "walletAddress": "0xembed00000000000000000000000000000000ed"}]},
+        # aggregate says $500; the per-wallet legs sum to $100 → gap $400, far past the $2 tolerance
+        "account_get_portfolio": {"portfolio": {
+            "total_balance_usd": 500.0, "total_allocated_in_strategy": 0, "total_withdrawable": 0,
+            "total_in_hyperliquid": 100.0, "total_spot_usd_in_hyperliquid": 0, "token_balances": []}},
+        "strategy_list": {"strategies": []},
+    }
+    res = portfolio.run(portfolio._FixtureClient(fixture), want_market=False)
+    assert res["totals"]["reconciles"] is False
+    warns = [w for w in res["meta"]["warnings"] if "RECONCILE" in w.upper()]
+    assert warns, "a silent reconciliation mismatch is the defect"
+    assert "$400.00" in warns[0]                           # the gap is quoted, not just asserted
+    # the fast money step computes reconciles through its own builder — it must be just as loud
+    m = portfolio.step_money(portfolio._FixtureClient(fixture),
+                             want_market=False, state_path=_tmp_state())
+    assert m["totals"]["reconciles"] is False
+    assert any("RECONCILE" in w.upper() for w in m["meta"]["warnings"])
+
+
+def test_reconciled_totals_stay_quiet():
+    """The other side: reconciles True (or unknowable — no aggregate) appends nothing."""
+    res = _result()
+    assert res["totals"]["reconciles"] is True
+    assert not any("RECONCILE" in w.upper() for w in res["meta"]["warnings"])
+
+
 # ──────────────────────────────────────────────── streaming STEPS (money · strategies · positions · all)
 def _client():
     """A fresh fixture client on the canonical portfolio fixture (each step consumes its own client)."""


### PR DESCRIPTION
## Summary

Follow-ups from @0xsarvesh's [review on #481](https://github.com/Senpi-ai/senpi-skills/pull/481#issuecomment-5296550846) (merged) — the blocking nit inside the merged lines plus the three pre-existing issues flagged for a separate PR. All in `senpi-portfolio`.

**1. `tokenPriceInUSD: 0` re-opened the bug #481 fixed (the review's blocking nit).** `_f` returns the first *present* numeric key, so a present-and-zero price made `raw * 0 == 0` and the balance invisible again. Guarded with the suggested `or 1.0` — zero-as-missing is a known sentinel shape on this API (#537 coerces the same `0` sentinels to `None`).

**2. `idle_total` omitted the HL spot USDC bucket.** `spot_usd` was read and never added, under-reporting embedded idle by exactly the spot balance — quietly enough on the review's live payload ($1.81) to hide under the reconciliation tolerance and flip `reconciles` to a false `True`. `idle_total` is now perps + spot + EVM, matching the funding waterfall.

**3. The canonical fixture encoded a payload shape the API does not return.** `tests/fixtures/portfolio_fixture.json` used `{symbol, chain, usdValue}`; live GetPortfolioV3 carries `{tokenSymbol, chainId, balanceInUSD, formattedBalance, tokenPriceInUSD}`. That's why the evm_usdc bug shipped green — the suite proved the parser reads the fixture, not the API. Rewritten to the live shape, with a guard test (`test_canonical_fixture_token_balances_use_the_live_shape`) that fails if the invented fields ever come back.

**4. `totals.reconciles == false` emitted no `meta.warnings` entry** — the only silent failure mode in the engine (13 other append sites), so SKILL.md's "STOP and re-run on `reconciles: false`" rule never fired for a reader scanning warnings. Both totals builders (`compute()` for `all`/`positions` and `_money_totals()` for the `money` step) now append a `TOTALS DO NOT RECONCILE` warning quoting both figures, the gap, and the tolerance.

SKILL.md updated to match: the idle-in-embedded bucket definition now names all three legs, and the `reconciles` degraded-mode entry points at the new warning.

## Tests

Five regression tests added, one per finding plus the quiet side:
- `test_embedded_evm_usdc_survives_a_present_and_zero_price` — the review's probe row that failed pre-fix (`formattedBalance` present, `tokenPriceInUSD: 0` → was `[]`, now $93.95)
- `test_embedded_idle_counts_the_hl_spot_bucket` — the review's live numbers: 135.21 + 1.81 + 93.95 = 230.97
- `test_canonical_fixture_token_balances_use_the_live_shape` — durable guard on the fixture shape
- `test_reconcile_mismatch_is_a_loud_warning_not_a_silent_flag` — both builders warn, gap quoted
- `test_reconciled_totals_stay_quiet` — no warning when totals tie out

Full suite: **67/67 passing** (plus `test_name_reader_parity.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JNoB3R6UHLT9N32sZ27SeK

---
_Generated by [Claude Code](https://claude.ai/code/session_01JNoB3R6UHLT9N32sZ27SeK)_