### PR TITLE
senpi-account-status: drop Arena — arena_* MCP tools are retired

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Every analytical skill follows the **hidden-engine pattern**: a vendored, stdlib
 | [`senpi-smart-money`](senpi-smart-money/) | 1.2.0 | Where the most-profitable wallets are positioned vs. the crowd |
 | [`senpi-trader-research`](senpi-trader-research/) | 1.4.0 | Rank + vet Hyperliquid traders before copying them (mirror-aware: copyability, min-budget, live book) |
 | [`senpi-improve-trades`](senpi-improve-trades/) | 1.1.1 | Retrospective review + health checks off the **telemetry event log**: exit quality, missed signals, leaks, crashes, "if I'd held" counterfactual |
-| [`senpi-account-status`](senpi-account-status/) | 1.1.1 | Points, loyalty tier, fees, Arena standing, referrals |
+| [`senpi-account-status`](senpi-account-status/) | 1.2.0 | Points, loyalty tier, fees, referrals |
 | **Run a strategy** | | |
 | [`senpi-strategy-discover`](senpi-strategy-discover/) | 2.17.0 | Conversational picker — rank the catalog against your worldview |
 | [`senpi-strategy-author`](senpi-strategy-author/) | 2.4.2 | Build/edit a DSL-protected strategy package, one decision at a time |

--- a/senpi-account-status/SKILL.md
+++ b/senpi-account-status/SKILL.md
@@ -1,16 +1,15 @@
 ---
 name: senpi-account-status
 description: >-
-  Show the user's standing across Senpi programs — points and rank, loyalty tier and fees, Agents
-  Arena position, and referral earnings. Use for "how many points do I have?",
-  "what's my rank/tier?", "what are my fees?", "how am I doing in the Arena?", "my referral
-  rewards". Use this instead of calling user_get_senpi_points + get_loyalty_tiers
-  + arena_* one by one. A hidden engine (scripts/status.py) pulls it all in one call. Requires
-  a USER-scoped Senpi token.
+  Show the user's standing across Senpi programs — points and rank, loyalty tier and fees, and
+  referral earnings. Use for "how many points do I have?", "what's my rank/tier?",
+  "what are my fees?", "my referral rewards". Use this instead of calling
+  user_get_senpi_points + get_loyalty_tiers one by one. A hidden engine (scripts/status.py)
+  pulls it all in one call. Requires a USER-scoped Senpi token.
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "1.1.1"
+  version: "1.2.0"
   platform: senpi
   exchange: hyperliquid
 ---
@@ -18,13 +17,13 @@ metadata:
 # Senpi Account Status — your standing across Senpi
 
 A hidden engine pulls the user's standing in one real-time call; **your job is to present it
-cleanly** and point at the next milestone (next loyalty tier, Arena prize, etc.).
+cleanly** and point at the next milestone (next loyalty tier, etc.).
 
 ## Golden rules
 
-- **Run the engine; never hand-pull.** `python3 scripts/status.py` gathers points, loyalty, Arena,
-  and referral together. Read its JSON.
-- **Real-time, not from memory.** Points/rank/Arena move — never quote a figure from earlier in the
+- **Run the engine; never hand-pull.** `python3 scripts/status.py` gathers points, loyalty, and
+  referral together. Read its JSON.
+- **Real-time, not from memory.** Points/rank move — never quote a figure from earlier in the
   conversation; re-run.
 - **Fees come from the data, never from memory.** Quote `loyalty.fee_bps` / `fee_discount_pct` as
   returned — the tier table changes; stale numbers mislead. (For the *full* tier table, that's
@@ -32,8 +31,6 @@ cleanly** and point at the next milestone (next loyalty tier, Arena prize, etc.)
 - **Lead with what they asked, then the milestone.** If they asked about points, lead with points +
   rank, then "X to the next tier." Don't dump every section if they asked one question — but the
   engine returns all of it so you can.
-- **Arena scope.** `arena.enrolled: false` means they're not in the competition — say so plainly and
-  point to senpi.ai/arena; don't report a rank they don't have.
 - **Always end with the two CTAs** (below).
 
 ## How to run the engine
@@ -42,14 +39,12 @@ cleanly** and point at the next milestone (next loyalty tier, Arena prize, etc.)
 python3 scripts/status.py
 ```
 
-Returns `{identity, points, loyalty, arena, referral, meta}`:
+Returns `{identity, points, loyalty, referral, meta}`:
 - `points` — `total`, `base` (Base copy-trading), `perp` (Hyperliquid), `multiplier`, `rank`,
   `rank_change`.
 - `loyalty` — `tier`, `fee_bps` + `fee_pct`, `fee_discount_pct`, `next_tier`, `points_to_next` (the
   milestone), plus `demoted` / `previous_tier` / `maintenance_deadline` — if `demoted` is true,
   mention the tier they fell from and that maintenance volume wins it back.
-- `arena` — `enrolled`; if enrolled: `rank`, `roe_pct`, `total_pnl_usd`, `qualified` (hit the volume
-  threshold), `week_pool_usd`, `prize_estimate_usd` (if top-5).
 - `referral` — `balance_usdc` (pending referral earnings, 25% of builder fee on referred trades).
 - `meta.warnings` / `meta.degraded` — narrate honestly.
 - Fails open — partial data still returns valid JSON.
@@ -61,18 +56,15 @@ Lead with the section they asked about; otherwise a tight standing card:
 1. **Points & rank** — total, base/perp split, multiplier, rank (+ change).
 2. **Loyalty** — current tier + fee/discount, and **`points_to_next` → next_tier** (the actionable
    milestone).
-3. **Arena** — if `enrolled`: rank, ROE %, qualified-or-not, and the prize context (week pool;
-   estimate if top-5). If not enrolled: one line + the arena link.
-4. **Referral** — pending `balance_usdc` (and that it's claimable if > 0).
+3. **Referral** — pending `balance_usdc` (and that it's claimable if > 0).
 
-Formatting: clean, scannable, numbers from the data; emoji sparingly (🏆 Arena, 🎯 next tier).
+Formatting: clean, scannable, numbers from the data; emoji sparingly (🎯 next tier).
 
 ## Mandatory closing (verbatim)
 
-> **Want me to break down what it takes to reach the next tier (or climb the Arena)?**
+> **Want me to break down what it takes to reach the next tier?**
 
-On yes: use `loyalty.points_to_next` + `get_loyalty_tiers` for the tier path, or the
-Arena `qualified`/volume threshold + `week_pool`/prize split for the Arena path.
+On yes: use `loyalty.points_to_next` + `get_loyalty_tiers` for the tier path.
 
 ## ⚠ Token scope
 

--- a/senpi-account-status/references/presentation-notes.md
+++ b/senpi-account-status/references/presentation-notes.md
@@ -4,16 +4,14 @@ This skill *presents* the user's standing; it doesn't analyze a market. A few ru
 
 ## Lead with the question, carry the rest
 
-The engine returns everything (points, loyalty, arena, referral) in one call, but the user
+The engine returns everything (points, loyalty, referral) in one call, but the user
 usually asked one thing. Lead with that section, then offer the rest. "How many points do I have?" →
-lead with `points.total` + `rank`, then *"you're 5,000 from Gold"* — don't open with the Arena.
+lead with `points.total` + `rank`, then *"you're 5,000 from Gold"* — don't open with the referral balance.
 
 ## Always point at the next milestone
 
 Standing is more motivating with a target. Pair every section with its next step:
 - **Loyalty** → `points_to_next` to `next_tier` (and what the next tier's fee discount buys).
-- **Arena** → if not `qualified`, the volume threshold to become prize-eligible; if ranked, the
-  prize at their rank vs. the rank above.
 - **Referral** → if `balance_usdc > 0`, that it's claimable (a separate explicit action — this skill
   doesn't claim it).
 
@@ -21,13 +19,11 @@ Standing is more motivating with a target. Pair every section with its next step
 
 - **Fees from the data, never memory.** Quote `loyalty.fee_bps` / `fee_discount_pct` as returned —
   the tier table changes.
-- **Arena scope.** `enrolled: false` means not in the competition — say so and link senpi.ai/arena;
-  never invent a rank.
 - **`found: false` on points** means no leaderboard entry yet (base-tier defaults) — present it as
   "you haven't started earning yet," not "0 / error."
 - **Demotion is a story, not a stat.** If `loyalty.demoted` is true, say it plainly — "you held
   APEX, maintenance lapsed, you're at BRONZE now" — and pair it with the way back
   (`maintenance_deadline`, maintenance volume). Never present a demoted user's tier as if it were
   their lifetime standing.
-- **Decimals arrive as strings** from several of these tools (roePct, prizeAmount, balance_usdc) — the
+- **Decimals arrive as strings** from several of these tools (e.g. balance_usdc) — the
   engine parses them; just present clean numbers.

--- a/senpi-account-status/scripts/status.py
+++ b/senpi-account-status/scripts/status.py
@@ -2,8 +2,8 @@
 """senpi-account-status engine — the user's standing across Senpi programs (hidden, deterministic).
 
 The agent (LLM) runs this via the OpenClaw `exec` tool, reads the JSON on stdout, and NARRATES the
-user's standing (see SKILL.md): Senpi points + rank, loyalty tier + fee, Arena position, and referral
-earnings. One real-time pull across all the status tools.
+user's standing (see SKILL.md): Senpi points + rank, loyalty tier + fee, and referral earnings.
+One real-time pull across all the status tools.
 
   python3 status.py                 # full standing
   python3 status.py --fixture f.json   # offline (tests)   |   --dry  (raw dump)
@@ -176,50 +176,6 @@ def fetch_referral(client, meta):
             "wallet": _field(r, "wallet_address", "walletAddress")}
 
 
-def _inner(data, key):
-    """Descend one level into the tool's named wrapper: {leaderboard:{...}} / {pool:{...}} / {prizes:{...}}."""
-    if isinstance(data, dict) and isinstance(data.get(key), dict):
-        return data[key]
-    return data
-
-
-def fetch_arena(client, meta, user_id):
-    arena = {"enrolled": False}
-    try:
-        lb_doc = _inner(_ok(client.mcp_call("arena_leaderboard", period_type="WEEK", limit=500, timeout=20)) or {},
-                        "leaderboard")
-        lb = _rows(lb_doc, "entries")
-        if _f(lb_doc, "totalCount", default=len(lb)) > len(lb):
-            meta.setdefault("warnings", []).append(
-                "arena_leaderboard truncated at 500 rows — enrollment check may miss agents ranked below 500")
-    except Exception as e:  # noqa
-        meta.setdefault("warnings", []).append(f"arena_leaderboard failed: {e}")
-        lb = []
-    me = next((e for e in lb if str(_field(e, "senpiUserId", "userId", default="")) == str(user_id)), None) if user_id else None
-    if me:
-        arena.update({"enrolled": True, "rank": _f(me, "rank"),
-                      "roe_pct": _f(me, "roePct", "roe"),
-                      "total_pnl_usd": _f(me, "totalPnl", "total_pnl"),
-                      "trade_count": _f(me, "tradeCount", "trades"),
-                      "notional_volume_usd": _f(me, "notionalVolume", "notional_volume"),
-                      "qualified": _field(me, "qualified", default=None)})
-    try:
-        pool = _inner(_ok(client.mcp_call("arena_pool", timeout=12)) or {}, "pool")
-        arena["week_pool_usd"] = _f(pool, "currentWeekPool", "current_week_pool")
-    except Exception as e:  # noqa
-        meta.setdefault("warnings", []).append(f"arena_pool failed: {e}")
-    if arena.get("enrolled") and arena.get("rank"):
-        try:
-            prizes = _rows(_inner(_ok(client.mcp_call("arena_prizes", period_type="WEEK", timeout=12)) or {},
-                                  "prizes"), "entries")
-            pe = next((e for e in prizes if _f(e, "rank") == arena["rank"]), None)
-            if pe:
-                arena["prize_estimate_usd"] = _f(pe, "prizeAmount", "prize_amount")
-        except Exception as e:  # noqa
-            meta.setdefault("warnings", []).append(f"arena_prizes failed: {e}")
-    return arena
-
-
 # ──────────────────────────────────────────────────────────────── orchestration
 def run(client):
     meta = {"warnings": []}
@@ -227,7 +183,6 @@ def run(client):
     points, loyalty = fetch_points(client, meta, user.get("wallet"), user.get("senpi_user_id"))
     enrich_from_tiers(client, meta, loyalty, points.get("total"))
     referral = fetch_referral(client, meta)
-    arena = fetch_arena(client, meta, user.get("senpi_user_id"))
     if not user.get("senpi_user_id") and not user.get("wallet"):
         meta["degraded"] = "no user resolved — check the token is USER-scoped"
     return {
@@ -235,7 +190,6 @@ def run(client):
         "identity": user,
         "points": points,
         "loyalty": loyalty,
-        "arena": arena,
         "referral": referral,
         "meta": meta,
     }
@@ -245,7 +199,7 @@ def run(client):
 def _dry(client):
     out = {}
     for tool, kw in (("user_get_me", {}), ("user_get_referral_rewards", {}),
-                    ("arena_pool", {}), ("get_loyalty_tiers", {})):
+                    ("get_loyalty_tiers", {})):
         try:
             out[tool] = client.mcp_call(tool, timeout=12, **kw)
         except Exception as e:  # noqa

--- a/senpi-account-status/tests/fixtures/status_fixture.json
+++ b/senpi-account-status/tests/fixtures/status_fixture.json
@@ -6,9 +6,21 @@
         "id": "u123",
         "privyId": "did:privy:test",
         "wallets": [
-          {"userId": "u123", "walletType": "injected", "walletAddress": "0xinjected"},
-          {"userId": "u123", "walletType": "subwallet", "walletAddress": "0xsub1"},
-          {"userId": "u123", "walletType": "embedded", "walletAddress": "0xme"}
+          {
+            "userId": "u123",
+            "walletType": "injected",
+            "walletAddress": "0xinjected"
+          },
+          {
+            "userId": "u123",
+            "walletType": "subwallet",
+            "walletAddress": "0xsub1"
+          },
+          {
+            "userId": "u123",
+            "walletType": "embedded",
+            "walletAddress": "0xme"
+          }
         ],
         "createdAt": "2025-11-13T06:00:46.165Z",
         "referralCode": "dGVzdA=="
@@ -26,7 +38,10 @@
       "loyaltyMultiplier": 1.5,
       "rank": 42,
       "rankChange": 3,
-      "profile": {"handle": "tester", "imageUrl": null},
+      "profile": {
+        "handle": "tester",
+        "imageUrl": null
+      },
       "lastUpdated": "2026-07-05T14:05:01.922Z",
       "loyaltyTier": "SILVER",
       "loyaltyTierIcon": "🥈",
@@ -51,64 +66,63 @@
     "success": true,
     "data": {
       "tiers": [
-        {"tier": "BRONZE", "threshold": 0, "feeBps": 50, "feePercent": "0.05%", "maintenance": 0, "discountPercent": 0},
-        {"tier": "SILVER", "threshold": 100, "feeBps": 47, "feePercent": "0.047%", "maintenance": 10, "discountPercent": 6},
-        {"tier": "GOLD", "threshold": 500, "feeBps": 45, "feePercent": "0.045%", "maintenance": 50, "discountPercent": 10},
-        {"tier": "PLATINUM", "threshold": 1000, "feeBps": 40, "feePercent": "0.04%", "maintenance": 100, "discountPercent": 20},
-        {"tier": "DIAMOND", "threshold": 2000, "feeBps": 35, "feePercent": "0.035%", "maintenance": 200, "discountPercent": 30},
-        {"tier": "APEX", "threshold": 2500, "feeBps": 30, "feePercent": "0.03%", "maintenance": 250, "discountPercent": 40},
-        {"tier": "LEGEND", "threshold": 3000, "feeBps": 25, "feePercent": "0.025%", "maintenance": 300, "discountPercent": 50}
+        {
+          "tier": "BRONZE",
+          "threshold": 0,
+          "feeBps": 50,
+          "feePercent": "0.05%",
+          "maintenance": 0,
+          "discountPercent": 0
+        },
+        {
+          "tier": "SILVER",
+          "threshold": 100,
+          "feeBps": 47,
+          "feePercent": "0.047%",
+          "maintenance": 10,
+          "discountPercent": 6
+        },
+        {
+          "tier": "GOLD",
+          "threshold": 500,
+          "feeBps": 45,
+          "feePercent": "0.045%",
+          "maintenance": 50,
+          "discountPercent": 10
+        },
+        {
+          "tier": "PLATINUM",
+          "threshold": 1000,
+          "feeBps": 40,
+          "feePercent": "0.04%",
+          "maintenance": 100,
+          "discountPercent": 20
+        },
+        {
+          "tier": "DIAMOND",
+          "threshold": 2000,
+          "feeBps": 35,
+          "feePercent": "0.035%",
+          "maintenance": 200,
+          "discountPercent": 30
+        },
+        {
+          "tier": "APEX",
+          "threshold": 2500,
+          "feeBps": 30,
+          "feePercent": "0.03%",
+          "maintenance": 250,
+          "discountPercent": 40
+        },
+        {
+          "tier": "LEGEND",
+          "threshold": 3000,
+          "feeBps": 25,
+          "feePercent": "0.025%",
+          "maintenance": 300,
+          "discountPercent": 50
+        }
       ]
-    }
-  },
-  "arena_leaderboard::week": {
-    "success": true,
-    "data": {
-      "leaderboard": {
-        "periodType": "WEEK",
-        "periodNumber": 27,
-        "totalCount": 2,
-        "updatedAt": "2026-07-05T14:09:08.524Z",
-        "entries": [
-          {"senpiUserId": "u999", "rank": 1, "roePct": "44.2", "totalPnl": "1210.55", "tradeCount": 210, "notionalVolume": "310000", "qualified": true},
-          {"senpiUserId": "u123", "rank": 5, "roePct": "18.5", "totalPnl": "230.40", "tradeCount": 57, "notionalVolume": "51000", "qualified": true}
-        ]
-      },
-      "count": 2
-    }
-  },
-  "arena_pool": {
-    "success": true,
-    "data": {
-      "pool": {
-        "currentWeekNumber": 27,
-        "currentWeekPool": "5000",
-        "currentWeekStart": "2026-06-29T00:00:00Z",
-        "currentWeekEnd": "2026-07-06T00:00:00Z",
-        "nextWeekNumber": 28,
-        "nextWeekPool": "5000",
-        "currentMonthNumber": 7,
-        "currentMonthPool": "20000",
-        "nextMonthNumber": 8,
-        "nextMonthPool": "20000"
-      }
-    }
-  },
-  "arena_prizes::week": {
-    "success": true,
-    "data": {
-      "prizes": {
-        "periodType": "WEEK",
-        "periodNumber": 27,
-        "totalPool": "5000",
-        "entries": [
-          {"rank": 1, "sharePct": 40, "senpiUserId": "u999", "roePct": "44.2", "prizeAmount": "2000"},
-          {"rank": 2, "sharePct": 25, "senpiUserId": "u777", "roePct": "31.0", "prizeAmount": "1250"},
-          {"rank": 3, "sharePct": 15, "senpiUserId": "u555", "roePct": "27.4", "prizeAmount": "750"},
-          {"rank": 4, "sharePct": 12, "senpiUserId": "u444", "roePct": "22.1", "prizeAmount": "600"},
-          {"rank": 5, "sharePct": 8, "senpiUserId": "u123", "roePct": "18.5", "prizeAmount": "400"}
-        ]
-      }
     }
   },
   "user_get_referral_rewards": {

--- a/senpi-account-status/tests/fixtures/status_fixture.json
+++ b/senpi-account-status/tests/fixtures/status_fixture.json
@@ -6,21 +6,9 @@
         "id": "u123",
         "privyId": "did:privy:test",
         "wallets": [
-          {
-            "userId": "u123",
-            "walletType": "injected",
-            "walletAddress": "0xinjected"
-          },
-          {
-            "userId": "u123",
-            "walletType": "subwallet",
-            "walletAddress": "0xsub1"
-          },
-          {
-            "userId": "u123",
-            "walletType": "embedded",
-            "walletAddress": "0xme"
-          }
+          {"userId": "u123", "walletType": "injected", "walletAddress": "0xinjected"},
+          {"userId": "u123", "walletType": "subwallet", "walletAddress": "0xsub1"},
+          {"userId": "u123", "walletType": "embedded", "walletAddress": "0xme"}
         ],
         "createdAt": "2025-11-13T06:00:46.165Z",
         "referralCode": "dGVzdA=="
@@ -38,10 +26,7 @@
       "loyaltyMultiplier": 1.5,
       "rank": 42,
       "rankChange": 3,
-      "profile": {
-        "handle": "tester",
-        "imageUrl": null
-      },
+      "profile": {"handle": "tester", "imageUrl": null},
       "lastUpdated": "2026-07-05T14:05:01.922Z",
       "loyaltyTier": "SILVER",
       "loyaltyTierIcon": "🥈",
@@ -66,62 +51,13 @@
     "success": true,
     "data": {
       "tiers": [
-        {
-          "tier": "BRONZE",
-          "threshold": 0,
-          "feeBps": 50,
-          "feePercent": "0.05%",
-          "maintenance": 0,
-          "discountPercent": 0
-        },
-        {
-          "tier": "SILVER",
-          "threshold": 100,
-          "feeBps": 47,
-          "feePercent": "0.047%",
-          "maintenance": 10,
-          "discountPercent": 6
-        },
-        {
-          "tier": "GOLD",
-          "threshold": 500,
-          "feeBps": 45,
-          "feePercent": "0.045%",
-          "maintenance": 50,
-          "discountPercent": 10
-        },
-        {
-          "tier": "PLATINUM",
-          "threshold": 1000,
-          "feeBps": 40,
-          "feePercent": "0.04%",
-          "maintenance": 100,
-          "discountPercent": 20
-        },
-        {
-          "tier": "DIAMOND",
-          "threshold": 2000,
-          "feeBps": 35,
-          "feePercent": "0.035%",
-          "maintenance": 200,
-          "discountPercent": 30
-        },
-        {
-          "tier": "APEX",
-          "threshold": 2500,
-          "feeBps": 30,
-          "feePercent": "0.03%",
-          "maintenance": 250,
-          "discountPercent": 40
-        },
-        {
-          "tier": "LEGEND",
-          "threshold": 3000,
-          "feeBps": 25,
-          "feePercent": "0.025%",
-          "maintenance": 300,
-          "discountPercent": 50
-        }
+        {"tier": "BRONZE", "threshold": 0, "feeBps": 50, "feePercent": "0.05%", "maintenance": 0, "discountPercent": 0},
+        {"tier": "SILVER", "threshold": 100, "feeBps": 47, "feePercent": "0.047%", "maintenance": 10, "discountPercent": 6},
+        {"tier": "GOLD", "threshold": 500, "feeBps": 45, "feePercent": "0.045%", "maintenance": 50, "discountPercent": 10},
+        {"tier": "PLATINUM", "threshold": 1000, "feeBps": 40, "feePercent": "0.04%", "maintenance": 100, "discountPercent": 20},
+        {"tier": "DIAMOND", "threshold": 2000, "feeBps": 35, "feePercent": "0.035%", "maintenance": 200, "discountPercent": 30},
+        {"tier": "APEX", "threshold": 2500, "feeBps": 30, "feePercent": "0.03%", "maintenance": 250, "discountPercent": 40},
+        {"tier": "LEGEND", "threshold": 3000, "feeBps": 25, "feePercent": "0.025%", "maintenance": 300, "discountPercent": 50}
       ]
     }
   },

--- a/senpi-account-status/tests/test_status.py
+++ b/senpi-account-status/tests/test_status.py
@@ -2,7 +2,7 @@
 """Offline engine test — runs status.run() against a recorded MCP fixture (no network).
 
 The fixture entries are REAL response shapes captured from the senpi MCP server
-(success/data envelopes, data.leaderboard/pool/prizes nesting, decimals-as-strings) —
+(success/data envelopes, decimals-as-strings) —
 do not hand-edit shapes; re-record with `status.py --dry` if the API changes."""
 # Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
 import json
@@ -45,26 +45,11 @@ def test_loyalty_demotion():
     assert loy["maintenance_deadline"] == "2026-08-23T13:25:02.760Z"
 
 
-def test_arena_standing():
-    a = _result()["arena"]
-    assert a["enrolled"] is True and a["rank"] == 5.0   # found inside data.leaderboard.entries
-    assert a["roe_pct"] == 18.5 and a["qualified"] is True
-    assert a["week_pool_usd"] == 5000.0                 # data.pool.currentWeekPool
-    assert a["prize_estimate_usd"] == 400.0             # data.prizes.entries rank-5
-
-
-def test_arena_truncation_warning():
-    with open(FIXTURE) as f:
-        fx = json.load(f)
-    fx["arena_leaderboard::week"]["data"]["leaderboard"]["totalCount"] = 900
-    r = status.run(status._FixtureClient(fx))
-    assert any("truncated" in w for w in r["meta"]["warnings"])
-
-
 def test_referral():
     r = _result()
     assert r["referral"]["balance_usdc"] == 12.5
     assert "wins" not in r                              # get_share_your_wins is retired
+    assert "arena" not in r                             # Arena is deprecated; arena_* tools retired
 
 
 def test_fails_open_on_empty():

--- a/senpi-account-status/tests/test_status.py
+++ b/senpi-account-status/tests/test_status.py
@@ -45,11 +45,18 @@ def test_loyalty_demotion():
     assert loy["maintenance_deadline"] == "2026-08-23T13:25:02.760Z"
 
 
+def test_arena_retired():
+    """Arena is deprecated and the arena_* MCP tools were removed from the server —
+    the engine must neither emit an arena section nor attempt an arena call."""
+    r = _result()
+    assert "arena" not in r
+    assert not any("arena" in w for w in r["meta"]["warnings"])
+
+
 def test_referral():
     r = _result()
     assert r["referral"]["balance_usdc"] == 12.5
     assert "wins" not in r                              # get_share_your_wins is retired
-    assert "arena" not in r                             # Arena is deprecated; arena_* tools retired
 
 
 def test_fails_open_on_empty():

--- a/strategies/lynx/main/runtime.yaml
+++ b/strategies/lynx/main/runtime.yaml
@@ -51,7 +51,7 @@ scanners:
       recentSignalTtlSeconds: 240          # v2 RECENT_SIGNAL_TTL_SEC (race-window dedup)
       # ── self-tuning audit (archetype #15) ──
       # auditUserId enables the audit. Empty -> audit skipped, floor stays at
-      # initialMinScore forever (v2 behaviour). Find it via user_get_me / arena_leaderboard.
+      # initialMinScore forever (v2 behaviour). Find it via user_get_me.
       # NOT hardcoded — operator sets it per install (defaults to env LYNX_AUDIT_USER_ID).
       auditUserId: "${LYNX_AUDIT_USER_ID}"
       maxMinScore: 7                       # v2 maxMinScore — HARD ceiling; never tunes above


### PR DESCRIPTION
## Summary

The Agents Arena is deprecated and the `arena_leaderboard` / `arena_pool` / `arena_prizes` tools have been removed from the senpi MCP server (Senpi-ai/senpi-hyperliquid-mcp#194) — they now return `NOT_FOUND`. `senpi-account-status` was the one active consumer, degrading gracefully but logging warnings on every run. This removes the Arena dependency:

- **`scripts/status.py`** — removed `fetch_arena` (the three `arena_*` calls) and its `_inner` helper, the `arena` section of the output JSON, and the `arena_pool` probe in `--dry` mode
- **`SKILL.md`** — Arena removed from the description, golden rules, engine output docs, output contract, and the mandatory closing CTA; version bumped **1.1.1 → 1.2.0**
- **`references/presentation-notes.md`** — Arena presentation guidance removed
- **Tests + fixture** — the two arena tests and fixture entries removed; a new assertion confirms the `arena` key is gone from the output (9/9 passing)
- **`README.md`** — skill catalog row updated (version + role)
- **`strategies/lynx/main/runtime.yaml`** — stale comment hint pointing at `arena_leaderboard` now points at `user_get_me` only

## Deliberately left as-is (for potential Arena revival)

- the `albatross` strategy — already parked and hidden from the catalog on 2026-07-23 with an explicit re-enable note
- the `arena_*` entry in the trading-runtime scan-contract read allowlist and the `arena_winners` glossary entry, which only back that parked strategy
- README marketing/history mentions of the Arena site

## Verification

- `python3 senpi-account-status/tests/test_status.py` — 9/9 pass
- `py_compile` clean on `status.py`
- Repo-wide grep confirms no remaining `arena_*` tool calls outside the parked albatross strategy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZqWcrfavAG5d9KcprMCRW

---
_Generated by [Claude Code](https://claude.ai/code/session_01TZqWcrfavAG5d9KcprMCRW)_