### PR TITLE
fleet: the DSL ratchet locks gains only, never a loss — 129/129 instances

### DIFF
--- a/strategies/albatross/main/runtime.yaml
+++ b/strategies/albatross/main/runtime.yaml
@@ -115,14 +115,17 @@ exit:
       enabled: false                        # v2: disabled
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 20.0                     # v2 phase1 floor
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (8% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 8.0   # was 20.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:                                # v2 wide ladder; FIRST lock reachable at +10% ROE
-        - { trigger_pct: 10,  lock_hw_pct: 0  }
         - { trigger_pct: 20,  lock_hw_pct: 25 }
         - { trigger_pct: 30,  lock_hw_pct: 40 }
         - { trigger_pct: 50,  lock_hw_pct: 60 }

--- a/strategies/albatross/strategy.yaml
+++ b/strategies/albatross/strategy.yaml
@@ -8,7 +8,7 @@
 schema_version: 1
 
 id: albatross
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Albatross — Multi-week Arena Conviction Mirror"

--- a/strategies/ant/main/runtime.yaml
+++ b/strategies/ant/main/runtime.yaml
@@ -110,14 +110,17 @@ exit:
       interval_in_minutes: 720         # 12h — cut a stalled short that isn't paying its way
       min_value: 2.0
     phase1:
-      enabled: true
-      max_loss_pct: 8.0                 # tight — a squeeze is cut fast
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (6% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 6.0   # was 8.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 6
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 6,  lock_hw_pct: 0 }
         - { trigger_pct: 12, lock_hw_pct: 40 }
         - { trigger_pct: 20, lock_hw_pct: 60 }
         - { trigger_pct: 35, lock_hw_pct: 75 }

--- a/strategies/ant/strategy.yaml
+++ b/strategies/ant/strategy.yaml
@@ -6,7 +6,7 @@
 schema_version: 1
 
 id: ant
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Ant — Funding Harvester"
   emoji: "🐜"

--- a/strategies/armadillo/main/runtime.yaml
+++ b/strategies/armadillo/main/runtime.yaml
@@ -106,14 +106,17 @@ exit:
       interval_in_minutes: 1440            # 24h — a stalled name frees its slot
       min_value: 2.0
     phase1:
-      enabled: true
-      max_loss_pct: 6.0                    # TIGHT floor — protect capital first
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (5% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 5.0   # was 6.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 5
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:                               # lock profit EARLY
-        - { trigger_pct: 6,  lock_hw_pct: 0 }
         - { trigger_pct: 12, lock_hw_pct: 45 }
         - { trigger_pct: 20, lock_hw_pct: 65 }
         - { trigger_pct: 35, lock_hw_pct: 80 }

--- a/strategies/armadillo/strategy.yaml
+++ b/strategies/armadillo/strategy.yaml
@@ -7,7 +7,7 @@
 schema_version: 1
 
 id: armadillo
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Armadillo — Capital Preservation"

--- a/strategies/asia-ai/hedge/runtime.yaml
+++ b/strategies/asia-ai/hedge/runtime.yaml
@@ -68,14 +68,17 @@ exit:
   engine: dsl
   dsl_preset:
     phase1:
-      enabled: true
-      max_loss_pct: 20.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (8% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 8
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 10,  lock_hw_pct: 0 }
         - { trigger_pct: 20,  lock_hw_pct: 25 }
         - { trigger_pct: 30,  lock_hw_pct: 40 }
         - { trigger_pct: 50,  lock_hw_pct: 60 }

--- a/strategies/asia-ai/main/runtime.yaml
+++ b/strategies/asia-ai/main/runtime.yaml
@@ -65,14 +65,17 @@ exit:
   engine: dsl
   dsl_preset:
     phase1:
-      enabled: true
-      max_loss_pct: 20.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (8% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 8
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 10,  lock_hw_pct: 0 }
         - { trigger_pct: 20,  lock_hw_pct: 25 }
         - { trigger_pct: 30,  lock_hw_pct: 40 }
         - { trigger_pct: 50,  lock_hw_pct: 60 }

--- a/strategies/asia-ai/strategy.yaml
+++ b/strategies/asia-ai/strategy.yaml
@@ -4,7 +4,7 @@
 schema_version: 1
 
 id: asia-ai
-version: "1.0.1"
+version: "1.1.0"
 
 catalog:
   name: "Asia AI — Hedged Sector Long"

--- a/strategies/badger/main/runtime.yaml
+++ b/strategies/badger/main/runtime.yaml
@@ -109,14 +109,17 @@ exit:
       enabled: false                       # v2: DISABLED
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 20.0                    # v2: catastrophic floor (cuts a failed breakout)
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (8% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 8.0   # was 20.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:                               # wide-by-design; FIRST lock at +10% ROE (reachable)
-        - { trigger_pct: 10,  lock_hw_pct: 0  }
         - { trigger_pct: 20,  lock_hw_pct: 25 }
         - { trigger_pct: 30,  lock_hw_pct: 40 }
         - { trigger_pct: 50,  lock_hw_pct: 60 }

--- a/strategies/badger/strategy.yaml
+++ b/strategies/badger/strategy.yaml
@@ -7,7 +7,7 @@
 schema_version: 1
 
 id: badger
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Badger — OI-Divergence Breakout Anticipator"
   emoji: "🦡"

--- a/strategies/bald-eagle/main/runtime.yaml
+++ b/strategies/bald-eagle/main/runtime.yaml
@@ -104,15 +104,19 @@ exit:
       interval_in_minutes: 120
     # Phase 1: Loss protection — wider for macro volatility (v2 verbatim)
     phase1:
-      enabled: true
-      max_loss_pct: 25.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (12.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 12.0   # was 25.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 12
       consecutive_breaches_required: 1
     # Phase 2: RatchetStop ladder — preserved verbatim from v2 (FIRST lock at +5% ROE — reachable)
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 5,  lock_hw_pct: 0  }
         - { trigger_pct: 10, lock_hw_pct: 20 }
         - { trigger_pct: 20, lock_hw_pct: 35 }
         - { trigger_pct: 30, lock_hw_pct: 50 }

--- a/strategies/bald-eagle/strategy.yaml
+++ b/strategies/bald-eagle/strategy.yaml
@@ -8,7 +8,7 @@
 schema_version: 1
 
 id: bald-eagle
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Bald Eagle — XYZ Macro Fader"

--- a/strategies/barnacle/main/runtime.yaml
+++ b/strategies/barnacle/main/runtime.yaml
@@ -137,14 +137,17 @@ exit:
       enabled: false                       # DISABLED — a multi-day grind tolerates flat windows
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 15.0                    # protective floor for a moderate-risk equity grind
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (8% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 8.0   # was 15.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:                               # wide-by-design; FIRST lock REACHABLE at +10% ROE (ride the grind)
-        - { trigger_pct: 10,  lock_hw_pct: 0  }
         - { trigger_pct: 20,  lock_hw_pct: 25 }
         - { trigger_pct: 30,  lock_hw_pct: 40 }
         - { trigger_pct: 50,  lock_hw_pct: 60 }

--- a/strategies/barnacle/strategy.yaml
+++ b/strategies/barnacle/strategy.yaml
@@ -10,7 +10,7 @@
 schema_version: 1
 
 id: barnacle
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Barnacle — Stealth Accumulation Detector"

--- a/strategies/barracuda/main/runtime.yaml
+++ b/strategies/barracuda/main/runtime.yaml
@@ -159,14 +159,18 @@ exit:
       enabled: true
       interval_in_minutes: 360         # a position held flat/red for 6h is cut
     phase1:
-      enabled: true
-      max_loss_pct: 15.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (7.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 7.0   # was 15.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 7
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 10,  lock_hw_pct: 0 }    # breakeven-first (stop to entry at +10% ROE)
         - { trigger_pct: 15,  lock_hw_pct: 20 }
         - { trigger_pct: 20,  lock_hw_pct: 40 }
         - { trigger_pct: 25,  lock_hw_pct: 55 }

--- a/strategies/barracuda/strategy.yaml
+++ b/strategies/barracuda/strategy.yaml
@@ -1,7 +1,7 @@
 # strategy.yaml — barracuda (the manifest: identity + catalog facets + instance)
 schema_version: 1
 id: barracuda
-version: "1.0.0"                  # the ONE strategy semver (catalog + MCP attribution derive from it)
+version: "1.1.0"                  # the ONE strategy semver (catalog + MCP attribution derive from it)
 
 catalog:
   name: "Barracuda"

--- a/strategies/beaver/main/runtime.yaml
+++ b/strategies/beaver/main/runtime.yaml
@@ -83,8 +83,13 @@ exit:
     execution_timeout_seconds: 30
   dsl_preset:
     phase1:
-      enabled: true
-      max_loss_pct: 20.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (8.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 8.0   # was 20.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:

--- a/strategies/beaver/strategy.yaml
+++ b/strategies/beaver/strategy.yaml
@@ -6,7 +6,7 @@
 schema_version: 1
 
 id: beaver
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Beaver — BTC Trend Follower"
   emoji: "🦫"

--- a/strategies/bison/main/runtime.yaml
+++ b/strategies/bison/main/runtime.yaml
@@ -113,14 +113,18 @@ exit:
       enabled: false                       # v2.1: DISABLED — multi-day thesis tolerates flat windows
       interval_in_minutes: 45
     phase1:
-      enabled: true
-      max_loss_pct: 30.0                    # v2.1: wide floor for conviction
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (8.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 8.0   # was 30.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:                               # wide-by-design; FIRST lock at +10% ROE (NOT +60-80%)
-        - { trigger_pct: 10, lock_hw_pct: 0 }
         - { trigger_pct: 20, lock_hw_pct: 25 }
         - { trigger_pct: 30, lock_hw_pct: 40 }
         - { trigger_pct: 50, lock_hw_pct: 60 }

--- a/strategies/bison/strategy.yaml
+++ b/strategies/bison/strategy.yaml
@@ -6,7 +6,7 @@
 schema_version: 1
 
 id: bison
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Bison — Conviction Momentum Holder"
   emoji: "🦬"

--- a/strategies/bloodhound/main/runtime.yaml
+++ b/strategies/bloodhound/main/runtime.yaml
@@ -120,14 +120,17 @@ exit:
       enabled: false
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 16.0                   # a failed pattern invalidates fast — the neckline is right there
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (8% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 8.0   # was 16.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 7, lock_hw_pct: 0 }
         - { trigger_pct: 13, lock_hw_pct: 30 }
         - { trigger_pct: 22, lock_hw_pct: 50 }
         - { trigger_pct: 36, lock_hw_pct: 65 }

--- a/strategies/bloodhound/strategy.yaml
+++ b/strategies/bloodhound/strategy.yaml
@@ -5,7 +5,7 @@ schema_version: 1
 
 id: bloodhound
 
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Bloodhound — Chart-Pattern Scanner"

--- a/strategies/boar/long/runtime.yaml
+++ b/strategies/boar/long/runtime.yaml
@@ -105,14 +105,17 @@ exit:
       enabled: true
       interval_in_minutes: 960            # 16h — recycle a position going nowhere
     phase1:
-      enabled: true
-      max_loss_pct: 16.0                  # BTC vol in the metals basket
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (10% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 10.0   # was 16.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 10
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 10,  lock_hw_pct: 0 }    # priming tier (arms the trail; no lock yet)
         - { trigger_pct: 20,  lock_hw_pct: 40 }   # first LOCK — reachable
         - { trigger_pct: 35,  lock_hw_pct: 60 }
         - { trigger_pct: 60,  lock_hw_pct: 78 }

--- a/strategies/boar/short/runtime.yaml
+++ b/strategies/boar/short/runtime.yaml
@@ -102,14 +102,17 @@ exit:
       enabled: true
       interval_in_minutes: 720            # 12h — recycle a short going nowhere
     phase1:
-      enabled: true
-      max_loss_pct: 12.0                  # tighter than long book — squeeze protection
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (7% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 7.0   # was 12.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 7
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 8,   lock_hw_pct: 0 }    # priming tier (arms the trail; no lock yet)
         - { trigger_pct: 18,  lock_hw_pct: 45 }   # first LOCK — reachable
         - { trigger_pct: 35,  lock_hw_pct: 65 }
         - { trigger_pct: 60,  lock_hw_pct: 80 }

--- a/strategies/boar/strategy.yaml
+++ b/strategies/boar/strategy.yaml
@@ -8,7 +8,7 @@
 schema_version: 1
 
 id: boar
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Boar — Hard Money vs Paper"

--- a/strategies/bobcat/main/runtime.yaml
+++ b/strategies/bobcat/main/runtime.yaml
@@ -113,14 +113,18 @@ exit:
       enabled: false                       # DISABLED (v2)
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 15.0                    # v2 / SKILL Phase 1 max_loss_pct
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (8.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 8.0   # was 15.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:                               # wide-by-design; FIRST lock at +10% ROE (NOT +60-80%)
-        - { trigger_pct: 10,  lock_hw_pct: 0  }
         - { trigger_pct: 20,  lock_hw_pct: 25 }
         - { trigger_pct: 30,  lock_hw_pct: 40 }
         - { trigger_pct: 50,  lock_hw_pct: 60 }

--- a/strategies/bobcat/strategy.yaml
+++ b/strategies/bobcat/strategy.yaml
@@ -10,7 +10,7 @@
 schema_version: 1
 
 id: bobcat
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Bobcat — Big Tech Trend Follower"
   emoji: "🐈"

--- a/strategies/camel/harvest/runtime.yaml
+++ b/strategies/camel/harvest/runtime.yaml
@@ -98,14 +98,17 @@ exit:
       enabled: true
       interval_in_minutes: 480            # 8h — recycle a flat carry position
     phase1:
-      enabled: true
-      max_loss_pct: 10.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (6% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 6
       retrace_threshold: 6
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 6, lock_hw_pct: 0 }     # priming tier (arms the trail; no lock yet)
         - { trigger_pct: 14, lock_hw_pct: 45 }   # first LOCK — reachable
         - { trigger_pct: 28, lock_hw_pct: 65 }
         - { trigger_pct: 50, lock_hw_pct: 80 }

--- a/strategies/camel/payout/runtime.yaml
+++ b/strategies/camel/payout/runtime.yaml
@@ -98,14 +98,17 @@ exit:
       enabled: true
       interval_in_minutes: 480            # 8h — recycle a flat carry position
     phase1:
-      enabled: true
-      max_loss_pct: 10.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (6% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 6
       retrace_threshold: 6
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 6, lock_hw_pct: 0 }     # priming tier (arms the trail; no lock yet)
         - { trigger_pct: 14, lock_hw_pct: 45 }   # first LOCK — reachable
         - { trigger_pct: 28, lock_hw_pct: 65 }
         - { trigger_pct: 50, lock_hw_pct: 80 }

--- a/strategies/camel/strategy.yaml
+++ b/strategies/camel/strategy.yaml
@@ -8,7 +8,7 @@
 schema_version: 1
 
 id: camel
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Camel — Funding Carry Hedge Fund"

--- a/strategies/caracal/breakout/runtime.yaml
+++ b/strategies/caracal/breakout/runtime.yaml
@@ -102,8 +102,12 @@ exit:
       enabled: true
       interval_in_minutes: 360             # 6h
     phase1:
-      enabled: true
-      max_loss_pct: 12.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (7% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 7
       retrace_threshold: 7
       consecutive_breaches_required: 1
     phase2:

--- a/strategies/caracal/catalyst/runtime.yaml
+++ b/strategies/caracal/catalyst/runtime.yaml
@@ -102,8 +102,12 @@ exit:
       enabled: true
       interval_in_minutes: 360             # 6h
     phase1:
-      enabled: true
-      max_loss_pct: 12.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (7% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 7
       retrace_threshold: 7
       consecutive_breaches_required: 1
     phase2:

--- a/strategies/caracal/strategy.yaml
+++ b/strategies/caracal/strategy.yaml
@@ -8,7 +8,7 @@
 schema_version: 1
 
 id: caracal
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Caracal — Volatility Hedge Fund"

--- a/strategies/caribou/long/runtime.yaml
+++ b/strategies/caribou/long/runtime.yaml
@@ -117,14 +117,17 @@ exit:
       enabled: false
       interval_in_minutes: 1440
     phase1:
-      enabled: true
-      max_loss_pct: 14.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (8% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 8
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 12, lock_hw_pct: 0 }     # priming tier (arms the trail; no lock yet)
         - { trigger_pct: 25, lock_hw_pct: 35 }    # first LOCK — reachable
         - { trigger_pct: 50, lock_hw_pct: 55 }
         - { trigger_pct: 90, lock_hw_pct: 72 }

--- a/strategies/caribou/short/runtime.yaml
+++ b/strategies/caribou/short/runtime.yaml
@@ -117,14 +117,17 @@ exit:
       enabled: false
       interval_in_minutes: 1440
     phase1:
-      enabled: true
-      max_loss_pct: 14.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (8% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 8
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 12, lock_hw_pct: 0 }     # priming tier (arms the trail; no lock yet)
         - { trigger_pct: 25, lock_hw_pct: 35 }    # first LOCK — reachable
         - { trigger_pct: 50, lock_hw_pct: 55 }
         - { trigger_pct: 90, lock_hw_pct: 72 }

--- a/strategies/caribou/strategy.yaml
+++ b/strategies/caribou/strategy.yaml
@@ -8,7 +8,7 @@
 schema_version: 1
 
 id: caribou
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Caribou — Cross-Asset Trend Fund"

--- a/strategies/chameleon/main/runtime.yaml
+++ b/strategies/chameleon/main/runtime.yaml
@@ -119,8 +119,13 @@ exit:
       enabled: false                       # v2: DISABLED
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 15.0                    # v2 Phase 1 max_loss
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (6.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 6.0   # was 15.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 6
       consecutive_breaches_required: 1
     phase2:

--- a/strategies/chameleon/strategy.yaml
+++ b/strategies/chameleon/strategy.yaml
@@ -9,7 +9,7 @@
 schema_version: 1
 
 id: chameleon
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Chameleon — Relative-Value / Pairs"
   emoji: "🦎"

--- a/strategies/cheetah/main/runtime.yaml
+++ b/strategies/cheetah/main/runtime.yaml
@@ -115,14 +115,17 @@ exit:
       enabled: false                       # v7.2.0: disabled — forced exits before trenders accelerate
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 15.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (10% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 10
       retrace_threshold: 10                # v2: raised 6->10 to avoid firing on normal 2-3% pullbacks in strong trends
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:                               # v2 v7.2.0 "let winners run" ladder (verbatim)
-        - { trigger_pct: 10, lock_hw_pct: 0 }
         - { trigger_pct: 20, lock_hw_pct: 25 }
         - { trigger_pct: 30, lock_hw_pct: 40 }
         - { trigger_pct: 50, lock_hw_pct: 60 }

--- a/strategies/cheetah/strategy.yaml
+++ b/strategies/cheetah/strategy.yaml
@@ -7,7 +7,7 @@
 schema_version: 1
 
 id: cheetah
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Cheetah — Multi-Signal Confluence Sniper"

--- a/strategies/chimp/main/runtime.yaml
+++ b/strategies/chimp/main/runtime.yaml
@@ -120,14 +120,17 @@ exit:
       interval_in_minutes: 2880        # 48h — a stalled position frees its slot within ~2 days
       min_value: 2.5
     phase1:
-      enabled: true
-      max_loss_pct: 18.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (8% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 8
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 8, lock_hw_pct: 0 }
         - { trigger_pct: 20, lock_hw_pct: 35 }
         - { trigger_pct: 45, lock_hw_pct: 60 }
         - { trigger_pct: 80, lock_hw_pct: 78 }

--- a/strategies/chimp/strategy.yaml
+++ b/strategies/chimp/strategy.yaml
@@ -7,7 +7,7 @@
 schema_version: 1
 
 id: chimp
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Chimp — Regime Allocator (Daily)"
   emoji: "🐒"

--- a/strategies/condor/main/runtime.yaml
+++ b/strategies/condor/main/runtime.yaml
@@ -111,8 +111,13 @@ exit:
       enabled: true
       interval_in_minutes: 60              # 60 min no movement = dead
     phase1:
-      enabled: true
-      max_loss_pct: 20.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (12.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 12.0   # was 20.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 12                # v2: raised 8 -> 12 (don't pre-exit the one amazing trade)
       consecutive_breaches_required: 1
     phase2:

--- a/strategies/condor/strategy.yaml
+++ b/strategies/condor/strategy.yaml
@@ -6,7 +6,7 @@
 schema_version: 1
 
 id: condor
-version: "1.1.0"
+version: "1.2.0"
 
 catalog:
   name: "Condor — One Amazing Trade per Day"

--- a/strategies/cougar/long/runtime.yaml
+++ b/strategies/cougar/long/runtime.yaml
@@ -93,14 +93,17 @@ exit:
       enabled: true
       interval_in_minutes: 960            # 16h — recycle a position going nowhere into a fresher leader
     phase1:
-      enabled: true
-      max_loss_pct: 14.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (8% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 8
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 8,   lock_hw_pct: 0 }    # priming tier (arms the trail; no lock yet)
         - { trigger_pct: 18,  lock_hw_pct: 40 }   # first LOCK — reachable (never +60-80%)
         - { trigger_pct: 35,  lock_hw_pct: 60 }
         - { trigger_pct: 60,  lock_hw_pct: 78 }

--- a/strategies/cougar/short/runtime.yaml
+++ b/strategies/cougar/short/runtime.yaml
@@ -93,14 +93,17 @@ exit:
       enabled: true
       interval_in_minutes: 960            # 16h — recycle a position going nowhere into a fresher laggard
     phase1:
-      enabled: true
-      max_loss_pct: 14.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (8% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 8
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 8,   lock_hw_pct: 0 }    # priming tier (arms the trail; no lock yet)
         - { trigger_pct: 18,  lock_hw_pct: 40 }   # first LOCK — reachable (never +60-80%)
         - { trigger_pct: 35,  lock_hw_pct: 60 }
         - { trigger_pct: 60,  lock_hw_pct: 78 }

--- a/strategies/cougar/strategy.yaml
+++ b/strategies/cougar/strategy.yaml
@@ -6,7 +6,7 @@
 schema_version: 1
 
 id: cougar
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Cougar — U.S. Equity Long/Short"

--- a/strategies/coyote/main/runtime.yaml
+++ b/strategies/coyote/main/runtime.yaml
@@ -106,14 +106,18 @@ exit:
       enabled: false
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 15.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (10.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 10.0   # was 15.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 10
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 10,  lock_hw_pct: 0 }
         - { trigger_pct: 20,  lock_hw_pct: 30 }
         - { trigger_pct: 35,  lock_hw_pct: 50 }
         - { trigger_pct: 60,  lock_hw_pct: 70 }

--- a/strategies/coyote/strategy.yaml
+++ b/strategies/coyote/strategy.yaml
@@ -8,7 +8,7 @@
 schema_version: 1
 
 id: coyote
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Coyote — Regime Classifier (BTC)"

--- a/strategies/crane/main/runtime.yaml
+++ b/strategies/crane/main/runtime.yaml
@@ -102,14 +102,17 @@ exit:
     execution_timeout_seconds: 60
   dsl_preset:
     phase1:
-      enabled: true
-      max_loss_pct: 10.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (6% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 6
       retrace_threshold: 6
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 6, lock_hw_pct: 0 }
         - { trigger_pct: 12, lock_hw_pct: 45 }
         - { trigger_pct: 25, lock_hw_pct: 70 }
 

--- a/strategies/crane/strategy.yaml
+++ b/strategies/crane/strategy.yaml
@@ -5,7 +5,7 @@
 schema_version: 1
 
 id: crane
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Crane — Managed Pairs / Stat-Arb"
   emoji: "🕊️"

--- a/strategies/cub/long/runtime.yaml
+++ b/strategies/cub/long/runtime.yaml
@@ -105,14 +105,17 @@ exit:
       enabled: true
       interval_in_minutes: 960            # 16h — recycle a position going nowhere
     phase1:
-      enabled: true
-      max_loss_pct: 16.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (10% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 10
       retrace_threshold: 10
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 10, lock_hw_pct: 0 }
         - { trigger_pct: 20, lock_hw_pct: 40 }
         - { trigger_pct: 35, lock_hw_pct: 60 }
         - { trigger_pct: 60, lock_hw_pct: 78 }

--- a/strategies/cub/preipo/runtime.yaml
+++ b/strategies/cub/preipo/runtime.yaml
@@ -115,14 +115,17 @@ exit:
       enabled: true
       interval_in_minutes: 960            # 16h
     phase1:
-      enabled: true
-      max_loss_pct: 14.0                  # tighter than haves (16) — pre-IPO gaps on news
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (10% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 10.0   # was 14.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 10
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 10, lock_hw_pct: 0 }
         - { trigger_pct: 20, lock_hw_pct: 40 }
         - { trigger_pct: 35, lock_hw_pct: 60 }
         - { trigger_pct: 60, lock_hw_pct: 78 }

--- a/strategies/cub/short/runtime.yaml
+++ b/strategies/cub/short/runtime.yaml
@@ -102,14 +102,17 @@ exit:
       enabled: true
       interval_in_minutes: 720            # 12h — recycle a short going nowhere
     phase1:
-      enabled: true
-      max_loss_pct: 12.0                  # tighter than long book — squeeze protection
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (7% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 7.0   # was 12.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 7
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 8, lock_hw_pct: 0 }
         - { trigger_pct: 18, lock_hw_pct: 45 }
         - { trigger_pct: 35, lock_hw_pct: 65 }
         - { trigger_pct: 60, lock_hw_pct: 80 }

--- a/strategies/cub/strategy.yaml
+++ b/strategies/cub/strategy.yaml
@@ -12,7 +12,7 @@
 schema_version: 1
 
 id: cub
-version: "1.1.0"
+version: "1.2.0"
 
 catalog:
   name: "Cub — Two-Speed-Market Long/Short + Pre-IPO"

--- a/strategies/cuckoo/main/runtime.yaml
+++ b/strategies/cuckoo/main/runtime.yaml
@@ -107,14 +107,17 @@ exit:
       enabled: false
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 18.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (10% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 10
       retrace_threshold: 10
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:                               # first lock at +10% ROE (reachable)
-        - { trigger_pct: 10, lock_hw_pct: 0 }
         - { trigger_pct: 20, lock_hw_pct: 45 }
         - { trigger_pct: 35, lock_hw_pct: 65 }
         - { trigger_pct: 55, lock_hw_pct: 78 }

--- a/strategies/cuckoo/strategy.yaml
+++ b/strategies/cuckoo/strategy.yaml
@@ -9,7 +9,7 @@
 schema_version: 1
 
 id: cuckoo
-version: "1.0.1"
+version: "1.1.0"
 
 catalog:
   name: "Cuckoo — Copy-the-Copiers"

--- a/strategies/dire/main/runtime.yaml
+++ b/strategies/dire/main/runtime.yaml
@@ -117,8 +117,13 @@ exit:
     execution_timeout_seconds: 60
   dsl_preset:
     phase1:
-      enabled: true
-      max_loss_pct: 20.0                   # tighter than Kodiak's 25% — oil tail risk
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (8.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 8.0   # was 20.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:

--- a/strategies/dire/strategy.yaml
+++ b/strategies/dire/strategy.yaml
@@ -6,7 +6,7 @@
 schema_version: 1
 
 id: dire
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Dire — BRENTOIL Oil Specialist"

--- a/strategies/dog/main/runtime.yaml
+++ b/strategies/dog/main/runtime.yaml
@@ -108,8 +108,12 @@ exit:
       enabled: true                        # v2.5: ON — v2.4 loosened 30 -> 60 (let fades develop)
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 15.0                    # v2.5: tighter than fleet 25% — contrarian losses small
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (8% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 8.0   # was 15.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:

--- a/strategies/dog/strategy.yaml
+++ b/strategies/dog/strategy.yaml
@@ -7,7 +7,7 @@
 schema_version: 1
 
 id: dog
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Dog — Contrarian Pup (SM Exhaustion Fader)"

--- a/strategies/dragonfly/btc/runtime.yaml
+++ b/strategies/dragonfly/btc/runtime.yaml
@@ -116,14 +116,17 @@ exit:
       interval_in_minutes: 480          # spec weak_peak_cut_minutes
       min_value: 3.0
     phase1:
-      enabled: true
-      max_loss_pct: 15.0                # spec max_loss_pct
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (8% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 8.0   # was 15.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8              # spec retrace_threshold
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:                            # spec triggers 5/15/50/100; locks per BTC vol ladder
-        - { trigger_pct: 5, lock_hw_pct: 0 }
         - { trigger_pct: 15, lock_hw_pct: 25 }
         - { trigger_pct: 50, lock_hw_pct: 60 }
         - { trigger_pct: 100, lock_hw_pct: 80 }

--- a/strategies/dragonfly/hype/runtime.yaml
+++ b/strategies/dragonfly/hype/runtime.yaml
@@ -118,14 +118,17 @@ exit:
       interval_in_minutes: 240          # spec weak_peak_cut_minutes
       min_value: 3.0
     phase1:
-      enabled: true
-      max_loss_pct: 12.0                # spec max_loss_pct
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (6% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 6.0   # was 12.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 6              # spec retrace_threshold
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:                            # spec triggers 3/10/30/60; locks per HYPE vol ladder
-        - { trigger_pct: 3, lock_hw_pct: 0 }
         - { trigger_pct: 10, lock_hw_pct: 20 }
         - { trigger_pct: 30, lock_hw_pct: 50 }
         - { trigger_pct: 60, lock_hw_pct: 72 }

--- a/strategies/dragonfly/strategy.yaml
+++ b/strategies/dragonfly/strategy.yaml
@@ -11,7 +11,7 @@
 schema_version: 1
 
 id: dragonfly               # == package dir name; == every leg's runtime.yaml `group`
-version: "1.0.0"            # single source for catalog + MCP attribution (skillName/skillVersion)
+version: "1.1.0"            # single source for catalog + MCP attribution (skillName/skillVersion)
 
 catalog:                    # discovery surface
   name: "Dragonfly — BTC + HYPE Composite Momentum"

--- a/strategies/eel/long/runtime.yaml
+++ b/strategies/eel/long/runtime.yaml
@@ -105,14 +105,17 @@ exit:
       enabled: true
       interval_in_minutes: 960            # 16h — recycle a position going nowhere
     phase1:
-      enabled: true
-      max_loss_pct: 15.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (10% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 10
       retrace_threshold: 10
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 10,  lock_hw_pct: 0 }    # priming tier (arms the trail; no lock yet)
         - { trigger_pct: 20,  lock_hw_pct: 40 }   # first LOCK — reachable
         - { trigger_pct: 35,  lock_hw_pct: 60 }
         - { trigger_pct: 60,  lock_hw_pct: 78 }

--- a/strategies/eel/short/runtime.yaml
+++ b/strategies/eel/short/runtime.yaml
@@ -100,14 +100,17 @@ exit:
       enabled: true
       interval_in_minutes: 720            # 12h — recycle a short going nowhere
     phase1:
-      enabled: true
-      max_loss_pct: 12.0                  # tighter than power book — oil-spike protection
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (7% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 7.0   # was 12.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 7
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 8,   lock_hw_pct: 0 }    # priming tier (arms the trail; no lock yet)
         - { trigger_pct: 18,  lock_hw_pct: 45 }   # first LOCK — reachable
         - { trigger_pct: 35,  lock_hw_pct: 65 }
         - { trigger_pct: 60,  lock_hw_pct: 80 }

--- a/strategies/eel/strategy.yaml
+++ b/strategies/eel/strategy.yaml
@@ -7,7 +7,7 @@
 schema_version: 1
 
 id: eel
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Eel — Electrons vs Hydrocarbons"

--- a/strategies/egret/main/runtime.yaml
+++ b/strategies/egret/main/runtime.yaml
@@ -108,8 +108,12 @@ exit:
       enabled: false                       # v2: DISABLED
       interval_in_minutes: 90
     phase1:
-      enabled: true
-      max_loss_pct: 15.0                    # v2 phase1 max_loss_pct 15
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (6% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 6.0   # was 15.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 6                  # v2 phase1 retrace_threshold 6
       consecutive_breaches_required: 1
     phase2:

--- a/strategies/egret/strategy.yaml
+++ b/strategies/egret/strategy.yaml
@@ -7,7 +7,7 @@
 schema_version: 1
 
 id: egret
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Egret — Smart-Money Divergence Fader"
   emoji: "🐦"

--- a/strategies/elephant/fade/runtime.yaml
+++ b/strategies/elephant/fade/runtime.yaml
@@ -96,8 +96,12 @@ exit:
       enabled: true
       interval_in_minutes: 480              # 8h
     phase1:
-      enabled: true
-      max_loss_pct: 8.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (5% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 5
       retrace_threshold: 5
       consecutive_breaches_required: 1
     phase2:

--- a/strategies/elephant/strategy.yaml
+++ b/strategies/elephant/strategy.yaml
@@ -9,7 +9,7 @@
 schema_version: 1
 
 id: elephant
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Elephant — Global-Macro Hedge Fund"

--- a/strategies/elephant/trend/runtime.yaml
+++ b/strategies/elephant/trend/runtime.yaml
@@ -96,14 +96,17 @@ exit:
       enabled: false
       interval_in_minutes: 1440
     phase1:
-      enabled: true
-      max_loss_pct: 18.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (10% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 10
       retrace_threshold: 10
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 12, lock_hw_pct: 0 }
         - { trigger_pct: 25, lock_hw_pct: 45 }
         - { trigger_pct: 45, lock_hw_pct: 65 }
         - { trigger_pct: 75, lock_hw_pct: 80 }

--- a/strategies/falcon/main/runtime.yaml
+++ b/strategies/falcon/main/runtime.yaml
@@ -100,14 +100,18 @@ exit:
       enabled: false
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 20.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (12.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 12.0   # was 20.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 12
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 10,  lock_hw_pct: 0 }
         - { trigger_pct: 20,  lock_hw_pct: 40 }
         - { trigger_pct: 35,  lock_hw_pct: 60 }
         - { trigger_pct: 60,  lock_hw_pct: 75 }

--- a/strategies/falcon/strategy.yaml
+++ b/strategies/falcon/strategy.yaml
@@ -7,7 +7,7 @@
 schema_version: 1
 
 id: falcon
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Falcon — Conversion-Event Momentum"
   emoji: "🦅"

--- a/strategies/gecko/main/runtime.yaml
+++ b/strategies/gecko/main/runtime.yaml
@@ -98,14 +98,17 @@ exit:
       interval_in_minutes: 1440              # 24h — a stalled name frees the single slot
       min_value: 2.5
     phase1:
-      enabled: true
-      max_loss_pct: 15.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (8% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 8
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 8,  lock_hw_pct: 0 }
         - { trigger_pct: 15, lock_hw_pct: 35 }
         - { trigger_pct: 25, lock_hw_pct: 52 }
         - { trigger_pct: 40, lock_hw_pct: 65 }

--- a/strategies/gecko/strategy.yaml
+++ b/strategies/gecko/strategy.yaml
@@ -8,7 +8,7 @@
 schema_version: 1
 
 id: gecko
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Gecko — Any-Coin Confluence"
   emoji: "🦎"

--- a/strategies/gibbon/main/runtime.yaml
+++ b/strategies/gibbon/main/runtime.yaml
@@ -116,14 +116,17 @@ exit:
       interval_in_minutes: 2160        # 36h — a stalled rotation frees its slot inside ~1.5 days
       min_value: 2.5
     phase1:
-      enabled: true
-      max_loss_pct: 15.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (8% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 8
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 8, lock_hw_pct: 0 }
         - { trigger_pct: 20, lock_hw_pct: 38 }
         - { trigger_pct: 45, lock_hw_pct: 62 }
         - { trigger_pct: 80, lock_hw_pct: 80 }

--- a/strategies/gibbon/strategy.yaml
+++ b/strategies/gibbon/strategy.yaml
@@ -7,7 +7,7 @@
 schema_version: 1
 
 id: gibbon
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Gibbon — Rotation Rider (Daily)"
   emoji: "🐒"

--- a/strategies/gorilla/main/runtime.yaml
+++ b/strategies/gorilla/main/runtime.yaml
@@ -113,14 +113,17 @@ exit:
       interval_in_minutes: 10080       # 7d — matches the weekly recalibration
       min_value: 2.5
     phase1:
-      enabled: true
-      max_loss_pct: 20.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (9% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 9
       retrace_threshold: 9
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 10, lock_hw_pct: 0 }
         - { trigger_pct: 25, lock_hw_pct: 40 }
         - { trigger_pct: 55, lock_hw_pct: 62 }
         - { trigger_pct: 100, lock_hw_pct: 80 }

--- a/strategies/gorilla/strategy.yaml
+++ b/strategies/gorilla/strategy.yaml
@@ -7,7 +7,7 @@
 schema_version: 1
 
 id: gorilla
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Gorilla — Regime Allocator (Weekly)"
   emoji: "🦍"

--- a/strategies/grizzly/main/runtime.yaml
+++ b/strategies/grizzly/main/runtime.yaml
@@ -112,8 +112,13 @@ exit:
     execution_timeout_seconds: 60
   dsl_preset:
     phase1:
-      enabled: true
-      max_loss_pct: 20.0                   # v5.1: more room for bull-rally drawdowns on BTC
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (8.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 8.0   # was 20.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:

--- a/strategies/grizzly/strategy.yaml
+++ b/strategies/grizzly/strategy.yaml
@@ -7,7 +7,7 @@
 schema_version: 1
 
 id: grizzly
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Grizzly — BTC Alpha Hunter"
   emoji: "🐻"

--- a/strategies/hare/main/runtime.yaml
+++ b/strategies/hare/main/runtime.yaml
@@ -89,14 +89,18 @@ exit:
     hard_timeout: { enabled: true, interval_in_minutes: 180 }               # scalp: flat within ~3h
     weak_peak_cut: { enabled: true, interval_in_minutes: 45, min_value: 1.5 }  # not working in 45m -> release
     phase1:
-      enabled: true
-      max_loss_pct: 8.0                      # tight stop — the "1" in 1:3
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (5.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 5.0   # was 8.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 5
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 10, lock_hw_pct: 0 }    # arm
         - { trigger_pct: 24, lock_hw_pct: 50 }   # ~3x the risk — lock half (the "3" in 1:3)
         - { trigger_pct: 40, lock_hw_pct: 70 }
         - { trigger_pct: 65, lock_hw_pct: 82 }

--- a/strategies/hare/strategy.yaml
+++ b/strategies/hare/strategy.yaml
@@ -6,7 +6,7 @@
 schema_version: 1
 
 id: hare
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Hare — Crypto Majors Session Scalper"

--- a/strategies/hawk/main/runtime.yaml
+++ b/strategies/hawk/main/runtime.yaml
@@ -111,14 +111,17 @@ exit:
       enabled: false                        # v2: DISABLED
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 8.0                      # v2: TIGHT floor — failed breakouts must be cut fast
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (5% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 5.0   # was 8.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 5
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:                                # wide-by-design; FIRST lock at +10% ROE (NOT >+40%)
-        - { trigger_pct: 10,  lock_hw_pct: 0  }
         - { trigger_pct: 20,  lock_hw_pct: 25 }
         - { trigger_pct: 30,  lock_hw_pct: 40 }
         - { trigger_pct: 50,  lock_hw_pct: 60 }

--- a/strategies/hawk/strategy.yaml
+++ b/strategies/hawk/strategy.yaml
@@ -8,7 +8,7 @@
 schema_version: 1
 
 id: hawk
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Hawk — Breakout Buyer / Breakdown Seller"
   emoji: "🦅"

--- a/strategies/hedgehog/main/runtime.yaml
+++ b/strategies/hedgehog/main/runtime.yaml
@@ -103,14 +103,18 @@ exit:
       enabled: false                       # v2: DISABLED
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 15.0                    # v2: per-position catastrophic floor
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (8.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 8.0   # was 15.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:                               # wide-by-design; FIRST lock at +10% ROE (reachable)
-        - { trigger_pct: 10, lock_hw_pct: 0 }
         - { trigger_pct: 20, lock_hw_pct: 25 }
         - { trigger_pct: 30, lock_hw_pct: 40 }
         - { trigger_pct: 50, lock_hw_pct: 60 }

--- a/strategies/hedgehog/strategy.yaml
+++ b/strategies/hedgehog/strategy.yaml
@@ -7,7 +7,7 @@
 schema_version: 1
 
 id: hedgehog
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Hedgehog — Major Crypto Basket"
   emoji: "🦔"

--- a/strategies/hen/main/runtime.yaml
+++ b/strategies/hen/main/runtime.yaml
@@ -115,14 +115,17 @@ exit:
       enabled: false
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 15.0                    # tighter than a swing: an open that goes wrong goes fast
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (8% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 8.0   # was 15.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:                                # bank the open move early, then let a real trend breathe
-        - { trigger_pct: 6, lock_hw_pct: 0 }
         - { trigger_pct: 12, lock_hw_pct: 30 }
         - { trigger_pct: 20, lock_hw_pct: 50 }
         - { trigger_pct: 35, lock_hw_pct: 65 }

--- a/strategies/hen/strategy.yaml
+++ b/strategies/hen/strategy.yaml
@@ -4,7 +4,7 @@
 schema_version: 1
 
 id: hen
-version: "1.0.0"
+version: "1.1.0"
 catalog:
   name: "Hen — The Basket Opener"
   emoji: "🐔"

--- a/strategies/heron/main/runtime.yaml
+++ b/strategies/heron/main/runtime.yaml
@@ -83,14 +83,18 @@ exit:
     execution_timeout_seconds: 30
   dsl_preset:
     phase1:
-      enabled: true
-      max_loss_pct: 20.0                    # v2 heron Phase 1 (NOT kodiak 15)
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (8.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 8.0   # was 20.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8                  # v2 heron (NOT kodiak 5)
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 10,  lock_hw_pct: 0  }   # confirms working, no lock yet
         - { trigger_pct: 20,  lock_hw_pct: 25 }   # FIRST REAL LOCK (+20% ROE) — reachable
         - { trigger_pct: 30,  lock_hw_pct: 40 }
         - { trigger_pct: 50,  lock_hw_pct: 60 }

--- a/strategies/heron/strategy.yaml
+++ b/strategies/heron/strategy.yaml
@@ -8,7 +8,7 @@
 schema_version: 1
 
 id: heron
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Heron — ETH Trend Follower"
   emoji: "🐦"

--- a/strategies/hornet/main/runtime.yaml
+++ b/strategies/hornet/main/runtime.yaml
@@ -137,14 +137,17 @@ exit:
       enabled: false
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 15.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (8% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 8
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:                               # wide-by-design; FIRST lock at +10% ROE
-        - { trigger_pct: 10,  lock_hw_pct: 0  }
         - { trigger_pct: 20,  lock_hw_pct: 25 }
         - { trigger_pct: 30,  lock_hw_pct: 40 }
         - { trigger_pct: 50,  lock_hw_pct: 60 }

--- a/strategies/hornet/strategy.yaml
+++ b/strategies/hornet/strategy.yaml
@@ -10,7 +10,7 @@
 schema_version: 1
 
 id: hornet
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Hornet — Semiconductor Supply-Chain Momentum"
   emoji: "🐝"

--- a/strategies/hummingbird/main/runtime.yaml
+++ b/strategies/hummingbird/main/runtime.yaml
@@ -82,14 +82,18 @@ exit:
     execution_timeout_seconds: 30
   dsl_preset:
     phase1:
-      enabled: true
-      max_loss_pct: 20.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (8.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 8.0   # was 20.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 10,  lock_hw_pct: 0  }   # confirms working, no lock yet (v2 Bison pattern)
         - { trigger_pct: 20,  lock_hw_pct: 25 }
         - { trigger_pct: 30,  lock_hw_pct: 40 }
         - { trigger_pct: 50,  lock_hw_pct: 60 }

--- a/strategies/hummingbird/strategy.yaml
+++ b/strategies/hummingbird/strategy.yaml
@@ -6,7 +6,7 @@
 schema_version: 1
 
 id: hummingbird
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Hummingbird — HYPE Trend Follower"
   emoji: "🪶"

--- a/strategies/hydra/core/runtime.yaml
+++ b/strategies/hydra/core/runtime.yaml
@@ -97,8 +97,12 @@ exit:
       enabled: false
       interval_in_minutes: 2880
     phase1:
-      enabled: true
-      max_loss_pct: 32.0                     # catastrophic-only disaster stop (thesis-breaking)
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (10% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 10.0   # was 32.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 10                  # tightened (was 20) — trail a winner into profit
       consecutive_breaches_required: 2
     phase2:

--- a/strategies/hydra/dip/runtime.yaml
+++ b/strategies/hydra/dip/runtime.yaml
@@ -92,8 +92,12 @@ exit:
       enabled: false
       interval_in_minutes: 720
     phase1:
-      enabled: true
-      max_loss_pct: 12.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (6% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 6
       retrace_threshold: 6
       consecutive_breaches_required: 1
     phase2:

--- a/strategies/hydra/hedge/runtime.yaml
+++ b/strategies/hydra/hedge/runtime.yaml
@@ -117,8 +117,12 @@ exit:
       enabled: false
       interval_in_minutes: 720
     phase1:
-      enabled: true
-      max_loss_pct: 12.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (6% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 6
       retrace_threshold: 6
       consecutive_breaches_required: 1
     phase2:

--- a/strategies/hydra/strategy.yaml
+++ b/strategies/hydra/strategy.yaml
@@ -14,7 +14,7 @@
 schema_version: 1
 
 id: hydra
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Hydra — Single-Coin Conviction Fund (cross-asset hedge)"

--- a/strategies/hyena/main/runtime.yaml
+++ b/strategies/hyena/main/runtime.yaml
@@ -115,14 +115,17 @@ exit:
       enabled: false
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 12.0                     # tight — an unwinding crowded long can squeeze a short hard
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (8% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 8.0   # was 12.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:                                 # first lock reachable EARLY (+8%); then breathe for a cascade
-        - { trigger_pct: 8,  lock_hw_pct: 0  }
         - { trigger_pct: 15, lock_hw_pct: 30 }
         - { trigger_pct: 25, lock_hw_pct: 50 }
         - { trigger_pct: 40, lock_hw_pct: 65 }

--- a/strategies/hyena/strategy.yaml
+++ b/strategies/hyena/strategy.yaml
@@ -10,7 +10,7 @@
 schema_version: 1
 
 id: hyena
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Hyena — Risk-Off Crypto Short (Hedge Sleeve)"

--- a/strategies/ibis/main/runtime.yaml
+++ b/strategies/ibis/main/runtime.yaml
@@ -127,14 +127,17 @@ exit:
       enabled: false
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 18.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (8% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 8
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 7, lock_hw_pct: 0 }
         - { trigger_pct: 14, lock_hw_pct: 28 }
         - { trigger_pct: 24, lock_hw_pct: 48 }
         - { trigger_pct: 38, lock_hw_pct: 62 }

--- a/strategies/ibis/strategy.yaml
+++ b/strategies/ibis/strategy.yaml
@@ -4,7 +4,7 @@
 schema_version: 1
 
 id: ibis
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Ibis — Trend/Range Regime-Switcher"
   emoji: "🦤"

--- a/strategies/iguana/main/runtime.yaml
+++ b/strategies/iguana/main/runtime.yaml
@@ -105,14 +105,18 @@ exit:
       enabled: false
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 12.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (8.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 8.0   # was 12.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 5,  lock_hw_pct: 0 }    # REACHABLE first lock (+5% ROE)
         - { trigger_pct: 10, lock_hw_pct: 40 }
         - { trigger_pct: 18, lock_hw_pct: 60 }
         - { trigger_pct: 30, lock_hw_pct: 75 }

--- a/strategies/iguana/strategy.yaml
+++ b/strategies/iguana/strategy.yaml
@@ -8,7 +8,7 @@ schema_version: 1
 
 id: iguana
 
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Iguana — XYZ Macro Index Trend"

--- a/strategies/jackal/main/runtime.yaml
+++ b/strategies/jackal/main/runtime.yaml
@@ -128,8 +128,13 @@ exit:
       enabled: false                         # v2: disabled — Jackal is patient
       interval_in_minutes: 240
     phase1:
-      enabled: true
-      max_loss_pct: 22.0                      # v2: 22%
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (10.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 10.0   # was 22.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 10                   # v2: 10
       consecutive_breaches_required: 1        # v2: 1
     phase2:

--- a/strategies/jackal/strategy.yaml
+++ b/strategies/jackal/strategy.yaml
@@ -9,7 +9,7 @@
 schema_version: 1
 
 id: jackal
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Jackal — The Smart Stalker"

--- a/strategies/jaguar/main/runtime.yaml
+++ b/strategies/jaguar/main/runtime.yaml
@@ -99,8 +99,13 @@ exit:
       enabled: true
       interval_in_minutes: 30               # v4.0.2: 12 -> 30
     phase1:
-      enabled: true
-      max_loss_pct: 15.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (8.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 8.0   # was 15.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:

--- a/strategies/jaguar/strategy.yaml
+++ b/strategies/jaguar/strategy.yaml
@@ -6,7 +6,7 @@
 schema_version: 1
 
 id: jaguar
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Jaguar — Striker Rank-Jump Detector"

--- a/strategies/kestrel/main/runtime.yaml
+++ b/strategies/kestrel/main/runtime.yaml
@@ -117,8 +117,13 @@ exit:
       enabled: true
       interval_in_minutes: 45              # v2 — catches false breakouts
     phase1:
-      enabled: true
-      max_loss_pct: 18.0                   # v2
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (8.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 8.0   # was 18.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8                 # v2
       consecutive_breaches_required: 1     # v2
     phase2:

--- a/strategies/kestrel/strategy.yaml
+++ b/strategies/kestrel/strategy.yaml
@@ -8,7 +8,7 @@
 schema_version: 1
 
 id: kestrel
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Kestrel — XYZ Macro Breakout Rider"

--- a/strategies/kingfisher/main/runtime.yaml
+++ b/strategies/kingfisher/main/runtime.yaml
@@ -110,14 +110,18 @@ exit:
       enabled: false
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 20.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (8.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 8.0   # was 20.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:                               # balanced: FIRST lock at +8% ROE, tighten as it runs
-        - { trigger_pct: 8, lock_hw_pct: 0 }
         - { trigger_pct: 15, lock_hw_pct: 25 }
         - { trigger_pct: 25, lock_hw_pct: 45 }
         - { trigger_pct: 40, lock_hw_pct: 60 }

--- a/strategies/kingfisher/strategy.yaml
+++ b/strategies/kingfisher/strategy.yaml
@@ -5,7 +5,7 @@
 schema_version: 1
 
 id: kingfisher
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Kingfisher — Classic Indicators (RSI + MACD)"

--- a/strategies/kite/main/runtime.yaml
+++ b/strategies/kite/main/runtime.yaml
@@ -90,8 +90,13 @@ exit:
     hard_timeout: { enabled: true, interval_in_minutes: 7200 }               # 5d backstop
     weak_peak_cut: { enabled: true, interval_in_minutes: 2880, min_value: 2.0 }  # retire a dead setup ~2d
     phase1:
-      enabled: true
-      max_loss_pct: 12.0                     # structural invalidation (0.786 area) as an ROE stop
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (8.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 8.0   # was 12.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:

--- a/strategies/kite/strategy.yaml
+++ b/strategies/kite/strategy.yaml
@@ -5,7 +5,7 @@
 schema_version: 1
 
 id: kite
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Kite — Market Structure & Divergence (SMC)"

--- a/strategies/koala/main/runtime.yaml
+++ b/strategies/koala/main/runtime.yaml
@@ -108,8 +108,13 @@ exit:
       enabled: false                       # v2: DISABLED
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 30.0                    # 30% margin loss tolerated
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (10.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 10.0   # was 30.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 10                 # v2: trail into profit (was 25)
       consecutive_breaches_required: 3      # 3 confirmations before the catastrophic stop trips
     phase2:

--- a/strategies/koala/strategy.yaml
+++ b/strategies/koala/strategy.yaml
@@ -7,7 +7,7 @@
 schema_version: 1
 
 id: koala
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Koala — Set-and-Forget Trail HODL"

--- a/strategies/kodiak/main/runtime.yaml
+++ b/strategies/kodiak/main/runtime.yaml
@@ -89,8 +89,13 @@ exit:
     execution_timeout_seconds: 60
   dsl_preset:
     phase1:
-      enabled: true
-      max_loss_pct: 15.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (5.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 5.0   # was 15.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 5
       consecutive_breaches_required: 1
     phase2:

--- a/strategies/kodiak/strategy.yaml
+++ b/strategies/kodiak/strategy.yaml
@@ -5,7 +5,7 @@
 schema_version: 1
 
 id: kodiak
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Kodiak — SOL Alpha Hunter"

--- a/strategies/lemon/main/runtime.yaml
+++ b/strategies/lemon/main/runtime.yaml
@@ -113,8 +113,13 @@ exit:
       enabled: true
       interval_in_minutes: 45                # cut early stallers (v2)
     phase1:
-      enabled: true
-      max_loss_pct: 15.0                      # v2: tighter than fleet 25% — fades fail fast
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (8.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 8.0   # was 15.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:

--- a/strategies/lemon/strategy.yaml
+++ b/strategies/lemon/strategy.yaml
@@ -7,7 +7,7 @@
 schema_version: 1
 
 id: lemon
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Lemon — Degen Fader"

--- a/strategies/lemur/main/runtime.yaml
+++ b/strategies/lemur/main/runtime.yaml
@@ -118,14 +118,18 @@ exit:
       enabled: false                        # DISABLED
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 10.0                     # v2: moderate floor (Discovery Bounds limit velocity)
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (8.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 8.0   # was 10.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:                                # wide-by-design; FIRST lock at +10% ROE (reachable)
-        - { trigger_pct: 10,  lock_hw_pct: 0  }
         - { trigger_pct: 20,  lock_hw_pct: 25 }
         - { trigger_pct: 30,  lock_hw_pct: 40 }
         - { trigger_pct: 50,  lock_hw_pct: 60 }

--- a/strategies/lemur/strategy.yaml
+++ b/strategies/lemur/strategy.yaml
@@ -8,7 +8,7 @@
 schema_version: 1
 
 id: lemur
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Lemur — Pre-IPO Perpetual Trend Follower"
   emoji: "🦤"

--- a/strategies/lion/long/runtime.yaml
+++ b/strategies/lion/long/runtime.yaml
@@ -115,14 +115,17 @@ exit:
       enabled: true
       interval_in_minutes: 960            # 16h — recycle a position going nowhere
     phase1:
-      enabled: true
-      max_loss_pct: 16.0                  # slightly wider than equity-only (HYPE vol in basket)
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (10% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 10.0   # was 16.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 10
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 10,  lock_hw_pct: 0 }    # priming tier (arms the trail; no lock yet)
         - { trigger_pct: 20,  lock_hw_pct: 40 }   # first LOCK — reachable
         - { trigger_pct: 35,  lock_hw_pct: 60 }
         - { trigger_pct: 60,  lock_hw_pct: 78 }

--- a/strategies/lion/short/runtime.yaml
+++ b/strategies/lion/short/runtime.yaml
@@ -111,14 +111,17 @@ exit:
       enabled: true
       interval_in_minutes: 720            # 12h — recycle a short going nowhere
     phase1:
-      enabled: true
-      max_loss_pct: 12.0                  # tighter than long book — squeeze protection
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (7% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 7.0   # was 12.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 7
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 8,   lock_hw_pct: 0 }    # priming tier (arms the trail; no lock yet)
         - { trigger_pct: 18,  lock_hw_pct: 45 }   # first LOCK — reachable
         - { trigger_pct: 35,  lock_hw_pct: 65 }
         - { trigger_pct: 60,  lock_hw_pct: 80 }

--- a/strategies/lion/strategy.yaml
+++ b/strategies/lion/strategy.yaml
@@ -8,7 +8,7 @@
 schema_version: 1
 
 id: lion
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Lion — Two-Speed-Market Cross-Asset L/S"

--- a/strategies/lynx/main/runtime.yaml
+++ b/strategies/lynx/main/runtime.yaml
@@ -114,14 +114,17 @@ exit:
       enabled: false                       # v2: disabled
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 20.0                    # v2 phase1.max_loss_pct
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (12% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 12.0   # was 20.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 12                 # v2 phase1.retrace_threshold
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:                               # v2 phase2 ladder (verbatim) — first lock at +10% ROE
-        - { trigger_pct: 10,  lock_hw_pct: 0 }
         - { trigger_pct: 20,  lock_hw_pct: 25 }
         - { trigger_pct: 35,  lock_hw_pct: 50 }
         - { trigger_pct: 60,  lock_hw_pct: 70 }

--- a/strategies/lynx/strategy.yaml
+++ b/strategies/lynx/strategy.yaml
@@ -8,7 +8,7 @@
 schema_version: 1
 
 id: lynx
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Lynx — Adaptive MIN_SCORE Self-Tuner"
   emoji: "🐯"

--- a/strategies/magpie/graduation/runtime.yaml
+++ b/strategies/magpie/graduation/runtime.yaml
@@ -84,8 +84,12 @@ exit:
     execution_timeout_seconds: 45
   dsl_preset:
     phase1:
-      enabled: true
-      max_loss_pct: 12.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (9% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 9
       retrace_threshold: 9
       consecutive_breaches_required: 1
     phase2:

--- a/strategies/magpie/pre_listing/runtime.yaml
+++ b/strategies/magpie/pre_listing/runtime.yaml
@@ -83,8 +83,12 @@ exit:
     execution_timeout_seconds: 60
   dsl_preset:
     phase1:
-      enabled: true
-      max_loss_pct: 10.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (7% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 7
       retrace_threshold: 7
       consecutive_breaches_required: 1
     phase2:

--- a/strategies/magpie/strategy.yaml
+++ b/strategies/magpie/strategy.yaml
@@ -7,7 +7,7 @@
 schema_version: 1
 
 id: magpie
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Magpie — IPO / New-Listing Event Fund"
   emoji: "🐦"

--- a/strategies/mandate/main/runtime.yaml
+++ b/strategies/mandate/main/runtime.yaml
@@ -89,8 +89,13 @@ exit:
     hard_timeout: { enabled: true, interval_in_minutes: 20160 }        # 14d staleness cap
     weak_peak_cut: { enabled: true, interval_in_minutes: 5760, min_value: 2.0 }  # retire dead weight ~4d
     phase1:
-      enabled: true
-      max_loss_pct: 10.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (8.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 8.0   # was 10.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8
       consecutive_breaches_required: 2
     phase2:

--- a/strategies/mandate/strategy.yaml
+++ b/strategies/mandate/strategy.yaml
@@ -6,7 +6,7 @@
 schema_version: 1
 
 id: mandate
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Mandate — Capital-Preservation Portfolio (Crypto + RWA)"

--- a/strategies/manta/main/runtime.yaml
+++ b/strategies/manta/main/runtime.yaml
@@ -114,14 +114,17 @@ exit:
       enabled: false
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 12.0                   # tighter: the invalidation (other side of the AOI) is close
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (8% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 8.0   # was 12.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:                               # FX-scaled position-ROE ladder (leverage already applied)
-        - { trigger_pct: 5, lock_hw_pct: 0 }
         - { trigger_pct: 10, lock_hw_pct: 30 }
         - { trigger_pct: 18, lock_hw_pct: 50 }
         - { trigger_pct: 30, lock_hw_pct: 65 }

--- a/strategies/manta/strategy.yaml
+++ b/strategies/manta/strategy.yaml
@@ -4,7 +4,7 @@
 schema_version: 1
 
 id: manta
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Manta — Multi-Timeframe Structure (FX)"

--- a/strategies/mantis/main/runtime.yaml
+++ b/strategies/mantis/main/runtime.yaml
@@ -116,8 +116,12 @@ exit:
       interval_in_minutes: 20
       min_value: 1.5
     phase1:
-      enabled: true
-      max_loss_pct: 12.0                    # v2 phase1.max_loss_pct
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (5% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 5.0   # was 12.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 5                  # v2 phase1.retrace_threshold
       consecutive_breaches_required: 1
     phase2:

--- a/strategies/mantis/strategy.yaml
+++ b/strategies/mantis/strategy.yaml
@@ -8,7 +8,7 @@
 schema_version: 1
 
 id: mantis
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Mantis — Cross-Asset Catchup Hunter"

--- a/strategies/marlin/main/runtime.yaml
+++ b/strategies/marlin/main/runtime.yaml
@@ -112,14 +112,17 @@ exit:
       enabled: false                       # v2: DISABLED
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 18.0                    # v2 phase1.max_loss_pct
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (8% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 8.0   # was 18.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8                  # v2 phase1.retrace_threshold
       consecutive_breaches_required: 1      # v2 phase1.consecutive_breaches_required
     phase2:
       enabled: true
       tiers:                               # wide-by-design; FIRST lock at +10% ROE (reachable)
-        - { trigger_pct: 10,  lock_hw_pct: 0  }
         - { trigger_pct: 20,  lock_hw_pct: 25 }
         - { trigger_pct: 30,  lock_hw_pct: 40 }
         - { trigger_pct: 50,  lock_hw_pct: 60 }

--- a/strategies/marlin/strategy.yaml
+++ b/strategies/marlin/strategy.yaml
@@ -8,7 +8,7 @@
 schema_version: 1
 
 id: marlin
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Marlin — Order-Book Imbalance Momentum"
   emoji: "🐟"

--- a/strategies/meerkat/main/runtime.yaml
+++ b/strategies/meerkat/main/runtime.yaml
@@ -109,14 +109,17 @@ exit:
       enabled: false                        # v2: DISABLED
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 18.0                     # v2: max_loss 18%
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (10% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 10.0   # was 18.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 10                  # v2 retrace_threshold
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:                                 # v2 v1.0.1 let-winners-run ladder (verbatim); FIRST lock at +10% (REACHABLE)
-        - { trigger_pct: 10, lock_hw_pct: 0 }
         - { trigger_pct: 20, lock_hw_pct: 45 }
         - { trigger_pct: 35, lock_hw_pct: 65 }
         - { trigger_pct: 55, lock_hw_pct: 78 }

--- a/strategies/meerkat/strategy.yaml
+++ b/strategies/meerkat/strategy.yaml
@@ -8,7 +8,7 @@
 schema_version: 1
 
 id: meerkat
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Meerkat — Momentum-Event Sniper"
   emoji: "🦦"

--- a/strategies/mongoose/long/runtime.yaml
+++ b/strategies/mongoose/long/runtime.yaml
@@ -108,14 +108,17 @@ exit:
       enabled: true
       interval_in_minutes: 960            # 16h — recycle a position going nowhere
     phase1:
-      enabled: true
-      max_loss_pct: 16.0                  # slightly wider than equity-only (HYPE vol in basket)
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (10% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 10.0   # was 16.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 10
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 10,  lock_hw_pct: 0 }    # priming tier (arms the trail; no lock yet)
         - { trigger_pct: 20,  lock_hw_pct: 40 }   # first LOCK — reachable
         - { trigger_pct: 35,  lock_hw_pct: 60 }
         - { trigger_pct: 60,  lock_hw_pct: 78 }

--- a/strategies/mongoose/short/runtime.yaml
+++ b/strategies/mongoose/short/runtime.yaml
@@ -103,14 +103,17 @@ exit:
       enabled: true
       interval_in_minutes: 720            # 12h — recycle a short going nowhere
     phase1:
-      enabled: true
-      max_loss_pct: 12.0                  # tighter than long book — squeeze protection
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (7% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 7.0   # was 12.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 7
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 8,   lock_hw_pct: 0 }    # priming tier (arms the trail; no lock yet)
         - { trigger_pct: 18,  lock_hw_pct: 45 }   # first LOCK — reachable
         - { trigger_pct: 35,  lock_hw_pct: 65 }
         - { trigger_pct: 60,  lock_hw_pct: 80 }

--- a/strategies/mongoose/strategy.yaml
+++ b/strategies/mongoose/strategy.yaml
@@ -8,7 +8,7 @@
 schema_version: 1
 
 id: mongoose
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Mongoose — On-Chain Finance vs Legacy"

--- a/strategies/octopus/long/runtime.yaml
+++ b/strategies/octopus/long/runtime.yaml
@@ -95,14 +95,17 @@ exit:
       enabled: true
       interval_in_minutes: 720            # 12h — recycle a position going nowhere
     phase1:
-      enabled: true
-      max_loss_pct: 14.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (8% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 8
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 8,   lock_hw_pct: 0 }    # priming tier (arms the trail; no lock yet)
         - { trigger_pct: 18,  lock_hw_pct: 40 }   # first LOCK — reachable on a real dispersion winner
         - { trigger_pct: 35,  lock_hw_pct: 60 }
         - { trigger_pct: 60,  lock_hw_pct: 78 }

--- a/strategies/octopus/short/runtime.yaml
+++ b/strategies/octopus/short/runtime.yaml
@@ -96,14 +96,17 @@ exit:
       enabled: true
       interval_in_minutes: 720            # 12h — recycle a position going nowhere
     phase1:
-      enabled: true
-      max_loss_pct: 14.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (8% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 8
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 8,   lock_hw_pct: 0 }    # priming tier (arms the trail; no lock yet)
         - { trigger_pct: 18,  lock_hw_pct: 40 }   # first LOCK — reachable on a real dispersion winner
         - { trigger_pct: 35,  lock_hw_pct: 60 }
         - { trigger_pct: 60,  lock_hw_pct: 78 }

--- a/strategies/octopus/strategy.yaml
+++ b/strategies/octopus/strategy.yaml
@@ -7,7 +7,7 @@
 schema_version: 1
 
 id: octopus
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Octopus — Market-Neutral Crypto Long/Short"

--- a/strategies/orangutan/main/runtime.yaml
+++ b/strategies/orangutan/main/runtime.yaml
@@ -111,14 +111,17 @@ exit:
       interval_in_minutes: 10080       # 7d — matches the weekly recalibration
       min_value: 2.5
     phase1:
-      enabled: true
-      max_loss_pct: 20.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (9% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 9
       retrace_threshold: 9
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 10, lock_hw_pct: 0 }
         - { trigger_pct: 25, lock_hw_pct: 40 }
         - { trigger_pct: 55, lock_hw_pct: 62 }
         - { trigger_pct: 100, lock_hw_pct: 80 }

--- a/strategies/orangutan/strategy.yaml
+++ b/strategies/orangutan/strategy.yaml
@@ -6,7 +6,7 @@
 schema_version: 1
 
 id: orangutan
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Orangutan — Rotation Rider (Weekly)"
   emoji: "🦧"

--- a/strategies/orca/main/runtime.yaml
+++ b/strategies/orca/main/runtime.yaml
@@ -112,14 +112,17 @@ exit:
       enabled: true                         # v2: enabled, 15m
       interval_in_minutes: 15
     phase1:
-      enabled: true
-      max_loss_pct: 20.0                     # v2 phase1.max_loss_pct
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (8% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 8.0   # was 20.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8                   # v2: raised 3->8 (HYPE post-mortem) to give trends room
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:                                 # v2 v4.0.1 "let winners run" ladder (verbatim)
-        - { trigger_pct: 10,  lock_hw_pct: 0 }
         - { trigger_pct: 20,  lock_hw_pct: 25 }
         - { trigger_pct: 30,  lock_hw_pct: 40 }
         - { trigger_pct: 50,  lock_hw_pct: 60 }

--- a/strategies/orca/strategy.yaml
+++ b/strategies/orca/strategy.yaml
@@ -7,7 +7,7 @@
 schema_version: 1
 
 id: orca
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Orca — Gen-1 Vanilla Striker"

--- a/strategies/osprey/main/runtime.yaml
+++ b/strategies/osprey/main/runtime.yaml
@@ -120,14 +120,18 @@ exit:
       enabled: false                       # v2: DISABLED
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 18.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (10.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 10.0   # was 18.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 10
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:                               # wide-by-design; FIRST lock at +10% ROE (reachable)
-        - { trigger_pct: 10, lock_hw_pct: 0 }
         - { trigger_pct: 20, lock_hw_pct: 45 }
         - { trigger_pct: 35, lock_hw_pct: 65 }
         - { trigger_pct: 55, lock_hw_pct: 78 }

--- a/strategies/osprey/strategy.yaml
+++ b/strategies/osprey/strategy.yaml
@@ -9,7 +9,7 @@
 schema_version: 1
 
 id: osprey
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Osprey — Cross-Venue Lag (Crypto -> XYZ Equity)"
   emoji: "🦅"

--- a/strategies/otter/main/runtime.yaml
+++ b/strategies/otter/main/runtime.yaml
@@ -108,8 +108,13 @@ exit:
       enabled: true
       interval_in_minutes: 90                # flat positions = thesis expired
     phase1:
-      enabled: true
-      max_loss_pct: 12.0                      # ~2.4% price stop at 5x — clean cut on flow reversal
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (5.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 5.0   # was 12.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 5
       consecutive_breaches_required: 1
     phase2:

--- a/strategies/otter/strategy.yaml
+++ b/strategies/otter/strategy.yaml
@@ -7,7 +7,7 @@
 schema_version: 1
 
 id: otter
-version: "1.0.1"
+version: "1.1.0"
 
 catalog:
   name: "Otter — Open Interest Velocity Hunter"

--- a/strategies/owl/main/runtime.yaml
+++ b/strategies/owl/main/runtime.yaml
@@ -109,8 +109,13 @@ exit:
       enabled: true
       interval_in_minutes: 30               # v6.0 Lemon-pattern fast loser cut
     phase1:
-      enabled: true
-      max_loss_pct: 35.0                     # wide — contrarian entries retrace hard before working
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (8.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 8.0   # was 35.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8                   # v2 dsl_preset block value (NOT the "15" in the prose)
       consecutive_breaches_required: 1       # v2 dsl_preset block value (NOT the "3" in the prose)
     phase2:

--- a/strategies/owl/strategy.yaml
+++ b/strategies/owl/strategy.yaml
@@ -7,7 +7,7 @@
 schema_version: 1
 
 id: owl
-version: "1.0.1"
+version: "1.1.0"
 
 catalog:
   name: "Owl — Contrarian Crowding-Unwind Hunter"

--- a/strategies/ox/ballast/runtime.yaml
+++ b/strategies/ox/ballast/runtime.yaml
@@ -107,14 +107,17 @@ exit:
       enabled: false
       interval_in_minutes: 1440
     phase1:
-      enabled: true
-      max_loss_pct: 14.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (9% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 9
       retrace_threshold: 9
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 10, lock_hw_pct: 0 }
         - { trigger_pct: 22, lock_hw_pct: 45 }
         - { trigger_pct: 45, lock_hw_pct: 65 }
         - { trigger_pct: 80, lock_hw_pct: 80 }

--- a/strategies/ox/core/runtime.yaml
+++ b/strategies/ox/core/runtime.yaml
@@ -102,14 +102,17 @@ exit:
       enabled: false
       interval_in_minutes: 1440
     phase1:
-      enabled: true
-      max_loss_pct: 16.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (10% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 10
       retrace_threshold: 10
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 12, lock_hw_pct: 0 }
         - { trigger_pct: 25, lock_hw_pct: 45 }
         - { trigger_pct: 50, lock_hw_pct: 65 }
         - { trigger_pct: 90, lock_hw_pct: 80 }

--- a/strategies/ox/strategy.yaml
+++ b/strategies/ox/strategy.yaml
@@ -15,7 +15,7 @@
 schema_version: 1
 
 id: ox
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Ox — Risk-Parity / All-Weather"

--- a/strategies/oxpecker/main/runtime.yaml
+++ b/strategies/oxpecker/main/runtime.yaml
@@ -130,14 +130,18 @@ exit:
       enabled: false
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 20.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (10.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 10.0   # was 20.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 10
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:                                 # wide-by-design; FIRST lock at +10% ROE (reachable)
-        - { trigger_pct: 10, lock_hw_pct: 0 }
         - { trigger_pct: 20, lock_hw_pct: 45 }
         - { trigger_pct: 35, lock_hw_pct: 65 }
         - { trigger_pct: 55, lock_hw_pct: 78 }

--- a/strategies/oxpecker/strategy.yaml
+++ b/strategies/oxpecker/strategy.yaml
@@ -11,7 +11,7 @@
 schema_version: 1
 
 id: oxpecker
-version: "1.0.1"
+version: "1.1.0"
 
 catalog:
   name: "Oxpecker — Elite-Conviction Concentrated Mirror"

--- a/strategies/pangolin/main/runtime.yaml
+++ b/strategies/pangolin/main/runtime.yaml
@@ -109,8 +109,13 @@ exit:
       enabled: true
       interval_in_minutes: 480               # 8h = one full funding cycle
     phase1:
-      enabled: true
-      max_loss_pct: 30.0                      # 10% price buffer at 3x
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (10.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 10.0   # was 30.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 10
       consecutive_breaches_required: 1
     phase2:

--- a/strategies/pangolin/strategy.yaml
+++ b/strategies/pangolin/strategy.yaml
@@ -7,7 +7,7 @@
 schema_version: 1
 
 id: pangolin
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Pangolin — Funding-Rate Fader"

--- a/strategies/piranha/main/runtime.yaml
+++ b/strategies/piranha/main/runtime.yaml
@@ -109,14 +109,17 @@ exit:
       enabled: false                         # v2: DISABLED
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 18.0                      # v2 phase1 max_loss_pct
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (8% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 8.0   # was 18.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8                    # v2 phase1 retrace_threshold
       consecutive_breaches_required: 1        # v2 phase1 consecutive_breaches_required
     phase2:
       enabled: true
       tiers:                                  # v2 phase2 ladder verbatim; FIRST lock at +10% ROE (reachable)
-        - { trigger_pct: 10, lock_hw_pct: 0 }
         - { trigger_pct: 20, lock_hw_pct: 25 }
         - { trigger_pct: 30, lock_hw_pct: 40 }
         - { trigger_pct: 50, lock_hw_pct: 60 }

--- a/strategies/piranha/strategy.yaml
+++ b/strategies/piranha/strategy.yaml
@@ -8,7 +8,7 @@
 schema_version: 1
 
 id: piranha
-version: "1.0.2"
+version: "1.1.0"
 catalog:
   name: "Piranha — Liquidation-Cascade / Forced-Flow Hunter"
   emoji: "🐟"

--- a/strategies/polar/main/runtime.yaml
+++ b/strategies/polar/main/runtime.yaml
@@ -102,8 +102,13 @@ exit:
     execution_timeout_seconds: 60
   dsl_preset:
     phase1:
-      enabled: true
-      max_loss_pct: 25.0                   # v2 polar Phase 1 (NOT kodiak 15)
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (8.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 8.0   # was 25.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8                 # v2 polar (NOT kodiak 5)
       consecutive_breaches_required: 1
     phase2:

--- a/strategies/polar/strategy.yaml
+++ b/strategies/polar/strategy.yaml
@@ -7,7 +7,7 @@
 schema_version: 1
 
 id: polar
-version: "1.0.2"
+version: "1.1.0"
 catalog:
   name: "Polar — ETH Alpha Hunter"
   emoji: "🧊"

--- a/strategies/python/main/runtime.yaml
+++ b/strategies/python/main/runtime.yaml
@@ -113,8 +113,13 @@ exit:
       enabled: true                        # v2: ENABLED — 24h no movement = dead
       interval_in_minutes: 1440
     phase1:
-      enabled: true
-      max_loss_pct: 20.0                    # v2: patient on losers too
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (10.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 10.0   # was 20.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 10
       consecutive_breaches_required: 1     # Senpi runtime is single-breach only
     phase2:

--- a/strategies/python/strategy.yaml
+++ b/strategies/python/strategy.yaml
@@ -7,7 +7,7 @@
 schema_version: 1
 
 id: python
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Python — The Patience Hunter"

--- a/strategies/raccoon/main/runtime.yaml
+++ b/strategies/raccoon/main/runtime.yaml
@@ -98,8 +98,12 @@ exit:
       enabled: false                        # DISABLED (v2)
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 12.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (8% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 8
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:

--- a/strategies/raccoon/strategy.yaml
+++ b/strategies/raccoon/strategy.yaml
@@ -6,7 +6,7 @@
 schema_version: 1
 
 id: raccoon
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Raccoon — Weekend XYZ Reconciliation"

--- a/strategies/ram/main/runtime.yaml
+++ b/strategies/ram/main/runtime.yaml
@@ -100,14 +100,17 @@ exit:
       interval_in_minutes: 2880            # 48h — a stalled gold position frees its slot
       min_value: 2.5
     phase1:
-      enabled: true
-      max_loss_pct: 12.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (7% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 7
       retrace_threshold: 7
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 8,  lock_hw_pct: 0 }    # T0 — breakeven arm (locks nothing yet)
         - { trigger_pct: 18, lock_hw_pct: 40 }   # T1 — first real profit lock
         - { trigger_pct: 35, lock_hw_pct: 62 }   # T2
         - { trigger_pct: 60, lock_hw_pct: 80 }   # T3 — parabolic extension

--- a/strategies/ram/strategy.yaml
+++ b/strategies/ram/strategy.yaml
@@ -7,7 +7,7 @@
 schema_version: 1
 
 id: ram
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Ram — Gold Specialist"

--- a/strategies/raptor/main/runtime.yaml
+++ b/strategies/raptor/main/runtime.yaml
@@ -114,8 +114,13 @@ exit:
       enabled: true
       interval_in_minutes: 40
     phase1:
-      enabled: true
-      max_loss_pct: 25.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (10.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 10.0   # was 25.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 10
       consecutive_breaches_required: 1
     phase2:

--- a/strategies/raptor/strategy.yaml
+++ b/strategies/raptor/strategy.yaml
@@ -8,7 +8,7 @@
 schema_version: 1
 
 id: raptor
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Raptor — Hot-Streak Follower"

--- a/strategies/raven/main/runtime.yaml
+++ b/strategies/raven/main/runtime.yaml
@@ -116,14 +116,17 @@ exit:
       interval_in_minutes: 1440        # 24h — a stalled momentum name frees its slot
       min_value: 2.5
     phase1:
-      enabled: true
-      max_loss_pct: 15.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (8% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 8
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 8,  lock_hw_pct: 0 }
         - { trigger_pct: 15, lock_hw_pct: 35 }
         - { trigger_pct: 25, lock_hw_pct: 52 }
         - { trigger_pct: 40, lock_hw_pct: 65 }

--- a/strategies/raven/strategy.yaml
+++ b/strategies/raven/strategy.yaml
@@ -6,7 +6,7 @@
 schema_version: 1
 
 id: raven
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Raven — Self-Calibrating Momentum"
   emoji: "🐦‍⬛"

--- a/strategies/remora/main/runtime.yaml
+++ b/strategies/remora/main/runtime.yaml
@@ -128,14 +128,18 @@ exit:
       enabled: false
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 18.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (10.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 10.0   # was 18.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 10
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 10, lock_hw_pct: 0 }
         - { trigger_pct: 20, lock_hw_pct: 45 }
         - { trigger_pct: 35, lock_hw_pct: 65 }
         - { trigger_pct: 55, lock_hw_pct: 78 }

--- a/strategies/remora/strategy.yaml
+++ b/strategies/remora/strategy.yaml
@@ -12,7 +12,7 @@
 schema_version: 1
 
 id: remora
-version: "1.1.1"
+version: "1.2.0"
 
 catalog:
   name: "Remora — Autonomous Smart-Money Whale Mirror"

--- a/strategies/rhino/escalation/runtime.yaml
+++ b/strategies/rhino/escalation/runtime.yaml
@@ -103,8 +103,12 @@ exit:
       enabled: true
       interval_in_minutes: 360            # 6h
     phase1:
-      enabled: true
-      max_loss_pct: 12.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (8% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 8
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:

--- a/strategies/rhino/hedge/runtime.yaml
+++ b/strategies/rhino/hedge/runtime.yaml
@@ -102,14 +102,17 @@ exit:
       enabled: false
       interval_in_minutes: 1440
     phase1:
-      enabled: true
-      max_loss_pct: 16.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (10% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 10
       retrace_threshold: 10
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 12,  lock_hw_pct: 0 }
         - { trigger_pct: 25,  lock_hw_pct: 45 }
         - { trigger_pct: 50,  lock_hw_pct: 65 }
         - { trigger_pct: 90,  lock_hw_pct: 80 }

--- a/strategies/rhino/strategy.yaml
+++ b/strategies/rhino/strategy.yaml
@@ -6,7 +6,7 @@
 schema_version: 1
 
 id: rhino
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Rhino — Tail-Risk / Crisis-Alpha Hedge Fund"

--- a/strategies/roach/main/runtime.yaml
+++ b/strategies/roach/main/runtime.yaml
@@ -118,8 +118,12 @@ exit:
       enabled: true
       interval_in_minutes: 25              # v1.1: 8 -> 25
     phase1:
-      enabled: true
-      max_loss_pct: 18.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (3% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 3
       retrace_threshold: 3
       consecutive_breaches_required: 1
     phase2:

--- a/strategies/roach/strategy.yaml
+++ b/strategies/roach/strategy.yaml
@@ -9,7 +9,7 @@
 schema_version: 1
 
 id: roach
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Roach — Striker Rank-Jump Sniper"

--- a/strategies/rooster/main/runtime.yaml
+++ b/strategies/rooster/main/runtime.yaml
@@ -112,14 +112,17 @@ exit:
       enabled: false
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 15.0                   # tighter than a swing: an open that goes wrong goes fast
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (8% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 8.0   # was 15.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:                               # bank the open move early, then let a real trend breathe
-        - { trigger_pct: 6, lock_hw_pct: 0 }
         - { trigger_pct: 12, lock_hw_pct: 30 }
         - { trigger_pct: 20, lock_hw_pct: 50 }
         - { trigger_pct: 35, lock_hw_pct: 65 }

--- a/strategies/rooster/strategy.yaml
+++ b/strategies/rooster/strategy.yaml
@@ -4,7 +4,7 @@
 schema_version: 1
 
 id: rooster
-version: "1.0.2"
+version: "1.1.0"
 catalog:
   name: "Rooster — The Opener"
   emoji: "🐓"

--- a/strategies/rotator/main/runtime.yaml
+++ b/strategies/rotator/main/runtime.yaml
@@ -92,14 +92,18 @@ exit:
     hard_timeout: { enabled: true, interval_in_minutes: 2880 }              # 48h — full turnover
     weak_peak_cut: { enabled: true, interval_in_minutes: 1440, min_value: 2.5 }  # free a stalled slot in ~1d
     phase1:
-      enabled: true
-      max_loss_pct: 15.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (8.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 8.0   # was 15.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 6,  lock_hw_pct: 0 }
         - { trigger_pct: 15, lock_hw_pct: 40 }
         - { trigger_pct: 35, lock_hw_pct: 62 }
         - { trigger_pct: 70, lock_hw_pct: 80 }

--- a/strategies/rotator/strategy.yaml
+++ b/strategies/rotator/strategy.yaml
@@ -6,7 +6,7 @@
 schema_version: 1
 
 id: rotator
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Rotator — Scheduled Conviction Rebalance"

--- a/strategies/sailfish/main/runtime.yaml
+++ b/strategies/sailfish/main/runtime.yaml
@@ -102,14 +102,18 @@ exit:
       enabled: false
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 12.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (8.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 8.0   # was 12.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:                               # first lock at +8% ROE (well under +40% — no flag)
-        - { trigger_pct: 8,  lock_hw_pct: 0 }
         - { trigger_pct: 15, lock_hw_pct: 40 }
         - { trigger_pct: 25, lock_hw_pct: 60 }
         - { trigger_pct: 40, lock_hw_pct: 75 }

--- a/strategies/sailfish/strategy.yaml
+++ b/strategies/sailfish/strategy.yaml
@@ -8,7 +8,7 @@
 schema_version: 1
 
 id: sailfish
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Sailfish — Relative-Strength Rotator"

--- a/strategies/salamander/main/runtime.yaml
+++ b/strategies/salamander/main/runtime.yaml
@@ -116,14 +116,17 @@ exit:
       enabled: false                        # v2: DISABLED
       interval_in_minutes: 90
     phase1:
-      enabled: true
-      max_loss_pct: 10.0                     # v2: WIDE floor — pullbacks within a trend need room
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (6% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 6.0   # was 10.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 6
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:                                # wide-by-design "let winners run"; FIRST lock at +10% ROE (NOT >+40%)
-        - { trigger_pct: 10,  lock_hw_pct: 0  }
         - { trigger_pct: 20,  lock_hw_pct: 25 }
         - { trigger_pct: 30,  lock_hw_pct: 40 }
         - { trigger_pct: 50,  lock_hw_pct: 60 }

--- a/strategies/salamander/strategy.yaml
+++ b/strategies/salamander/strategy.yaml
@@ -10,7 +10,7 @@
 schema_version: 1
 
 id: salamander
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Salamander — Pullback Catcher"
   emoji: "🦎"

--- a/strategies/salmon/main/runtime.yaml
+++ b/strategies/salmon/main/runtime.yaml
@@ -101,14 +101,17 @@ exit:
       interval_in_minutes: 720          # 12h — a stalled reversion frees its slot
       min_value: 2.0
     phase1:
-      enabled: true
-      max_loss_pct: 8.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (6% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 6
       retrace_threshold: 6
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 6,  lock_hw_pct: 0 }
         - { trigger_pct: 12, lock_hw_pct: 40 }
         - { trigger_pct: 20, lock_hw_pct: 60 }
         - { trigger_pct: 35, lock_hw_pct: 75 }

--- a/strategies/salmon/strategy.yaml
+++ b/strategies/salmon/strategy.yaml
@@ -8,7 +8,7 @@
 schema_version: 1
 
 id: salmon
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Salmon — RSI Mean-Reversion"
   emoji: "🐟"

--- a/strategies/scorpion/main/runtime.yaml
+++ b/strategies/scorpion/main/runtime.yaml
@@ -108,8 +108,13 @@ exit:
       enabled: true
       interval_in_minutes: 60              # v4.1: 30 → 60 (oil consolidates 1h+ before moving)
     phase1:
-      enabled: true
-      max_loss_pct: 15.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (10.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 10.0   # was 15.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 10                # v2 2026-05-14: 6 → 10 (was firing on normal 2-3% pullbacks)
       consecutive_breaches_required: 1
     phase2:
@@ -118,7 +123,6 @@ exit:
         # v2 2026-05-21 Bison "let winners run" ladder. T0 lock=0 gives room before
         # any profit lock — first NON-ZERO lock reachable at +20% (lock 25%). First
         # tier triggers at a reachable +10% (NOT +60-80%).
-        - { trigger_pct: 10,  lock_hw_pct: 0 }
         - { trigger_pct: 20,  lock_hw_pct: 25 }
         - { trigger_pct: 30,  lock_hw_pct: 40 }
         - { trigger_pct: 50,  lock_hw_pct: 60 }

--- a/strategies/scorpion/strategy.yaml
+++ b/strategies/scorpion/strategy.yaml
@@ -6,7 +6,7 @@
 schema_version: 1
 
 id: scorpion
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Scorpion — Multi-Market Momentum Trader"

--- a/strategies/shadow/main/runtime.yaml
+++ b/strategies/shadow/main/runtime.yaml
@@ -86,8 +86,13 @@ exit:
     hard_timeout: { enabled: true, interval_in_minutes: 2880 }      # 48h cap
     weak_peak_cut: { enabled: true, interval_in_minutes: 720, min_value: 2.0 }
     phase1:
-      enabled: true
-      max_loss_pct: 20.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (8.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 8.0   # was 20.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8
       consecutive_breaches_required: 2
     phase2:

--- a/strategies/shadow/strategy.yaml
+++ b/strategies/shadow/strategy.yaml
@@ -6,7 +6,7 @@
 schema_version: 1
 
 id: shadow
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Shadow — Multi-Trader Fresh-Entry Mirror"

--- a/strategies/sheep/main/runtime.yaml
+++ b/strategies/sheep/main/runtime.yaml
@@ -104,14 +104,18 @@ exit:
       enabled: false
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 12.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (8.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 8.0   # was 12.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:                               # first lock at +8% ROE (reachable)
-        - { trigger_pct: 8,  lock_hw_pct: 0 }
         - { trigger_pct: 15, lock_hw_pct: 40 }
         - { trigger_pct: 25, lock_hw_pct: 60 }
         - { trigger_pct: 40, lock_hw_pct: 75 }

--- a/strategies/sheep/strategy.yaml
+++ b/strategies/sheep/strategy.yaml
@@ -7,7 +7,7 @@
 schema_version: 1
 
 id: sheep
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Sheep — Triple-EMA Trend Follower"
   emoji: "🐑"

--- a/strategies/spider/scalp/runtime.yaml
+++ b/strategies/spider/scalp/runtime.yaml
@@ -100,8 +100,12 @@ exit:
       enabled: true
       interval_in_minutes: 25       # at/below break-even after 25m → cut
     phase1:
-      enabled: true
-      max_loss_pct: 5.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (3% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 3
       retrace_threshold: 3
       consecutive_breaches_required: 1
     phase2:

--- a/strategies/spider/strategy.yaml
+++ b/strategies/spider/strategy.yaml
@@ -5,7 +5,7 @@
 schema_version: 1
 
 id: spider                  # == package dir name; == every leg's runtime.yaml `group`
-version: "6.0.3"            # single source for catalog + MCP attribution (skillName/skillVersion)
+version: "6.1.0"            # single source for catalog + MCP attribution (skillName/skillVersion)
 
 catalog:                    # discovery surface. `group` here is the discovery TAXONOMY bucket —
                             # distinct from each runtime.yaml's `group: spider` linkage key.

--- a/strategies/spider/swing/runtime.yaml
+++ b/strategies/spider/swing/runtime.yaml
@@ -107,8 +107,12 @@ exit:
       enabled: false                # patience leg
       interval_in_minutes: 1440
     phase1:
-      enabled: true
-      max_loss_pct: 22.0            # source tolerates deep drawdowns
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (12% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 12.0   # was 22.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 12
       consecutive_breaches_required: 1
     phase2:
@@ -119,7 +123,6 @@ exit:
         # +150% tier cannot be expressed. Dropped; the +100% tier (lock 80%) is now the
         # top of the ladder. All tiers <= 100 are carried verbatim. This is the single
         # threshold that does not map cleanly to the v2 schema.
-        - { trigger_pct: 15, lock_hw_pct: 0 }
         - { trigger_pct: 30, lock_hw_pct: 45 }
         - { trigger_pct: 60, lock_hw_pct: 68 }
         - { trigger_pct: 100, lock_hw_pct: 80 }

--- a/strategies/stag/main/runtime.yaml
+++ b/strategies/stag/main/runtime.yaml
@@ -96,14 +96,18 @@ exit:
       interval_in_minutes: 20160           # 14d — parabolic runs can extend 2-3 weeks
     # weak_peak_cut + dead_weight_cut deliberately OFF — consolidations are NORMAL here
     phase1:
-      enabled: true
-      max_loss_pct: 25.0                    # accept deeper initial drawdown to stay on the bus
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (18.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 18.0   # was 25.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 18                 # accommodate 5-8% intraday gyrations
       consecutive_breaches_required: 2      # one bad bar doesn't trip
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 15,  lock_hw_pct: 0  }   # don't lock anything until +15% — let it build (INTENTIONALLY late)
         - { trigger_pct: 30,  lock_hw_pct: 30 }   # light early lock
         - { trigger_pct: 60,  lock_hw_pct: 55 }
         - { trigger_pct: 120, lock_hw_pct: 72 }

--- a/strategies/stag/strategy.yaml
+++ b/strategies/stag/strategy.yaml
@@ -8,7 +8,7 @@
 schema_version: 1
 
 id: stag
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Stag — Parabolic-Run Hunter"
   emoji: "🦌"

--- a/strategies/stingray/main/runtime.yaml
+++ b/strategies/stingray/main/runtime.yaml
@@ -109,14 +109,17 @@ exit:
       enabled: false                        # multi-day rotation tolerates flat windows
       interval_in_minutes: 45
     phase1:
-      enabled: true
-      max_loss_pct: 30.0                     # wide floor for a swing rotation leg
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (8% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 8.0   # was 30.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:                                 # trend-following ladder; FIRST lock at +10% ROE (reachable)
-        - { trigger_pct: 10, lock_hw_pct: 0 }
         - { trigger_pct: 20, lock_hw_pct: 25 }
         - { trigger_pct: 30, lock_hw_pct: 40 }
         - { trigger_pct: 50, lock_hw_pct: 60 }

--- a/strategies/stingray/strategy.yaml
+++ b/strategies/stingray/strategy.yaml
@@ -8,7 +8,7 @@
 schema_version: 1
 
 id: stingray
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Stingray — Cross-Asset Smart-Money Rotation"

--- a/strategies/terrapin/strategy.yaml
+++ b/strategies/terrapin/strategy.yaml
@@ -6,7 +6,7 @@
 schema_version: 1
 
 id: terrapin
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Terrapin — Turtle-Style Breakout Pyramid"
   emoji: "🐢"

--- a/strategies/terrapin/u1/runtime.yaml
+++ b/strategies/terrapin/u1/runtime.yaml
@@ -106,14 +106,17 @@ exit:
       enabled: false
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 25.0                   # WIDEST — the base rides through the noise
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (10% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 10.0   # was 25.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 10
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:                               # lock LATE, let the core trend run
-        - { trigger_pct: 15, lock_hw_pct: 0 }
         - { trigger_pct: 25, lock_hw_pct: 25 }
         - { trigger_pct: 45, lock_hw_pct: 45 }
         - { trigger_pct: 70, lock_hw_pct: 62 }

--- a/strategies/terrapin/u2/runtime.yaml
+++ b/strategies/terrapin/u2/runtime.yaml
@@ -102,14 +102,17 @@ exit:
       enabled: false
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 22.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (10% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 10
       retrace_threshold: 10
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 12, lock_hw_pct: 0 }
         - { trigger_pct: 22, lock_hw_pct: 28 }
         - { trigger_pct: 38, lock_hw_pct: 48 }
         - { trigger_pct: 60, lock_hw_pct: 65 }

--- a/strategies/terrapin/u3/runtime.yaml
+++ b/strategies/terrapin/u3/runtime.yaml
@@ -102,14 +102,17 @@ exit:
       enabled: false
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 18.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (9% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 9
       retrace_threshold: 9
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 10, lock_hw_pct: 0 }
         - { trigger_pct: 18, lock_hw_pct: 32 }
         - { trigger_pct: 32, lock_hw_pct: 55 }
         - { trigger_pct: 52, lock_hw_pct: 70 }

--- a/strategies/terrapin/u4/runtime.yaml
+++ b/strategies/terrapin/u4/runtime.yaml
@@ -104,14 +104,17 @@ exit:
       enabled: false
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 14.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (8% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 8
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 8, lock_hw_pct: 0 }
         - { trigger_pct: 14, lock_hw_pct: 40 }
         - { trigger_pct: 24, lock_hw_pct: 62 }
         - { trigger_pct: 40, lock_hw_pct: 80 }

--- a/strategies/thesis-fund/main/runtime.yaml
+++ b/strategies/thesis-fund/main/runtime.yaml
@@ -103,14 +103,17 @@ exit:
       enabled: true
       interval_in_minutes: 960            # 16h
     phase1:
-      enabled: true
-      max_loss_pct: 14.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (9% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 9
       retrace_threshold: 9
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 10, lock_hw_pct: 0 }
         - { trigger_pct: 22, lock_hw_pct: 45 }
         - { trigger_pct: 40, lock_hw_pct: 65 }
         - { trigger_pct: 70, lock_hw_pct: 80 }

--- a/strategies/thesis-fund/strategy.yaml
+++ b/strategies/thesis-fund/strategy.yaml
@@ -9,7 +9,7 @@
 schema_version: 1
 
 id: thesis-fund
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Thesis Fund — Bet Your Macro View"

--- a/strategies/tortoise/main/runtime.yaml
+++ b/strategies/tortoise/main/runtime.yaml
@@ -101,14 +101,18 @@ exit:
       enabled: false
       interval_in_minutes: 60
     phase1:
-      enabled: true
-      max_loss_pct: 15.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (10.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 10.0   # was 15.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 10
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 10, lock_hw_pct: 0 }
         - { trigger_pct: 25, lock_hw_pct: 50 }
         - { trigger_pct: 50, lock_hw_pct: 70 }
         - { trigger_pct: 100, lock_hw_pct: 85 }

--- a/strategies/tortoise/strategy.yaml
+++ b/strategies/tortoise/strategy.yaml
@@ -7,7 +7,7 @@
 schema_version: 1
 
 id: tortoise
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Tortoise — DCA Scheduler"

--- a/strategies/viper/main/runtime.yaml
+++ b/strategies/viper/main/runtime.yaml
@@ -100,14 +100,17 @@ exit:
       interval_in_minutes: 1440        # 24h — a stalled structure name frees its slot
       min_value: 2.5
     phase1:
-      enabled: true
-      max_loss_pct: 15.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (8% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 8
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 8,  lock_hw_pct: 0 }
         - { trigger_pct: 15, lock_hw_pct: 35 }
         - { trigger_pct: 25, lock_hw_pct: 52 }
         - { trigger_pct: 40, lock_hw_pct: 65 }

--- a/strategies/viper/strategy.yaml
+++ b/strategies/viper/strategy.yaml
@@ -5,7 +5,7 @@
 schema_version: 1
 
 id: viper
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Viper — SMC/ICT Structure Trader"
   emoji: "🐍"

--- a/strategies/vulture/main/runtime.yaml
+++ b/strategies/vulture/main/runtime.yaml
@@ -121,8 +121,12 @@ exit:
       enabled: true
       interval_in_minutes: 90               # 90min — fast cut on no-movement
     phase1:
-      enabled: true
-      max_loss_pct: 25.0                    # 25% margin loss = ~5% price at 5x; small-cap volatility
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (10% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 10.0   # was 25.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 10                 # v2 value; <= the ~10 cap (first lock stays reachable)
       consecutive_breaches_required: 1
     phase2:

--- a/strategies/vulture/strategy.yaml
+++ b/strategies/vulture/strategy.yaml
@@ -7,7 +7,7 @@
 schema_version: 1
 
 id: vulture                  # == package dir name; == the instance runtime.yaml `group`
-version: "1.0.0"             # single source for catalog + MCP attribution (skillName/skillVersion)
+version: "1.1.0"             # single source for catalog + MCP attribution (skillName/skillVersion)
 
 catalog:                     # discovery surface. `group` here is the discovery TAXONOMY bucket.
   name: "Vulture — Small-Cap Momentum Rider"

--- a/strategies/whalehunter/long/runtime.yaml
+++ b/strategies/whalehunter/long/runtime.yaml
@@ -90,8 +90,13 @@ exit:
     execution_timeout_seconds: 45
   dsl_preset:
     phase1:
-      enabled: true
-      max_loss_pct: 30.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (10.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 10.0   # was 30.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 10
       consecutive_breaches_required: 2
     phase2:

--- a/strategies/whalehunter/short/runtime.yaml
+++ b/strategies/whalehunter/short/runtime.yaml
@@ -89,8 +89,13 @@ exit:
     execution_timeout_seconds: 45
   dsl_preset:
     phase1:
-      enabled: true
-      max_loss_pct: 30.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (10.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 10.0   # was 30.0 — set to the old retrace so the risk cap is unchanged
       retrace_threshold: 10
       consecutive_breaches_required: 2
     phase2:

--- a/strategies/whalehunter/strategy.yaml
+++ b/strategies/whalehunter/strategy.yaml
@@ -5,7 +5,7 @@
 schema_version: 1
 
 id: whalehunter
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "WhaleHunter — Smart-Money Cohort Divergence"

--- a/strategies/wolf/risk_off/runtime.yaml
+++ b/strategies/wolf/risk_off/runtime.yaml
@@ -96,8 +96,12 @@ exit:
       enabled: true
       interval_in_minutes: 480             # 8h (ported verbatim)
     phase1:
-      enabled: true
-      max_loss_pct: 10.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (6% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 6
       retrace_threshold: 6
       consecutive_breaches_required: 1
     phase2:

--- a/strategies/wolf/risk_on/runtime.yaml
+++ b/strategies/wolf/risk_on/runtime.yaml
@@ -96,8 +96,12 @@ exit:
       enabled: false
       interval_in_minutes: 1440
     phase1:
-      enabled: true
-      max_loss_pct: 14.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a favourable move it
+      # could sit BELOW entry and close a winner at a loss. max_loss_pct is set to the old
+      # retrace (9% ROE) so the per-trade risk cap is UNCHANGED — only the ratchet-into-
+      # a-loss behaviour is removed. retrace_threshold below is inert while enabled: false.
+      enabled: false
+      max_loss_pct: 9
       retrace_threshold: 9
       consecutive_breaches_required: 1
     phase2:

--- a/strategies/wolf/strategy.yaml
+++ b/strategies/wolf/strategy.yaml
@@ -9,7 +9,7 @@
 schema_version: 1
 
 id: wolf
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Wolf — Regime-Rotation Hedge Fund"

--- a/strategies/wolverine/main/runtime.yaml
+++ b/strategies/wolverine/main/runtime.yaml
@@ -103,8 +103,13 @@ exit:
     execution_timeout_seconds: 60
   dsl_preset:
     phase1:
-      enabled: true
-      max_loss_pct: 20.0
+      # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
+      # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.
+      # The ratchet must only ever lock a GAIN, or the position rides to the stop.
+      # max_loss_pct := the old retrace (8.0% ROE), which is what the trail was already
+      # enforcing, so the per-trade risk cap is UNCHANGED. retrace_threshold is now inert.
+      enabled: false
+      max_loss_pct: 8.0   # was 20.0 — set to the old retrace so the risk cap is unchanged
       # REVIEW FIX: v2 description claimed retrace 15 (over-wide for a single-breach
       # trailing rule); the actual v2 CODE value was 8. Kept at 8 (<=10, as reviewed):
       # at 5x apex an 8-ROE retrace is a ~1.6% HYPE price leash — distinct from the 20%

--- a/strategies/wolverine/strategy.yaml
+++ b/strategies/wolverine/strategy.yaml
@@ -7,7 +7,7 @@
 schema_version: 1
 
 id: wolverine
-version: "1.0.1"
+version: "1.1.0"
 catalog:
   name: "Wolverine — HYPE Alpha Hunter"
   emoji: "🦡"


### PR DESCRIPTION
**No strategy may churn a user's fees by ratcheting a winner into a loss.** The ratchet locks a **gain**, or the position rides to its **stop**. Nothing in between.

## The defect

Phase-1's floor **trails high-water**. At entry `high_water == entry`, so the floor sits `retrace/leverage` *below* entry and only rises as the position moves our way. **If the favourable excursion is smaller than the trail width, the floor is still under entry when price turns** — so the "ratchet" closes a position that was *in profit* at a **loss**, and the user pays a round trip of fees for it.

Live example (Starling, 1.1.0): a ZEC short reached **+8.5% ROE**, bounced 2.8% off its low, and closed at **−5.9%**. `max_loss` never fired — it sat 16 points further away and was unreachable.

## The fix — and why it is risk-neutral

- **`phase1.enabled: false`** → `phase1BaseFloor()` returns `absoluteFloor` verbatim. The floor no longer trails, so it can never sit below entry after a favourable move.
- **`max_loss_pct` := the old `retrace_threshold`.** The trail always bound first (`retrace < max_loss` on **129/129**), so **`retrace` *was* the effective stop.** Setting `max_loss` to it preserves each strategy's per-trade risk cap **exactly**.
- **Dropped every `lock_hw_pct: 0` rung** (87 across the fleet). A breakeven lock exits flat and still pays fees — a scratch *is* a loss.

**Net: identical downside, strictly more room for winners, no scratch exits.**

## Coverage — all 129, no exceptions

An earlier pass excluded 45 instances (42 with no `time_horizon`, plus fast-horizon and scanner-owned-exit cases) on the argument that a tight trail is correct for a scalper. **That argument does not survive the principle.** A scalper that ticks up 0.3% and gets trailed out at −0.2% is churning fees exactly like a swing follower that ticks up 8.5% and gets trailed out at −5.9%. The scale differs; the defect is identical. All 45 were checked individually — every one has a valid `retrace`, a real stop, and a ladder that survives dropping its breakeven rung — so the same transform applied with no exceptions.

## Verification

All 129 instances carrying a DSL preset, re-parsed and asserted:
- phase1 trailing **OFF**
- a usable `max_loss_pct` remains
- **no rung locks ≤ 0**
- every ladder non-empty and **monotonic** in both trigger and lock
- **risk cap moved on exactly one**: `starling` 14 → 15, the deliberate change in #551

**27/27 strategy test suites pass.** MINOR bump on all 103 affected strategies.

*(A first pass silently missed 36 files whose `max_loss_pct` line carried a trailing comment — the regex required end-of-line after the value. Verification caught it before it shipped as a half-applied fleet change.)*

## Expect this to look different

Fewer exits, larger individual losses, longer holds. Positions that used to scratch out near flat will now either run to a real gain or take the full — unchanged — stop. **Judge on net PnL and fees paid, not on win rate.**