### PR TITLE
starling 1.2.0: the ratchet locks gains only — stop selling winners for a scratch

### DIFF
--- a/strategies/starling/main/runtime.yaml
+++ b/strategies/starling/main/runtime.yaml
@@ -16,8 +16,8 @@ description: >
   snapshot-to-snapshot diff catches consensus FORMING, not a stale standing
   crowd. Conviction/size scales with how many wallets agree (base/good/apex).
   Opens only on the cohort's DOMINANT side while its net margin widens. One wallet,
-  up to 6 positions, leverage clamped to venue max. DSL is the ONLY exit (15% Phase 1,
-  granular profit-lock ladder to +90%, 48h weak-peak).
+  up to 6 positions, leverage clamped to venue max. DSL is the ONLY exit: a FIXED 15% max-loss
+  floor plus a gains-only profit ratchet (no trailing stop, no breakeven exits), 48h weak-peak.
 
 strategy:
   wallet: "${STARLING_WALLET}"
@@ -103,28 +103,42 @@ exit:
     execution_timeout_seconds: 60
   dsl_preset:
     weak_peak_cut:
+      # THE stall-cutter, and the only time-based exit. The 48h clock RESETS whenever ROE >= min_value
+      # (runtime: weakPeakCutStartedAt "resets when currentROE >= minValue"), so min_value is the bar a
+      # follow must clear to prove it is still working. At 2.5 (= 0.5% of price at 5x) any wiggle reset
+      # the clock and this fired ONCE in 179 closes. At 10 (= 2% of price at 5x) a position that never
+      # gets 2% our way in two days is correctly declared dead and frees its slot.
       enabled: true
-      interval_in_minutes: 2880        # 48h — a stalled follow frees its slot
-      min_value: 2.5
+      interval_in_minutes: 2880        # 48h
+      min_value: 10
     phase1:
-      enabled: true
-      max_loss_pct: 15.0
-      # 8 cut 27% of all positions at a median high-water ROE of just 3.3% — an 8% retrace
-      # from a ~3% bump is ordinary noise at 3-5x, not a reversal. 71% of positions never
-      # reached the first profit tier because phase 1 killed them first.
-      retrace_threshold: 14
+      # TRAILING DISABLED — this is the fix for "the ratchet locked a LOSS".
+      # The phase-1 trail is measured from HIGH-WATER, so once a position moved our way it
+      # followed the move down and could cut BELOW entry. Live example: a ZEC short reached
+      # +8.5% ROE (813.18 -> ~799.33), bounced 2.8% off its low, and the trail closed it at
+      # -5.9%. That is not a ratchet; a ratchet only moves one way and only locks gains.
+      # With enabled:false the ONLY floor beneath entry is the FIXED max-loss, and gains are
+      # protected exclusively by the phase-2 tiers — which can never lock a negative.
+      # (runtime: phase1BaseFloor() returns absoluteFloor verbatim when enabled === false.)
+      enabled: false
+      max_loss_pct: 15.0            # the real risk budget: 15% ROE = 3.0% of PRICE at 5x, fixed from ENTRY
+      retrace_threshold: 14         # INERT while enabled:false (parser forces it to 1) — kept for schema + easy revert
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        # trigger_pct is ROE, so at 3-5x the rungs arm on small price moves: the old first
-        # rung locked breakeven after ~1.6-2.7% of price, inside normal HL volatility.
-        - { trigger_pct: 12, lock_hw_pct: 0 }
-        - { trigger_pct: 20, lock_hw_pct: 35 }
-        - { trigger_pct: 25, lock_hw_pct: 52 }
-        - { trigger_pct: 40, lock_hw_pct: 65 }
-        - { trigger_pct: 60, lock_hw_pct: 77 }
-        - { trigger_pct: 90, lock_hw_pct: 86 }
+        # EVERY rung locks a POSITIVE ROE — never breakeven. A 0% lock exits flat and still pays
+        # fees, which is a loss dressed as a scratch. Below the first rung the position simply
+        # rides on the fixed max-loss floor; we only start protecting once there is a real gain.
+        # The first rung does not engage until +25% ROE (= 5% of PRICE at 5x) and then locks +10%.
+        # Anything earlier just re-creates the churn: a floor at +3% ROE is ~$8 on a $260 margin
+        # against ~$2 of fees — a scratch, not a win. Below +25% the position rides on the fixed
+        # max-loss and, if it stalls, weak_peak retires it at 48h.
+        - { trigger_pct: 25,  lock_hw_pct: 40 }   # peak +25% ROE -> floor +10.0%
+        - { trigger_pct: 40,  lock_hw_pct: 55 }   # -> +22.0%
+        - { trigger_pct: 60,  lock_hw_pct: 68 }   # -> +40.8%
+        - { trigger_pct: 90,  lock_hw_pct: 78 }   # -> +70.2%
+        - { trigger_pct: 130, lock_hw_pct: 85 }   # -> +110.5%
 
 risk:
   guard_rails:

--- a/strategies/starling/strategy.yaml
+++ b/strategies/starling/strategy.yaml
@@ -7,11 +7,11 @@
 schema_version: 1
 
 id: starling
-version: "1.1.0"
+version: "1.2.0"
 catalog:
   name: "Starling — Smart-Money Rotation Follower"
   emoji: "🐦"
-  tagline: "Watches a flock of the most profitable wallets on Hyperliquid and moves when they do — the instant several of them start piling into the SAME trade in the SAME direction at the SAME time, it buys (or shorts) alongside them, betting more the more of them agree. It only acts on a rotation that's just forming, not a crowd that's been standing in a name for hours, and it never sells manually — a trailing stop does all the exiting, so last week's follows wind down on their own as the flock rotates into the next name."
+  tagline: "Watches a flock of the most profitable wallets on Hyperliquid and moves when they do — the instant several of them start piling into the SAME trade in the SAME direction at the SAME time, it buys (or shorts) alongside them, betting more the more of them agree. It only acts on a rotation that's just forming, not a crowd that's been standing in a name for hours, and it never sells manually — a fixed max-loss floor caps the downside while a profit ratchet that can only ever lock GAINS (never breakeven) protects the upside, so winners are given room to run and last week's follows wind down on their own as the flock rotates into the next name."
   belief_plain: "The proven winners on Hyperliquid tend to rotate into the same trades at the same time, and the freshest edge is the moment that agreement is FORMING — not once everyone can already see it. Starling keeps a live shortlist of the wallets with the best all-time track record, watches what they're opening, and when enough of them freshly line up on one name in one direction it opens with them, sizing up when the agreement is strongest. It never manually closes — a ratchet stop protects and exits every position, so the book rotates as the smart money does, and a hard drawdown halt is the backstop."
   thesis: "Cohort copiers average a pool's standing net bias (already priced); Starling instead trades the DERIVATIVE of that bias — the snapshot-to-snapshot change. Each tick it counts, per name and direction, how many proven wallets hold it, takes ONLY the side more of them are on, and fires when that side's NET MARGIN over the other has just become decisive or is still widening — never on the minority side, and never on a margin that is flat or narrowing. Conviction sizing scales with the agreement count. It force-closes nothing — turnover is set by the market via DSL (rotate-by-attrition), the same never-close discipline as the gibbon/orangutan rotation riders."
   group: multi-asset-universe

--- a/strategies/starling/tests/test_engine.py
+++ b/strategies/starling/tests/test_engine.py
@@ -113,6 +113,50 @@ def test_fresh_picks_sorted_by_margin_desc():
     assert picks[0]["asset"] == "ETH" and picks[0]["direction"] == "SHORT"
 
 
+def test_ratchet_locks_gains_only_and_never_a_loss():
+    """Starling takes longer-term bets, so the exit must never convert a winner into a loser.
+
+    Two invariants, both learned the hard way from live trades:
+      1. phase1 TRAILING must stay disabled. It trails from HIGH-WATER, so once price moved our
+         way the floor followed it and could sit BELOW entry — a ratchet that locks a LOSS. A live
+         ZEC short hit +8.5% ROE, bounced 2.8% off its low, and the trail closed it at -5.9%.
+         With phase1 disabled the only floor beneath entry is the FIXED max-loss.
+      2. No tier may lock 0% of high-water. A breakeven exit still pays fees, so "scratch" is a
+         loss. Every rung must protect a positive ROE or it should not exist.
+    """
+    import os
+    import yaml
+    rt = os.path.join(os.path.dirname(__file__), "..", "main", "runtime.yaml")
+    preset = yaml.safe_load(open(rt))["exit"]["dsl_preset"]
+    p1, tiers = preset["phase1"], preset["phase2"]["tiers"]
+
+    assert p1["enabled"] is False, "phase1 trailing must stay off — it can ratchet into a loss"
+    # the runtime REQUIRES max_loss_pct when phase1 is disabled; it is the only sub-entry floor
+    assert p1.get("max_loss_pct", 0) > 0, "max_loss_pct is the sole downside floor once phase1 is off"
+
+    assert tiers, "a gains-only ratchet still needs rungs"
+    for t_ in tiers:
+        assert t_["lock_hw_pct"] > 0, f"tier {t_} locks breakeven/negative — fees make that a loss"
+    trigs = [t_["trigger_pct"] for t_ in tiers]
+    locks = [t_["lock_hw_pct"] for t_ in tiers]
+    assert trigs == sorted(trigs) and len(set(trigs)) == len(trigs), trigs
+    assert locks == sorted(locks), locks          # never lock LESS at a higher peak
+
+    # NO-SCRATCH INVARIANT: the smallest gain the ratchet can ever exit on must be worth taking.
+    # A floor at +3% ROE is ~$8 on a $260 margin against ~$2 of fees — churn, not a win. The point
+    # of the strategy is longer-term bets, so nothing may exit between the max-loss and a real gain.
+    lowest_lockable = tiers[0]["trigger_pct"] * tiers[0]["lock_hw_pct"] / 100
+    assert lowest_lockable >= 8, (
+        f"first rung can exit at only +{lowest_lockable:.1f}% ROE — that is a scratch after fees")
+
+    # …and the stall cut must be the ONLY way out of the dead zone, with a bar high enough to mean
+    # something: weak_peak's 48h clock resets whenever ROE >= min_value.
+    wp = preset["weak_peak_cut"]
+    assert wp["enabled"] is True and wp["interval_in_minutes"] >= 2880, wp
+    assert wp["min_value"] >= 5, (
+        f"weak_peak min_value {wp['min_value']} is so low any wiggle resets the 48h clock")
+
+
 def test_min_consensus_and_bands_stay_coherent():
     """Raising the floor without raising the bands would make EVERY pick apex (5x, 14% margin).
     Guard the shipped config so the sizing ladder keeps three distinct rungs."""


### PR DESCRIPTION
Live 1.1.0 trades were still converting winners into losers — and doing it well below the −15% stop, which is why it looked like the stop wasn't working:

```
ZEC Short 5x   813.18 -> 821.71   = -5.9%   held 3h14m   fees $1.48
MON Short 5x   0.029  -> 0.029    = -12.5%  held 1h07m   fees $2.72
```

**`max_loss` never fired.** At 15% ROE / 5× = 3.0% of price, ZEC would have exited at **837.58**. It exited at **821.71**.

The **phase-1 trail** did it. That trail is measured from **high-water**, so once ZEC fell to ~**799.33** (**+8.5% ROE in profit**) the floor followed it down, and a 2.8% bounce off the low closed the position *below entry*. A ratchet that locks a loss is not a ratchet. (MON is the same mechanism with a ~0.3% favourable blip, which ratcheted its effective stop *tighter* than max_loss.)

## New exit model

| | |
|---|---|
| **losers** | fixed max-loss **15% ROE** (3.0% of price at 5×), from **entry**, never moves |
| **stalled** | **weak_peak at 48h** if ROE never reaches **+10%** |
| **winners** | profit ratchet, first rung at **+25% ROE** locking **+10%** |
| **trailing** | **disabled** — `phase1.enabled: false` → `phase1BaseFloor()` returns `absoluteFloor` |

**⇒ no exit is possible between −15% and +10% ROE except the 48h stall cut.** Hold the bet, let the max-loss protect it, and only retire it if it genuinely stalls.

## Changes

- **`phase1.enabled: false`.** `max_loss_pct` stays 15 and becomes the sole sub-entry floor — the runtime *requires* it in this mode (`"max_loss_pct must be > 0 when phase1.enabled is false"`). `retrace_threshold` kept but inert (parser forces it to 1) for schema safety and easy revert.
- **Every tier locks a positive ROE.** The `trigger 12 → lock 0` breakeven rung is gone: a breakeven exit still pays fees, so a scratch *is* a loss. First rung moved out to **+25% ROE** (5% of price at 5×) locking **+10%** — a gain worth taking, versus ~$8 on a $260 margin against ~$2 of fees.
- **`weak_peak.min_value` 2.5 → 10.** Its 48h clock **resets whenever `ROE >= min_value`**. At 2.5 (0.5% of price at 5×) any wiggle reset it — it fired **once in 179 closes**. At 10 (2% of price) it becomes the real stall-cutter it was designed to be.

## Tests 12 → 13

The new test pins the invariants so this can't regress: trailing stays off, no rung may lock ≤ 0, **no rung may exit under +8% ROE**, and weak_peak's bar stays meaningful.

## Expect this to look different

Fewer exits, larger individual losses, longer holds. Positions that used to scratch out at −5% to +2% will now either run to a real gain, hit −15%, or get retired at 48h. That is the intended trade: **fewer, bigger outcomes instead of churn.** Judge it on net PnL over a couple of weeks, not on win rate.

Leverage (5×) deliberately untouched — that question is being observed separately.