### PR TITLE
Bump senpi-portfolio to 1.15.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Every analytical skill follows the **hidden-engine pattern**: a vendored, stdlib
 | Skill | Ver | Role |
 |---|---|---|
 | **Analyze** | | |
-| [`senpi-portfolio`](senpi-portfolio/) | 1.14.0 | All-wallet portfolio, positions, DSL protection, per-strategy mandate reads |
+| [`senpi-portfolio`](senpi-portfolio/) | 1.15.0 | All-wallet portfolio, positions, DSL protection, per-strategy mandate reads |
 | [`senpi-market-pulse`](senpi-market-pulse/) | 1.2.0 | Daily cross-asset market read (crypto, equities, commodities, macro, funding regime) |
 | [`senpi-smart-money`](senpi-smart-money/) | 1.2.0 | Where the most-profitable wallets are positioned vs. the crowd |
 | [`senpi-trader-research`](senpi-trader-research/) | 1.4.0 | Rank + vet Hyperliquid traders before copying them (mirror-aware: copyability, min-budget, live book) |

--- a/senpi-portfolio/SKILL.md
+++ b/senpi-portfolio/SKILL.md
@@ -16,7 +16,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "1.14.0"
+  version: "1.15.0"
   platform: senpi
   exchange: hyperliquid
   requires:


### PR DESCRIPTION
## Summary

One-line release bump: `senpi-portfolio` `1.14.0 → 1.15.0` in `SKILL.md` `metadata.version`.

#542 merged with real engine behavior changes but without the version bump this repo's convention requires, so installed copies can't tell the fixed skill from `1.14.0`. This releases:

- the `tokenPriceInUSD: 0` zero-price guard (`or 1.0`)
- the HL spot USDC bucket in `idle_total` — reported `idle_in_embedded` changes for wallets holding spot, which is why this is a minor bump rather than a patch
- the live-shape canonical fixture + guard test
- the `TOTALS DO NOT RECONCILE` `meta.warnings` entry (new output surface)

No catalog regen needed — `strategies/catalog.json` is generated from `strategies/*/strategy.yaml` only, and `senpi-portfolio` is a utility skill, not a strategy package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JNoB3R6UHLT9N32sZ27SeK

---
_Generated by [Claude Code](https://claude.ai/code/session_01JNoB3R6UHLT9N32sZ27SeK)_