### PR TITLE
starling 1.1.0: open only the cohort's DOMINANT side + loosen the phase-1 retrace

### DIFF
--- a/strategies/starling/main/runtime.yaml
+++ b/strategies/starling/main/runtime.yaml
@@ -15,8 +15,9 @@ description: >
   moment several are FRESHLY buying/shorting the same name together — the
   snapshot-to-snapshot diff catches consensus FORMING, not a stale standing
   crowd. Conviction/size scales with how many wallets agree (base/good/apex).
-  One wallet, up to 6 positions, leverage clamped to venue max. DSL is the ONLY
-  exit (15% Phase 1, granular profit-lock ladder to +90%, 48h weak-peak).
+  Opens only on the cohort's DOMINANT side while its net margin widens. One wallet,
+  up to 6 positions, leverage clamped to venue max. DSL is the ONLY exit (15% Phase 1,
+  granular profit-lock ladder to +90%, 48h weak-peak).
 
 strategy:
   wallet: "${STARLING_WALLET}"
@@ -47,10 +48,15 @@ scanners:
       pageSize: 1000
       maxPages: 6
       stateBatch: 50                  # discovery_get_trader_state addresses per call
-      # ── consensus bands ──
-      minConsensus: 3                 # >= this many freshly-agreeing wallets to open
-      goodConsensus: 4
-      apexConsensus: 6
+      # ── consensus bands (of a cohort capped at 120) ──
+      # Picks are taken ONLY on the cohort's dominant side, and only while its NET margin
+      # over the other side is widening — see scoring.fresh_picks.
+      minConsensus: 6                 # >= this many wallets on the DOMINANT side to open (3 was 2.5% of
+                                      # the cohort — inside the noise floor, which is how a 13-vs-29
+                                      # minority long kept firing while the cohort was net short)
+      minMargin: 4                    # dominant must lead the other side by >= this many wallets
+      goodConsensus: 10               # bands rescaled with the floor — at the old 4/6 every pick would
+      apexConsensus: 15               # have banded apex (5x, 14% margin) the moment minConsensus hit 6
       # ── slots + sizing ──
       maxSlots: 6
       recentSignalTtlSeconds: 21600   # 6h per-name signal debounce
@@ -103,13 +109,18 @@ exit:
     phase1:
       enabled: true
       max_loss_pct: 15.0
-      retrace_threshold: 8
+      # 8 cut 27% of all positions at a median high-water ROE of just 3.3% — an 8% retrace
+      # from a ~3% bump is ordinary noise at 3-5x, not a reversal. 71% of positions never
+      # reached the first profit tier because phase 1 killed them first.
+      retrace_threshold: 14
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 8,  lock_hw_pct: 0 }
-        - { trigger_pct: 15, lock_hw_pct: 35 }
+        # trigger_pct is ROE, so at 3-5x the rungs arm on small price moves: the old first
+        # rung locked breakeven after ~1.6-2.7% of price, inside normal HL volatility.
+        - { trigger_pct: 12, lock_hw_pct: 0 }
+        - { trigger_pct: 20, lock_hw_pct: 35 }
         - { trigger_pct: 25, lock_hw_pct: 52 }
         - { trigger_pct: 40, lock_hw_pct: 65 }
         - { trigger_pct: 60, lock_hw_pct: 77 }

--- a/strategies/starling/main/scanners/scoring.py
+++ b/strategies/starling/main/scanners/scoring.py
@@ -168,24 +168,59 @@ def name_map(trader_states):
 
 # ── THE DIFF — fire on newly-formed / rising consensus, never on stale standing ──
 
+def _margin_toward(dirs, direction):
+    """Net cohort agreement on `direction`: how many more wallets hold that side than
+    the other. Signed, so a cohort leaning the OTHER way yields a negative number."""
+    d = dirs or {}
+    lo = int(_f(d.get("LONG"), 0))
+    sh = int(_f(d.get("SHORT"), 0))
+    return (lo - sh) if direction == "LONG" else (sh - lo)
+
+
 def fresh_picks(cur, prev, inputs):
-    """Snapshot diff. A candidate (asset, direction) qualifies iff:
-        cur >= minConsensus  AND  (prev < minConsensus  OR  cur > prev)
-    i.e. consensus has just reached the bar (newly formed) or is still rising —
-    NEVER a name that was already at/above the bar and hasn't grown (prev == cur
-    >= minConsensus => no pick: stale standing consensus is already priced in).
-    Returns [{asset, direction, count}] sorted by count desc. PURE."""
+    """Snapshot diff on the cohort's DOMINANT side, measured by NET MARGIN.
+
+    Per asset we take only the side more wallets are on, and require that side to be
+    decisively ahead (`margin = dominant - opposite >= minMargin`). A candidate then
+    qualifies iff the margin has just become decisive, or is still WIDENING:
+
+        count >= minConsensus AND margin >= minMargin
+        AND (prev_margin < minMargin  OR  margin > prev_margin)
+
+    Two failures this replaces, both of which made the book 100% long while the proven
+    cohort was net SHORT:
+
+      1. Directions were evaluated INDEPENDENTLY, with no reference to each other. With
+         29 wallets short and 13 long, a long leg ticking 10 -> 13 emitted a LONG pick —
+         and 13 even banded it apex, so it sized UP on the minority side. Reading the
+         margin makes the minority side unpickable by construction.
+      2. Freshness was measured per-leg, which systematically selected the NOISY side.
+         A cohort standing 29-short for weeks has a flat short count (prev == cur), so it
+         was discarded as "stale" and never traded, while the long leg churned and fired
+         constantly. Margin-based freshness fixes the asymmetry: wallets piling further
+         onto the dominant side WIDENS the margin and fires; a few defectors to the other
+         side NARROW it and are correctly ignored.
+
+    Returns [{asset, direction, count, margin, opposite}] sorted by margin desc. PURE."""
     min_c = int(_f(inputs.get("minConsensus"), 3))
+    min_margin = int(_f(inputs.get("minMargin"), 3))
     picks = []
     for asset, dirs in (cur or {}).items():
-        for direction in ("LONG", "SHORT"):
-            c = int(_f((dirs or {}).get(direction), 0))
-            if c < min_c:
-                continue
-            pc = int(_f(((prev or {}).get(asset) or {}).get(direction), 0))
-            if pc < min_c or c > pc:
-                picks.append({"asset": asset, "direction": direction, "count": c})
-    picks.sort(key=lambda p: p["count"], reverse=True)
+        d = dirs or {}
+        lo = int(_f(d.get("LONG"), 0))
+        sh = int(_f(d.get("SHORT"), 0))
+        if lo == sh:
+            continue                       # no dominant side — a split cohort says nothing
+        direction = "LONG" if lo > sh else "SHORT"
+        count, opposite = max(lo, sh), min(lo, sh)
+        margin = count - opposite
+        if count < min_c or margin < min_margin:
+            continue
+        prev_margin = _margin_toward((prev or {}).get(asset), direction)
+        if prev_margin < min_margin or margin > prev_margin:
+            picks.append({"asset": asset, "direction": direction, "count": count,
+                          "margin": margin, "opposite": opposite})
+    picks.sort(key=lambda p: (p["margin"], p["count"]), reverse=True)
     return picks
 
 

--- a/strategies/starling/strategy.yaml
+++ b/strategies/starling/strategy.yaml
@@ -7,13 +7,13 @@
 schema_version: 1
 
 id: starling
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Starling — Smart-Money Rotation Follower"
   emoji: "🐦"
   tagline: "Watches a flock of the most profitable wallets on Hyperliquid and moves when they do — the instant several of them start piling into the SAME trade in the SAME direction at the SAME time, it buys (or shorts) alongside them, betting more the more of them agree. It only acts on a rotation that's just forming, not a crowd that's been standing in a name for hours, and it never sells manually — a trailing stop does all the exiting, so last week's follows wind down on their own as the flock rotates into the next name."
   belief_plain: "The proven winners on Hyperliquid tend to rotate into the same trades at the same time, and the freshest edge is the moment that agreement is FORMING — not once everyone can already see it. Starling keeps a live shortlist of the wallets with the best all-time track record, watches what they're opening, and when enough of them freshly line up on one name in one direction it opens with them, sizing up when the agreement is strongest. It never manually closes — a ratchet stop protects and exits every position, so the book rotates as the smart money does, and a hard drawdown halt is the backstop."
-  thesis: "Cohort copiers average a pool's standing net bias (already priced); Starling instead trades the DERIVATIVE of that bias — the snapshot-to-snapshot change. Each tick it counts, per name and direction, how many proven wallets hold it, and fires only when that count has just crossed the consensus bar or is still rising (newly-formed / growing), never on a stale standing consensus. Conviction sizing scales with the agreement count. It force-closes nothing — turnover is set by the market via DSL (rotate-by-attrition), the same never-close discipline as the gibbon/orangutan rotation riders."
+  thesis: "Cohort copiers average a pool's standing net bias (already priced); Starling instead trades the DERIVATIVE of that bias — the snapshot-to-snapshot change. Each tick it counts, per name and direction, how many proven wallets hold it, takes ONLY the side more of them are on, and fires when that side's NET MARGIN over the other has just become decisive or is still widening — never on the minority side, and never on a margin that is flat or narrowing. Conviction sizing scales with the agreement count. It force-closes nothing — turnover is set by the market via DSL (rotate-by-attrition), the same never-close discipline as the gibbon/orangutan rotation riders."
   group: multi-asset-universe
   archetype: copy_trading
   sub_style: sm_rotation

--- a/strategies/starling/tests/test_engine.py
+++ b/strategies/starling/tests/test_engine.py
@@ -51,15 +51,16 @@ def test_direction_of_from_szi_then_side_fallback():
 # ── (b) fresh_picks: fires on newly-formed / rising, NOT on stale standing ──
 
 def test_fresh_picks_forming_growing_and_stale():
-    inp = {"minConsensus": 3}
+    inp = {"minConsensus": 3, "minMargin": 3}
     cur = {"BTC": {"LONG": 3, "SHORT": 0}}
     # newly FORMED (prev absent) -> fires
-    assert scoring.fresh_picks(cur, {}, inp) == [{"asset": "BTC", "direction": "LONG", "count": 3}]
+    assert scoring.fresh_picks(cur, {}, inp) == [
+        {"asset": "BTC", "direction": "LONG", "count": 3, "margin": 3, "opposite": 0}]
     # STALE standing consensus (prev == cur >= min) -> NO pick  (the core guarantee)
     assert scoring.fresh_picks(cur, {"BTC": {"LONG": 3, "SHORT": 0}}, inp) == []
     # GROWING (prev 3 -> cur 5) -> fires
     grew = scoring.fresh_picks({"BTC": {"LONG": 5}}, {"BTC": {"LONG": 3}}, inp)
-    assert grew == [{"asset": "BTC", "direction": "LONG", "count": 5}]
+    assert grew[0]["count"] == 5 and grew[0]["margin"] == 5
     # crossing the bar from below (prev 2 < min -> cur 4) -> fires
     assert scoring.fresh_picks({"BTC": {"LONG": 4}}, {"BTC": {"LONG": 2}}, inp)[0]["count"] == 4
     # below the bar -> never
@@ -68,12 +69,61 @@ def test_fresh_picks_forming_growing_and_stale():
     assert scoring.fresh_picks({"BTC": {"LONG": 4}}, {"BTC": {"LONG": 5}}, inp) == []
 
 
-def test_fresh_picks_sorted_by_count_desc():
-    inp = {"minConsensus": 3}
+def test_fresh_picks_never_opens_the_minority_side():
+    """THE REGRESSION. Live cohort read: ETH 29 short / 13 long. The old engine evaluated each
+    direction independently, so a long leg ticking 10 -> 13 emitted a LONG pick — and banded it
+    apex. That is how the book went 97/97 long while the proven cohort was net SHORT.
+
+    Note every pre-existing fixture pinned one side to 0, so the both-sides-populated case was
+    never exercised and the suite could not catch this."""
+    inp = {"minConsensus": 3, "minMargin": 3}
+    cur = {"ETH": {"LONG": 13, "SHORT": 29}}
+    prev = {"ETH": {"LONG": 10, "SHORT": 29}}          # the long leg grew, the short leg stood still
+    picks = scoring.fresh_picks(cur, prev, inp)
+    assert all(p["direction"] != "LONG" for p in picks), picks   # minority side is unpickable
+    # …and the long leg growing does NOT widen the short margin, so nothing fires at all
+    assert picks == [], picks
+    # a split cohort asserts nothing
+    assert scoring.fresh_picks({"ETH": {"LONG": 15, "SHORT": 15}}, {}, inp) == []
+    # a lead too thin to be decisive is ignored even when both counts clear minConsensus
+    assert scoring.fresh_picks({"ETH": {"LONG": 9, "SHORT": 7}}, {}, inp) == []
+
+
+def test_fresh_picks_fires_when_the_dominant_short_side_widens():
+    """The other half of the failure: per-leg freshness discarded a STANDING short cohort as
+    'stale' (flat count), so shorts could never fire while the churning long leg fired constantly.
+    Margin-based freshness fixes the asymmetry."""
+    inp = {"minConsensus": 3, "minMargin": 3}
+    # more wallets pile onto the dominant short side -> margin widens 16 -> 19 -> fires SHORT
+    picks = scoring.fresh_picks({"ETH": {"LONG": 13, "SHORT": 32}},
+                                {"ETH": {"LONG": 13, "SHORT": 29}}, inp)
+    assert len(picks) == 1
+    assert picks[0]["direction"] == "SHORT" and picks[0]["count"] == 32
+    assert picks[0]["margin"] == 19 and picks[0]["opposite"] == 13
+    # defectors to the other side NARROW the margin -> correctly ignored, not treated as news
+    assert scoring.fresh_picks({"ETH": {"LONG": 16, "SHORT": 29}},
+                               {"ETH": {"LONG": 13, "SHORT": 29}}, inp) == []
+
+
+def test_fresh_picks_sorted_by_margin_desc():
+    inp = {"minConsensus": 3, "minMargin": 3}
     cur = {"BTC": {"LONG": 4, "SHORT": 0}, "ETH": {"LONG": 0, "SHORT": 7}, "SOL": {"LONG": 3}}
     picks = scoring.fresh_picks(cur, {}, inp)
-    assert [p["count"] for p in picks] == [7, 4, 3]      # apex ETH first
-    assert picks[0] == {"asset": "ETH", "direction": "SHORT", "count": 7}
+    assert [p["margin"] for p in picks] == [7, 4, 3]      # apex ETH first
+    assert picks[0]["asset"] == "ETH" and picks[0]["direction"] == "SHORT"
+
+
+def test_min_consensus_and_bands_stay_coherent():
+    """Raising the floor without raising the bands would make EVERY pick apex (5x, 14% margin).
+    Guard the shipped config so the sizing ladder keeps three distinct rungs."""
+    import os
+    import yaml
+    rt = os.path.join(os.path.dirname(__file__), "..", "main", "runtime.yaml")
+    inputs = yaml.safe_load(open(rt))["scanners"][1]["inputs"]
+    assert inputs["minConsensus"] < inputs["goodConsensus"] < inputs["apexConsensus"], inputs
+    assert scoring.band_for(inputs["minConsensus"], inputs) == "base"
+    assert scoring.band_for(inputs["goodConsensus"], inputs) == "good"
+    assert scoring.band_for(inputs["apexConsensus"], inputs) == "apex"
 
 
 # ── band + sizing (fleet caps) ──


### PR DESCRIPTION
Starling went **97/97 LONG over 14 days while the proven cohort was net SHORT** (live read: ETH 29s/13L, SOL 24s/9L, XRP 16s/2L, FARTCOIN 11s/3L, DOGE 9s/1L), realized **−$389** across four wallets. Two independent defects — one picking the wrong side, one cutting the positions it did open before they could pay.

## Entry — two bugs in `fresh_picks`, not one

**1. Directions were evaluated independently.** There was no comparison between the legs anywhere:

```python
for direction in ("LONG", "SHORT"):        # ← no reference to the other side
```

With ETH at 29 short / 13 long, a long leg ticking 10 → 13 emitted a LONG pick — and 13 **banded it apex**, so it sized *up* (5×, 14% margin) on the minority side.

**2. Per-leg freshness systematically selected the noisy side.** A cohort standing 29-short for weeks has a *flat* short count (`prev == cur`) → discarded as "stale standing consensus" → **shorts were structurally unreachable**, while the churning long leg fired every tick. Fixing only #1 would have made Starling stop trading rather than take the shorts.

Both fall out of reading the **net margin**: take only the dominant side, require it to lead by `minMargin`, and test freshness on *the margin*. Piling further onto the dominant side widens it and fires; defectors narrow it and are ignored.

**Verified against the live cohort data, same tick:**

| | emits |
|---|---|
| old (1.0.1) | `LONG ETH` count 13 **apex**, `LONG SOL` count 9 **apex**, `LONG FARTCOIN` base |
| new (1.1.0) | *nothing* — every long is the minority side, no short margin widened |
| new, once shorts genuinely widen (ETH 29→34) | `SHORT ETH` count 34, margin 21 |

Thresholds: `minConsensus` 3 → 6 (3 of a 120-wallet cohort is 2.5%, inside the noise floor), new `minMargin: 4`, and **`goodConsensus` 4 → 10 / `apexConsensus` 6 → 15** — the bands *must* rise with the floor or every pick would band apex the moment `minConsensus` hit 6, silently doubling risk. A new test guards that invariant.

## Exit — the primary money leak

`phase1.retrace_threshold` **8 → 14**. From the DSL archives: `dsl_breach` fired on **27% of positions at a median high-water ROE of 3.3%**, and **71% never reached the first profit tier**. An 8% retrace off a ~3% bump is ordinary noise at 3–5×, not a reversal. Also moved the first profit rung 8 → 12 ROE — `trigger_pct` is ROE, so at 3–5× the old rung locked breakeven after only ~1.6–2.7% of *price*.

Tape confirms the exits were early, not the direction: the last two SOL exits were ~$96.5 and ~$101.5; SOL is **$108.55** now (**+12%** / **+7%**).

## Tests 8 → 12

Every pre-existing fixture pinned one side to `0` (`{"LONG": 3, "SHORT": 0}`), so the both-sides-populated case was **never exercised** — the suite structurally could not catch this. New cases use the real 29-vs-13 shape.

## Deliberately NOT changed

Following the cohort **short** is now *possible* but **unproven**. The cohort is selected on all-time realized PnL — a lagging filter — and it is currently offside (SOL +12% against its shorts since our last exit). This PR stops Starling taking the wrong side; it does not assert the cohort's side is right. Re-measure before leaning on it.

## Still open (separate, from telemetry)
- **Duplicate DSL state on XYZ assets** — every XYZ close fires twice, as `CL`/`dex:""` *and* `xyz:CL`/`dex:"xyz"`.
- **183 skipped DSL ticks** on Starling (`clearinghouse state unavailable`) — the trailing stop goes dark intermittently on a DSL-only strategy.