### PR TITLE
fix forward-only and move overclaims

### DIFF
--- a/senpi-strategy-author/SKILL.md
+++ b/senpi-strategy-author/SKILL.md
@@ -352,10 +352,10 @@ loop every time:
 > deployed package — "make my live strategy more aggressive", re-tune, re-score) — then hand it to
 > **`senpi-strategy-ops`**, which applies it IN PLACE with `openclaw senpi update`: no close, no fresh
 > wallet, no market exit. **Re-running `create` will NOT apply it** — the deploy verb is idempotent, so it
-> adopts the existing wallet and leaves the deployed scanner as it is. Tell the user two things: exit
-> changes are **forward-only**, so a tightened `dsl_preset` governs new entries and never reaches a
-> position already open; and a changed `strategy.wallet`, a renamed or moved scanner or a changed
-> `action_type` still forces a close-and-redeploy — a market exit. Below is the not-yet-live path.
+> adopts the existing wallet and leaves the deployed scanner as it is. Tell the user two things:
+> `dsl_preset` is **forward-only** — new entries only, never a position already open (other `exit:` fields
+> like `order_type` DO reach open ones); and a changed `strategy.wallet`, a renamed or moved external
+> scanner or a changed `action_type` still forces close-and-redeploy — a market exit. Below: the not-yet-live path.
 
 1. **Confirm with the user** — budget + "ready to deploy?" Funding a wallet is real money and one-way, so
    this is an explicit yes, not an assumption.

--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -310,10 +310,10 @@ the deployed scanner as it is.
 **Apply it in place — `openclaw senpi update`.** No close, no fresh wallet, no market exit; DSL state,
 scanner stores and action history survive. `senpi validate <instance-dir>` writes the proof `--apply`
 needs; `senpi update <instance-dir> --id <runtime_id>` PLANS, the same with `--apply` commits. **Read the
-plan out first**: exit changes are **forward-only** — a tightened `dsl_preset` governs new entries only and
-never reaches one already open, so never let "I made it tighter" be heard as "my open trades are tighter".
+plan out first**: `dsl_preset` is **forward-only** — new entries only, never one already open (other `exit:`
+fields, e.g. `order_type`, DO reach open positions) — never let "tighter" be heard as "my open trades are tighter".
 
-**Only a changed `strategy.wallet`, a renamed or moved scanner, or a changed `action_type` still need
+**Only a changed `strategy.wallet`, a renamed or moved external scanner, or a changed `action_type` still need
 close-and-redeploy**, which market-exits every open position and drops any custom ratchet ladder — take
 **explicit consent in those words first**. Everything else: [`references/editing-a-live-strategy.md`](references/editing-a-live-strategy.md).
 

--- a/senpi-trading-runtime/SKILL.md
+++ b/senpi-trading-runtime/SKILL.md
@@ -95,9 +95,9 @@ openclaw senpi update ./pkg --apply               # commit (needs the same proof
 openclaw senpi update ./pkg --apply --code-only   # assert only scan.py changed; refuses if not
 ```
 
-It plans by default; `--apply` is the only way to commit. **Exit changes are forward-only** — a new
-`dsl_preset` governs new entries, while every open position keeps a snapshot of the preset it was
-opened under, so a tightened stop does not reach one already running. Refused outright, changing
+It plans by default; `--apply` is the only way to commit. **`dsl_preset` changes are forward-only** — new
+entries only, while every open position keeps a snapshot of the preset it was opened under (other `exit:`
+fields, e.g. `order_type`, are read live and DO reach open positions). Refused outright, changing
 nothing: a different `strategy.wallet` (that is a new deployment, and the old wallet's positions
 would be left unmanaged), an external scanner renamed or moved (state is keyed by name and position
 together, and inserting or removing one moves every external scanner below it — appending at the end


### PR DESCRIPTION
Two overclaims, both routed to a wrong action. "Exit changes are forward-only" let an agent tell a user their open positions were untouched after an order_type change — the exit: siblings (order_type, interval_seconds, fee options) are read live and DO reach open positions once an apply lands; only the ladder is frozen. And "a renamed or moved scanner" sent a harmless internal-scanner move to close-and-redeploy — a market exit — when only EXTERNAL scanner state is keyed by name and position. Length-neutral: ops stays at its 300-line body budget.