### PR TITLE
docs: route live-strategy edits through senpi update, not close-and-redeploy

### DIFF
--- a/senpi-strategy-author/SKILL.md
+++ b/senpi-strategy-author/SKILL.md
@@ -354,7 +354,7 @@ loop every time:
 > wallet, no market exit. **Re-running `create` will NOT apply it** — the deploy verb is idempotent, so it
 > adopts the existing wallet and leaves the deployed scanner as it is. Tell the user two things: exit
 > changes are **forward-only**, so a tightened `dsl_preset` governs new entries and never reaches a
-> position already open; and a changed `strategy.wallet`, a renamed/reordered scanner or a changed
+> position already open; and a changed `strategy.wallet`, a renamed or moved scanner or a changed
 > `action_type` still forces a close-and-redeploy — a market exit. Below is the not-yet-live path.
 
 1. **Confirm with the user** — budget + "ready to deploy?" Funding a wallet is real money and one-way, so

--- a/senpi-strategy-author/SKILL.md
+++ b/senpi-strategy-author/SKILL.md
@@ -349,13 +349,13 @@ only once **`senpi-strategy-ops` deploys it AND that deploy's report says `overa
 loop every time:
 
 > **Was this an edit to a strategy that is ALREADY LIVE?** (you changed the scoring / scanner / DSL of a
-> deployed package — "make my live strategy more aggressive", re-tune, re-score) — then say so before you
-> do anything. **There is no single verb for this today, and re-running `create` will NOT apply your
-> edit**: the deploy verb is idempotent, so it adopts the wallet that already exists and leaves the
-> deployed scanner as it is. Applying an edit to a live strategy means **closing it and redeploying** —
-> `close.py <id>` (which flattens its open positions and returns the funds) and then the loop below on a
-> fresh wallet. That is real money and a market exit, so **confirm it with the user in those words
-> first**; never present it as a re-tune. The steps below are for a strategy that is not yet live.
+> deployed package — "make my live strategy more aggressive", re-tune, re-score) — then hand it to
+> **`senpi-strategy-ops`**, which applies it IN PLACE with `openclaw senpi update`: no close, no fresh
+> wallet, no market exit. **Re-running `create` will NOT apply it** — the deploy verb is idempotent, so it
+> adopts the existing wallet and leaves the deployed scanner as it is. Tell the user two things: exit
+> changes are **forward-only**, so a tightened `dsl_preset` governs new entries and never reaches a
+> position already open; and a changed `strategy.wallet`, a renamed/reordered scanner or a changed
+> `action_type` still forces a close-and-redeploy — a market exit. Below is the not-yet-live path.
 
 1. **Confirm with the user** — budget + "ready to deploy?" Funding a wallet is real money and one-way, so
    this is an explicit yes, not an assumption.

--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -303,19 +303,19 @@ is strategy-driven: close also cleans up an attributed package's **orphaned** (n
 
 ## Applying an edit to a strategy that is already LIVE
 
-"Make my live strategy more aggressive." **The edit is authored in `senpi-strategy-author`**, never
-here. And **re-running `create` will NOT apply it**: the deploy verb is idempotent, so it adopts the
-existing wallet and leaves the deployed scanner as it is. Applying an edit means **closing the strategy
-and redeploying on a fresh wallet** — a market exit of every open position, funds back to main, and a
-custom ratchet/stop ladder that does **not** carry over. **Get explicit consent in those words before
-you close anything**; never present it as a re-tune.
+"Make my live strategy more aggressive." **The edit is authored in `senpi-strategy-author`**, never here.
+**Re-running `create` will NOT apply it** — it is idempotent, so it adopts the existing wallet and leaves
+the deployed scanner as it is.
 
-**Prove the edited package still RUNS — `openclaw senpi validate <instance-dir>` → `PASS` — BEFORE you
-close anything**: you are about to flatten a live book to install it. And `--budget` is the WHOLE
-package's, split by `funding_share`, so on a per-sleeve redeploy size it **want ÷ share** ($300 into a
-`0.3` arm is `--budget 1000`; `--budget 300` funds that arm **$90**) and **say the resulting wallet
-figure to the user, not the `--budget` number**, when you take consent. Durable-root check, per-sleeve
-adopt mechanics, what NEVER to reach for: [`references/editing-a-live-strategy.md`](references/editing-a-live-strategy.md).
+**Apply it in place — `openclaw senpi update`.** No close, no fresh wallet, no market exit; DSL state,
+scanner stores and action history survive. `senpi validate <instance-dir>` writes the proof `--apply`
+needs; `senpi update <instance-dir> --id <runtime_id>` PLANS, the same with `--apply` commits. **Read the
+plan out first**: exit changes are **forward-only** — a tightened `dsl_preset` governs new entries only and
+never reaches one already open, so never let "I made it tighter" be heard as "my open trades are tighter".
+
+**Only a changed `strategy.wallet`, a renamed/reordered scanner, or a changed `action_type` still need
+close-and-redeploy**, which market-exits every open position and drops any custom ratchet ladder — take
+**explicit consent in those words first**. Everything else: [`references/editing-a-live-strategy.md`](references/editing-a-live-strategy.md).
 
 ## Invariants
 

--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -313,7 +313,7 @@ needs; `senpi update <instance-dir> --id <runtime_id>` PLANS, the same with `--a
 plan out first**: exit changes are **forward-only** — a tightened `dsl_preset` governs new entries only and
 never reaches one already open, so never let "I made it tighter" be heard as "my open trades are tighter".
 
-**Only a changed `strategy.wallet`, a renamed/reordered scanner, or a changed `action_type` still need
+**Only a changed `strategy.wallet`, a renamed or moved scanner, or a changed `action_type` still need
 close-and-redeploy**, which market-exits every open position and drops any custom ratchet ladder — take
 **explicit consent in those words first**. Everything else: [`references/editing-a-live-strategy.md`](references/editing-a-live-strategy.md).
 

--- a/senpi-strategy-ops/references/editing-a-live-strategy.md
+++ b/senpi-strategy-ops/references/editing-a-live-strategy.md
@@ -27,6 +27,11 @@ openclaw senpi update <recipe-dir> --id <runtime_id> --apply
 you re-tune one sleeve and leave its siblings untouched. `--address <wallet>` works too. Changed only
 `scan.py`/`scoring.py`? Add `--code-only` and it refuses if the recipe moved as well.
 
+Always point `update` at the **directory**, as above — never hand it the recipe as bare text. The
+proof is a claim about a package on disk, so a recipe with no package behind it has nothing to
+verify against and `--apply` refuses it rather than swapping in unvalidated bytes. The proof must
+also cover the recipe actually being applied, not merely some recipe sitting in that directory.
+
 **Read the plan to the user before applying — one thing in it will surprise them.** Exit changes are
 **forward-only**: a new `dsl_preset` governs NEW entries, while every position already open keeps a
 snapshot of the preset it was opened under. A tightened stop does **not** reach a position that is
@@ -45,7 +50,7 @@ the runtime was restored to its previous recipe or is down with positions unmana
 | Change | Why it needs a new deployment |
 |---|---|
 | a different `strategy.wallet` | That is a different deployment. The old wallet's positions would be left with nothing managing them. |
-| a **renamed** or **reordered** scanner | External scanner state is keyed by name and position together — a rename starts it from empty, a reorder points it at another scanner's directory. **Appending at the end is allowed.** |
+| an external scanner **renamed**, **moved**, **inserted** or **removed** | External scanner state is keyed by name and by position among the external scanners, so both matter. A rename starts it from empty; moving one — or inserting or removing one **above** it, which shifts every external scanner below — points it at another scanner's directory. **Appending at the end moves nobody and is allowed**, as is moving an internal scanner, which no state directory is keyed on. |
 | a changed `action_type` under a stable `name` | The new action class would inherit the previous one's execution history. |
 
 Only for those does applying mean **closing the strategy and redeploying it on a fresh wallet** —

--- a/senpi-strategy-ops/references/editing-a-live-strategy.md
+++ b/senpi-strategy-ops/references/editing-a-live-strategy.md
@@ -7,12 +7,50 @@ holding positions. `senpi-strategy-ops/SKILL.md` routes here; this file is the p
 `senpi-strategy-author`** (the only skill that knows the scanner / yaml / DSL schema). Ops APPLIES the
 edited package; it does not write it.
 
-**There is no in-place scanner reload, and no single verb for this today.** Re-running `create` will
-NOT apply the edit: the deploy verb is idempotent, so it adopts the wallet that already exists and
-leaves the deployed scanner as it is. Applying an edit means **closing the strategy and redeploying it
-on a fresh wallet** — which market-exits its open positions and returns the funds to main.
+**Most edits now apply IN PLACE — `openclaw senpi update`. Do not close a live book to re-tune it.**
+No wallet is created, nothing is funded, no position is market-exited, and DSL state, scanner stores
+and action history all survive. Re-running `create` still will NOT apply an edit — the deploy verb is
+idempotent, so it adopts the wallet that already exists and leaves the deployed scanner as it is.
 
-**So this is a money conversation before it is a command:**
+```bash
+# 1. Prove the edit runs, and write the proof `--apply` requires.
+openclaw senpi validate <recipe-dir>
+
+# 2. PLAN it — what changes, and what it leaves alone. Changes nothing; show this to the user.
+openclaw senpi update <recipe-dir> --id <runtime_id>
+
+# 3. Apply.
+openclaw senpi update <recipe-dir> --id <runtime_id> --apply
+```
+
+`--id` names which runtime; on a multi-instance package each arm is its own runtime, so this is how
+you re-tune one sleeve and leave its siblings untouched. `--address <wallet>` works too. Changed only
+`scan.py`/`scoring.py`? Add `--code-only` and it refuses if the recipe moved as well.
+
+**Read the plan to the user before applying — one thing in it will surprise them.** Exit changes are
+**forward-only**: a new `dsl_preset` governs NEW entries, while every position already open keeps a
+snapshot of the preset it was opened under. A tightened stop does **not** reach a position that is
+already running, and the only way to move one onto the new exits is to close and re-open it. The plan
+names the affected positions. Do not let "I made it tighter" be heard as "my open trades are now
+tighter".
+
+Exit `2` means it refused and the runtime was never touched. Exit `1` means an apply was attempted
+and the runtime may not be where you left it — read the message rather than retrying; it says whether
+the runtime was restored to its previous recipe or is down with positions unmanaged and needs a human.
+
+## When the edit CANNOT be applied in place
+
+`senpi update` refuses these outright, because each would silently orphan state the runtime keys on:
+
+| Change | Why it needs a new deployment |
+|---|---|
+| a different `strategy.wallet` | That is a different deployment. The old wallet's positions would be left with nothing managing them. |
+| a **renamed** or **reordered** scanner | External scanner state is keyed by name and position together — a rename starts it from empty, a reorder points it at another scanner's directory. **Appending at the end is allowed.** |
+| a changed `action_type` under a stable `name` | The new action class would inherit the previous one's execution history. |
+
+Only for those does applying mean **closing the strategy and redeploying it on a fresh wallet** —
+which market-exits its open positions and returns the funds to main. That is the procedure below, and
+it is a money conversation before it is a command:
 
 1. **Confirm the edited package is on disk** in the durable root (`/data/workspace/strategies/<id>/…`),
    authored via `senpi-strategy-author`, not hand-guessed here.
@@ -44,6 +82,9 @@ on a fresh wallet** — which market-exits its open positions and returns the fu
 
 **NEVER, when applying an edit:**
 
+- close a live strategy to apply a change `senpi update` would have made in place. Flattening a book
+  costs the user spread, fees and their open P&L; reach for the close/redeploy path only for the
+  three changes in the table above.
 - hand-render a `runtime.yaml` or run raw `openclaw senpi runtime create` on a hand-built file — the
   `./scanners` "NO ENTRY SCANNERS" trap, and it skips the funds preflight, the attribution and the
   verified tick.

--- a/senpi-trading-runtime/SKILL.md
+++ b/senpi-trading-runtime/SKILL.md
@@ -83,7 +83,28 @@ real tick with no wallet and no funding, and a full unscoped PASS at live depth 
 `.senpi-proof.json` `senpi deploy` refuses to fund a package without. Run it before `deploy`, once per
 instance, pointed at the directory holding that instance's `runtime.yaml`.
 
-Beyond `validate`, `deploy`/`deploy status` and `runtime list/delete`, the CLI exposes the runtime's live state — `senpi dsl
+**To CHANGE a strategy that is already live** → `openclaw senpi update`, not a delete-and-redeploy.
+Deleting a runtime abandons its DSL position files, so every open position loses the trailing stop
+the strategy already promised and its replacement re-adopts from scratch at whatever price it
+finds. `update` swaps the components in place and keeps DSL state, scanner stores and action
+history — no wallet is created, nothing is funded, and no position is closed.
+
+```bash
+openclaw senpi update ./pkg                       # PLAN — what changes, what it leaves alone
+openclaw senpi update ./pkg --apply               # commit (needs the same proof deploy needs)
+openclaw senpi update ./pkg --apply --code-only   # assert only scan.py changed; refuses if not
+```
+
+It plans by default; `--apply` is the only way to commit. **Exit changes are forward-only** — a new
+`dsl_preset` governs new entries, while every open position keeps a snapshot of the preset it was
+opened under, so a tightened stop does not reach one already running. Refused outright, changing
+nothing: a different `strategy.wallet` (that is a new deployment, and the old wallet's positions
+would be left unmanaged), a renamed or reordered scanner (external scanner state is keyed by name
+and position together), or a changed `action_type` under a stable name. Exit `2` means the runtime
+was never touched; exit `1` means an apply was attempted and it may not be where you left it — read
+the message before retrying.
+
+Beyond `validate`, `deploy`/`deploy status`, `update` and `runtime list/delete`, the CLI exposes the runtime's live state — `senpi dsl
 positions|inspect|closes` (the exit engine), `senpi action list|inspect|history|decisions` (the
 decision layer), `senpi risk` (am I allowed to trade, and why not), `senpi audit` (backend trade
 trail with AI reasoning), `senpi scanner` (per-scanner health, liveness, and a `(no signals yet)` flag for scanners that run but produce nothing),

--- a/senpi-trading-runtime/SKILL.md
+++ b/senpi-trading-runtime/SKILL.md
@@ -99,8 +99,11 @@ It plans by default; `--apply` is the only way to commit. **Exit changes are for
 `dsl_preset` governs new entries, while every open position keeps a snapshot of the preset it was
 opened under, so a tightened stop does not reach one already running. Refused outright, changing
 nothing: a different `strategy.wallet` (that is a new deployment, and the old wallet's positions
-would be left unmanaged), a renamed or reordered scanner (external scanner state is keyed by name
-and position together), or a changed `action_type` under a stable name. Exit `2` means the runtime
+would be left unmanaged), an external scanner renamed or moved (state is keyed by name and position
+together, and inserting or removing one moves every external scanner below it — appending at the end
+moves nobody and is allowed), or a changed `action_type` under a stable name. `--apply` also needs a
+passing proof that covers the recipe being applied, so point it at the package DIRECTORY: a recipe
+handed over as bare text has nothing to verify against and is refused. Exit `2` means the runtime
 was never touched; exit `1` means an apply was attempted and it may not be where you left it — read
 the message before retrying.
 


### PR DESCRIPTION
`senpi update` shipped in `@senpi-ai/runtime` ([senpi-trading-runtime#342](https://github.com/Senpi-ai/senpi-trading-runtime/pull/342)): it swaps a running strategy onto a new recipe **in place**, keeping DSL position files, scanner stores and action history. These skills predate it and still teach the only path that existed before — close the strategy and redeploy on a fresh wallet.

## Why this is worth doing now

`references/editing-a-live-strategy.md` opened with:

> **There is no in-place scanner reload, and no single verb for this today.** … Applying an edit means **closing the strategy and redeploying it on a fresh wallet** — which market-exits its open positions and returns the funds to main.

An agent following that today **flattens a live book** to apply a re-tune that no longer requires closing anything. That costs the user spread, fees and their open P&L, for nothing.

## What changed

**`senpi-strategy-ops`** — SKILL.md and `references/editing-a-live-strategy.md` now lead with `senpi update`:

```bash
openclaw senpi validate <instance-dir>                          # writes the proof --apply needs
openclaw senpi update <instance-dir> --id <runtime_id>          # PLAN — show this to the user
openclaw senpi update <instance-dir> --id <runtime_id> --apply
```

Close-and-redeploy is kept, scoped to the three changes `senpi update` refuses outright, each of which genuinely needs a new deployment:

| Change | Why it can't be in-place |
|---|---|
| different `strategy.wallet` | A different deployment; the old wallet's positions would be left unmanaged. |
| renamed / reordered scanner | External scanner state is keyed by name **and** position. Appending at the end is fine. |
| changed `action_type` | The new class would inherit the old one's execution history. |

All the money and consent guidance is preserved for that path — it is still a market exit and still needs explicit consent in those words.

**Both surfaces now lead the plan with forward-only exits.** A tightened `dsl_preset` governs new entries and never reaches a position already open. That is the thing a user will otherwise mishear, so the agent is told to say it out loud: never let *"I made it tighter"* be heard as *"my open trades are now tighter."*

**`senpi-strategy-author`** — the handoff sentence. Authoring still does not apply edits (it hands to ops), so the boundary is unchanged; it now names `senpi update` as what ops will do, and carries the two facts the author must say out loud when handing over — forward-only exits, and the three changes that still force a market exit.

**`senpi-trading-runtime`** — same routing added.

All three skills previously said some version of *"there is no single verb for this today."* Fixing two and leaving the third would have made the catalogue contradict itself, so all three move together.

## On the line budget

`senpi-strategy-ops/SKILL.md` sits exactly at its 300-line budget and `senpi-strategy-author/SKILL.md` at its 368. Both edits are **length-neutral** — the depth went into the reference, which is pay-per-read.

`test_skill_surface`'s docstring predicted this task almost exactly — *"every task in this workstream had a reason to add just three more lines resident"* — so the budget was held rather than raised.

## Testing

354 ops tests pass. They must be run from the repo root: from inside the skill directory `test_pkg` fails on a relative `strategies` path, with or without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012bkDp51mWSPrk6jfaNKkUt
