### PR TITLE
discover: publish the 5 new templates + bump the two skills #553 changed

### DIFF
--- a/senpi-strategy-author/SKILL.md
+++ b/senpi-strategy-author/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "3.0.3"
+  version: "3.1.0"
   platform: senpi
   exchange: hyperliquid
   requires:

--- a/senpi-strategy-discover/SKILL.md
+++ b/senpi-strategy-discover/SKILL.md
@@ -15,7 +15,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.17.0"
+  version: "2.18.0"
   platform: senpi
   exchange: hyperliquid
 ---

--- a/senpi-strategy-discover/catalog.json
+++ b/senpi-strategy-discover/catalog.json
@@ -1,6 +1,6 @@
 {
   "_version": "2.1",
-  "_updated": "2026-08-13",
+  "_updated": "2026-08-28",
   "_generated": true,
   "_instructions": "GENERATED from each strategy package's strategy.yaml — do not hand-edit; run senpi-trading-runtime/scripts/gen_catalog.py. Agents read this via senpi-strategy-discover (scripts/discover.py). DECLARED fields (archetype, sub_style, asset_classes, asset_scope, risk_level, tier, belief_plain, direction) are author-set in strategy.yaml `catalog:`; DERIVED fields (assets, leverage_max, funding_split, instance_count, cadence_seconds, time_horizon, max_slots) are computed from instances/params. Labels/glosses come from senpi-strategy-discover/references/glossary.yaml. 'min_budget' is the machine-COMPUTED minimum total budget at which the design functions (min_budget.py) — the smallest budget where every wallet funds and its smallest slot clears the $12 bumped notional; 'wallet_count' + 'min_budget_binding_wallet' explain it. It is NOT authored — deleting an authored min_budget is a no-op; use min_budget_floor to RAISE it. Positions scale with budget above the min. A strategy is a deployable package; install via senpi-strategy-ops.",
   "skills": [
@@ -10,7 +10,7 @@
       "emoji": "🦈",
       "tagline": null,
       "belief_plain": "Continuously scans every liquid crypto and xyz: equity perp for breakouts and breakdowns, opens with the strongest momentum in either direction (confirmed by smart-money positioning, funding squeeze and rising open interest, with a size bonus for the harder-pumping small caps), lets winners run on a trailing stop, and banks the whole book once total profit hits its target.\n",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "You want an always-on screener that hunts the hottest moves across the entire market — long the breakouts, short the breakdowns — instead of watching a fixed basket, and you accept the higher turnover and leverage that pump-chasing implies.\n",
       "tags": [
         "breakout",
@@ -62,7 +62,7 @@
       "emoji": "🦅",
       "tagline": "An onboarding-grade breakout trader on the liquid majors (BTC/ETH/SOL): goes LONG when price breaks above its 7-day high AND smart-money is net long, SHORT when it breaks below the 7-day low AND smart-money is net short, then cuts failed breakouts fast (tight 8% Phase 1) while letting a real one run on a wide Phase 2 ratchet.",
       "belief_plain": "Watches BTC, ETH and SOL. When one of them breaks above its highest price of the last week and the best traders are also leaning long, it buys; when one breaks below its weekly low and the best traders are leaning short, it sells short. A fake breakout gets cut quickly, but a real one is given lots of room to run.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Most breakout strategies lose because they fight the trend, chase fake breakouts into stop-hunts, or hold failed breakouts too long. Hawk requires three things at once — a genuine break of the 7-day range, the 4h trend pointing the same way, and the smart-money leaderboard net in the breakout direction — so it only fires on confirmed breaks. Then the asymmetry does the work: an 8% Phase 1 floor cuts a breakout that fails immediately, while a wide Phase 2 ladder (first lock only at +10% ROE) keeps the rare breakout that runs, because that tail pays for the quiet weeks.",
       "tags": [
         "btc",
@@ -113,7 +113,7 @@
       "emoji": "🐫",
       "tagline": "Harvests funding carry across the liquid main-DEX crypto cross-section: the HARVEST book SHORTS the most-positive-funding names (longs pay shorts → short collects) and the PAYOUT book LONGS the most-negative-funding names (shorts pay longs → paid to hold) — both gated to EXHAUSTING crowds (4h trend + RSI confirmation) so price doesn't fight the carry — on two equally-funded wallets that net the fund slightly market-neutral.",
       "belief_plain": "On Hyperliquid you get paid (or pay) funding every hour for holding a perp. Camel always takes the side that COLLECTS that payment — it shorts coins where longs are paying through the nose, and longs coins where shorts are paying — but only on crowds that are running out of steam, so the price doesn't move against it while it banks the funding.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Funding is a recurring, structural inefficiency: when a trade gets too crowded, the funding rate blows out and the collecting side gets paid to hold. The edge is that carry, not market direction — so Camel ranks the whole liquid crypto board by funding and takes the most-extreme collecting side, but only when the crowded trade is exhausting (4h rolling over for shorts / capitulating for longs, RSI confirming) so price doesn't fight the carry. Taking some shorts and some longs also skews the fund net-neutral as a by-product.",
       "tags": [
         "funding",
@@ -160,7 +160,7 @@
       "emoji": "🦅",
       "tagline": "A contrarian fader on the 6 deepest XYZ macro markets (oil, brent, gold, silver, SP500, XYZ100): when smart money is piled into one side AND the 4h move is exhausting, it takes the OPPOSITE side and lets a wide DSL ride the mean-reversion for hours.",
       "belief_plain": "Trades only macro markets — oil, gold, silver, and the big stock indices — that run around the clock. When the best traders have all crowded into one direction and the move over the last few hours is already stretched, it bets on the snap-back the other way, sizes up when more signals agree, and trails a wide stop so a slow reversal has hours to play out.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Macro assets on Hyperliquid attract directional momentum traders who load up after a clean 1-3% intraday move. By the time smart-money concentration crosses 10-20% on a 4h-extended move, the trade is usually exhausted — mean reversion is the positive-edge play. Bald Eagle scores SM crowding + contribution velocity + move exhaustion, hard-gates on tight book spread, fades the crowd, and gives commodities the wide exit they need to revert.",
       "tags": [
         "xyz",
@@ -217,7 +217,7 @@
       "emoji": "🍋",
       "tagline": "Watches where the worst, most crowded traders are piling in across a fixed basket of 12 crypto majors and 4 commodity/index names — and once that one-sided crowd stops following through (its 15-minute momentum rolls over), takes the OTHER side at conviction-scaled leverage and lets a wide ratcheting stop ride the snap-back.",
       "belief_plain": "When a lot of low-quality traders crowd hard onto one side of a coin and the move starts running out of steam, that crowd usually gets unwound. Lemon waits for the crowding to actually start fading on the 15-minute clock, blocks the trade if it's really a genuine trend (big BTC move or the asset itself ripping), then bets the OPPOSITE direction and trails a wide stop while the over-stretched move mean-reverts.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Hyperliquid is full of high-leverage retail that piles into exhausted moves. A crowded smart-money consensus is only a fade setup once it STOPS following through — so Lemon gates on 15m exhaustion, not just crowding, and refuses to fade a real run (crypto MACRO gate on |BTC 4h|>3%, per-asset gate on |4h|>5%) because fading genuine trend is how a contrarian dies. Concentration + velocity-fade + overextension + reversal compound into a score; it fires the single best fade at score >=9, sizes leverage to conviction, and lets a wide DSL ride the mean reversion since reversals take hours, not minutes.",
       "tags": [
         "degen-fader",
@@ -283,7 +283,7 @@
       "emoji": "🦉",
       "tagline": "Scans every liquid Hyperliquid crypto perp (OI > $3M) for one-sided crowding — extreme funding + lopsided smart money + concentrated OI — then waits for that crowding to persist 1h+ AND for exhaustion to fire (volume fading, price stalling, RSI divergence) before fading the crowd. Conviction-scaled leverage (7/8/10) at 25% margin, with a macro gate that stands down when BTC's 4h move is extreme.",
       "belief_plain": "The crowd is wrong at the extremes. When everyone piles onto one side of a coin — paying punishing funding, the best traders all leaning the same way, open interest stacking up — and the price then stops following through, the unwind is violent and predictable. Owl waits for both the crowded state AND the exhaustion trigger, then takes the other side. Most days it does nothing, because most days one or both is missing.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Crowded trades unwind violently. Owl's edge is timing the unwind: it never fades on crowding alone (which can persist and grind), it waits for crowding to PERSIST 1h+ and for distinct exhaustion signals (declining volume under extreme funding, price stalling against the crowd, capitulation wicks, 4h RSI divergence) to confirm the move is dying. Mean reversion fails in trending macro, so a hard gate blocks all fades when |BTC 4h| > 3%. XYZ banned — the funding/smart-money scoring is calibrated on crypto data shape.",
       "tags": [
         "contrarian",
@@ -329,7 +329,7 @@
       "emoji": "🦔",
       "tagline": "Scans every liquid perp for funding that has stayed extreme for hours — the crowd piled onto one side and is paying to hold it — then fades that crowd at exhaustion, collecting funding while the over-stretched position mean-reverts.",
       "belief_plain": "When everyone crowds the same side of a trade and keeps paying a steep funding fee to stay there for hours, that crowd usually unwinds. Pangolin waits for the crowding to actually persist, checks the smartest traders aren't on the crowd's side, then takes the OTHER side and gets paid funding while it waits for the snap-back.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Persistent extreme funding is a crowding signal, not noise. A fresh funding spike means nothing — but funding that stays extreme for 3+ hours means real positioning that has to unwind. Fade the crowd only once the regime confirms (or is at least neutral), size conservatively because crowded unwinds are violent, and let the funding you collect pay you to be patient through a 24-48h mean reversion.",
       "tags": [
         "funding-fade",
@@ -373,7 +373,7 @@
       "emoji": "🐺",
       "tagline": "Maintains a daily-refreshed pool of the top-ROI Hyperliquid traders (win-rate + age + 30d-ROI filtered, quality-scored toward tail-winner trend-followers), watches for the moment a pool member opens a fresh position, and mirrors only the freshest entries (< 10 min old) when pool consensus and independent TA confirm — sized to the source trader's quality and ridden on its own wide DSL.",
       "belief_plain": "Keeps a shortlist of the most profitable traders on Hyperliquid and refreshes it every day. The instant one of them opens a new trade, Jackal copies that trade in the same direction — but only if the entry is brand new, other shortlisted traders are leaning the same way, and the chart agrees. It bets a bit more behind the highest-quality traders and then trails a wide stop so a good copy can run for days.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "High-quality traders telegraph alpha, but naive copy-trading loses because winners regress, signals lag, and style mismatches amplify risk. Jackal only copies the freshest entries (< 10 min, before the alpha is public) from a pool ranked toward tail-winner trend-followers (ROI 35% / gain-to-pain 25% / age 15% / win-rate 10% — deliberately NOT high-win-rate scalpers), and confirms each copy with pool consensus + independent multi-timeframe TA + funding regime before sizing to the source's quality and riding its OWN DSL rather than the source trader's.",
       "tags": [
         "copy-trading",
@@ -418,7 +418,7 @@
       "emoji": "🐢",
       "tagline": "A time-triggered dollar-cost-averaging scheduler on a small basket (BTC/ETH/SOL): no price prediction, no scoring, no timing — each tick it buys a fixed % of budget on whichever asset is most overdue past its DCA interval, always LONG, and lets a wide DSL ratchet ride the accumulation for days.",
       "belief_plain": "Buys a fixed slice of your budget on a strict schedule — by default every 24 hours, one of BTC, ETH or SOL at a time. It predicts nothing; it just keeps accumulating on cadence and trails a wide stop so the position can run instead of getting churned. The most-overdue coin goes first.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Dollar-cost averaging is the single most accessible trade in crypto and needs zero prediction skill. Every other agent makes a directional call; Tortoise makes none — it buys on a clock. Cadence IS the signal: when an asset has gone longer than the interval since its last buy it is due, never-bought assets are always due, and the most-overdue wins. A very wide let-winners-run DSL (30d hard_timeout) lets the accumulated longs compound while Phase-2 locks bank gains gradually.",
       "tags": [
         "btc",
@@ -470,7 +470,7 @@
       "emoji": "🐦",
       "tagline": "Trades the full pre-IPO → listing → graduation arc of tokenized equities on Hyperliquid XYZ: a pre-listing book accumulates pre-IPO perpetuals (IPOPs) into the IPO, and a graduation book rides the explosive post-conversion price discovery — the SpaceX $1.4B-day-1 pattern.",
       "belief_plain": "Auto-finds brand-new pre-IPO contracts (like a SpaceX-before-it-lists perp) by their tell-tale tiny funding and low leverage cap, rides the trend into the IPO, then detects the moment they convert to a full equity perp and rides the fireworks of the first few days of free price discovery.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "You think the biggest, most repeatable edge on Hyperliquid right now is the new-listing EVENT itself, not the ongoing equity market. Pre-IPO perpetuals trade throttled and quiet; the instant they graduate to a standard equity perp the funding jumps ~100x, the leverage cap lifts and price discovery goes vertical. Capture both halves of that arc with two books on two wallets so the slow accumulation and the explosive pop never fight over the same margin.",
       "tags": [
         "ipo",
@@ -519,7 +519,7 @@
       "emoji": "🐘",
       "tagline": "Trades the cross-asset macro complex — equity indices, precious metals, energy, FX (all on XYZ) plus BTC — on two books and two wallets: the TREND book rides the durable multi-timeframe macro trend (both directions); the FADE book fades short-TF over-extensions back to regime (both directions, with a knife guard). The edge is GLOBAL MACRO — the complex moves on regime, not crypto noise.",
       "belief_plain": "Trades the big global markets — stock indices, gold/silver/copper, oil and gas, the major currencies, and Bitcoin. One book rides the slow, durable trends (buying things going up, shorting things going down); a second book on a separate wallet bets on stretched moves snapping back. It only fades a snap-back when the bigger trend isn't fighting it.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Crypto-only funds all crowd the same coins; the cross-asset macro complex (indices / metals / energy / FX) moves on macro regime — oil on geopolitics, indices on the AI-equity bid, metals on risk-off — and is uncorrelated with crypto noise. Running a trend book AND a mean-reversion book on the same macro whitelist, on two wallets, harvests both the durable direction and the over-extensions without the two conflicting. These markets trade 24/7 on Hyperliquid XYZ, so the fund never has to wait for a market open.",
       "tags": [
         "macro",
@@ -589,7 +589,7 @@
       "emoji": "🦡",
       "tagline": "Only takes the breakout the order flow confirms: enters a prior-24h range break on BTC/ETH/SOL/HYPE only when open interest is RISING (new money committing) AND smart money agrees with the break — then sizes 20% / 5x and lets a wide DSL ratchet ride the move for days.",
       "belief_plain": "Most price breakouts fail. The single best filter for whether a breakout will follow through is open interest: if price breaks its prior 24-hour high (or low) while open interest is rising, new money is committing and the move has conviction. If open interest is flat or falling, it's just stops and short-covering — a fakeout — and Badger skips it. It also checks that the best traders are leaning the same way before it commits.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Open interest is the fuel of a breakout. A price push beyond the recent range confirmed by rising OI = new positions opening in the breakout direction = real follow-through; a breakout on flat/declining OI is shorts covering or stops triggering, with no new money behind it. Gating breakouts on OI velocity (plus smart-money agreement) filters the fakeouts that kill a naive breakout buyer, and a wide let-winners-run exit ladder means the rare confirmed breakout that runs far pays for the ones that don't.",
       "tags": [
         "btc",
@@ -641,7 +641,7 @@
       "emoji": "🦪",
       "tagline": "An autonomous decoupler on Hyperliquid XYZ equity/commodity/index perps: it finds names quietly DECOUPLING from the broad market — outperforming the xyz index on persistent rising volume with shallow, bought dips (relentless accumulation, not a one-bar spike) — and rides the grind. No calendar, no event feed: the catalyst footprint is read straight from the tape. LONG up-accumulation, SHORT down-distribution; a wide DSL ratchet lets winners run.",
       "belief_plain": "Big catalysts — a stock getting added to an index, a buyout brewing, a sector run-up — all leave the same tell in the chart before anyone needs to know the news: the name starts beating the broad market on steady, rising volume, and every dip gets bought instead of selling off. That is accumulation, and Barnacle hunts for it automatically across the stocks, commodities and indices on Hyperliquid XYZ. It doesn't need you to feed it a calendar — it reads the footprint itself, goes long the quiet climbers (or short the quiet bleeders), and trails a stop so a real move can run for days.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "You don't need to know WHY a name is being accumulated to trade the accumulation. Index inclusions, M&A targets, and catalyst run-ups share one observable signature: the name decouples from its benchmark (positive excess return vs the broad xyz market) on PERSISTENT rising volume, and the largest pullback within the move stays shallow because the dips are bought — a grind, not a volatile breakout. Barnacle measures exactly that footprint from market data: excess return vs xyz:XYZ100 sets direction and conviction, 4h volume persistence and a shallow-deepest-dip confirm it's accumulation not noise, 4h/1h trend structure confirms the path, and a smart-money lean nudges the score. Because the edge is read from the tape rather than an event date, the agent needs no operator calendar and the DSL owns the exit — a wide let-winners-run ratchet rides the grind, with a 48h cap so equity/index perps don't camp through the weekend pricing gap.",
       "tags": [
         "accumulation",
@@ -694,7 +694,7 @@
       "emoji": "🦬",
       "tagline": "A patient multi-asset momentum holder on liquid majors (BTC/ETH/SOL): enters only when a 9-factor composite (4h/1h trend structure, 1h/4h momentum, smart-money lean, funding, volume, OI proxy, RSI) clears a high conviction floor, then sizes margin to conviction (25/31/37%) and lets a wide DSL ratchet ride the move for days.",
       "belief_plain": "Trades only the big, liquid coins (BTC, ETH, SOL). It waits until the 4-hour and 1-hour trend, momentum, the best traders, and funding all line up the same way before entering, bets bigger when more of them agree, and then trails a wide stop so a real move can run for days instead of getting chopped out early.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "You want few, high-conviction trades on coins deep enough to size into, not a scattergun across thin small-caps. Restricting to BTC/ETH/SOL kills the small-cap-volume-spike failure mode (a thin coin spiking into the universe and consuming a slot), and a demanding multi-factor floor means the agent only acts when a real directional thesis exists — then it holds, because the edge is in the tail of the move, not the entry.",
       "tags": [
         "btc",
@@ -744,7 +744,7 @@
       "emoji": "🐕",
       "tagline": "Scans the whole liquid market for the patterns traders actually draw and trades whichever way the pattern points. A double bottom goes long once price reclaims the peak between the two lows; a double top goes short on a break of the trough; intact higher-high or lower-low structure is traded as continuation. Every pattern must clear a depth and magnitude floor so noise can't manufacture one, and each coin+pattern fires at most once per 6 hours.",
       "belief_plain": "Instead of watching one coin, this hunts the entire liquid market for recognisable chart setups — the double bottom (a W), the double top (an M), and clean staircase trends. It doesn't take the pattern on faith: the two lows have to be at genuinely the same level, the shape has to be deep enough to matter, and price has to actually break the confirmation line before it commits. It has no opinion on direction — if the chart says down, it shorts. And it won't keep re-entering the same setup, because a pattern that's on the chart today is still there tomorrow.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Pattern recognition is the most common way retail traders actually read a chart, and the catalog had no equivalent — the closest template reads market structure on a single name rather than hunting setups across a universe. The engineering that matters is not finding patterns but refusing bad ones: swing pivots come from a symmetric fractal window (so a pivot needs bars of hindsight on both sides and cannot be invented at the live edge), the two lows of a W must sit within a tolerance of each other and be separated by real time, the shape must clear a depth floor, and continuation structure must STEP by a minimum percent — without that last gate random data produces a clean 'lower low' about half the time. Direction is an output of the pattern, never an input.",
       "tags": [
         "pattern",
@@ -796,7 +796,7 @@
       "emoji": "🐱",
       "tagline": "Two volatility books on two wallets — one scans liquid crypto, the other scans tokenized stocks/commodities/indices (XYZ) — for names coiled in a low-volatility squeeze that break their recent range with an expansion surge, then rides the break direction (LONG up / SHORT down). It trades MOVEMENT, not a view: the edge is that compression precedes expansion.",
       "belief_plain": "Watches the market for coins and stocks that have gone quiet (price barely moving), then pounces the moment one breaks out of its quiet range with a big jump — going long if it breaks up, short if it breaks down. It runs two separate pots: one for crypto, one for tokenized stocks and commodities. The bet is on the size of the move, not its direction.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Volatility is the edge. A breakout FROM a low-volatility coil has far higher follow-through than a breakout in already-volatile tape — compression precedes expansion. Caracal only fires when a name has been coiling (recent ATR << baseline ATR) AND breaks its range AND the breakout bar is an outsized move, then rides whichever way it broke. Splitting crypto (breakout book) from tokenized stocks/commodities/indices (catalyst book) lets it capture oil-geopolitics and AI-infra moves 24/7 alongside crypto vol, on two separately-funded wallets that net to a direction-agnostic volatility harvester.",
       "tags": [
         "volatility",
@@ -851,7 +851,7 @@
       "emoji": "🦅",
       "tagline": "Scans the top 50 Hyperliquid crypto assets by volume and fires at most one position at a time — only when 4h, 1h and 15m momentum all align, the smart-money leaderboard is leaning the same way on a market it is actually concentrated in, and the move isn't a runaway counter-trend. Sizes margin to conviction (50/70/80%) at 10x, then rides a wide DSL.",
       "belief_plain": "Watches every liquid coin on Hyperliquid and waits, doing nothing until ONE setup is near-perfect: the trend, the momentum and the best traders all pointing the same direction at once. Then it takes a single, well-sized swing and trails a stop instead of guessing the top.",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "thesis": "The biggest swings happen when 4h + 1h + 15m momentum are perfectly unified AND the smart-money leaderboard is leaning that same way on a market it has meaningful skin in — a runaway trend's continuation, not a reversal. One amazing trade a day beats a scattergun: scan broadly, fire rarely, size to conviction, and never fight a trend already up >10% on the 4h.",
       "tags": [
         "momentum",
@@ -895,7 +895,7 @@
       "emoji": "🦅",
       "tagline": "Watches every Hyperliquid XYZ pre-IPO perpetual and fires the moment one converts to a normal equity perp — when the company IPOs, funding jumps ~100x, the leverage cap lifts and the price throttle comes off, opening a window of free price discovery. Falcon catches that flip and rides the post-conversion momentum with a wide let-winners-run stop (7d).",
       "belief_plain": "A pre-IPO name on Hyperliquid is deliberately pinned — its price can barely move. The instant the company goes public the brakes come off all at once and the name often trends hard for days. Falcon detects that exact handover from a tell in the funding rate, then takes a single position in the direction it's already running and trails a wide stop so a real move can run.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "The IPOP->equity conversion is a detectable regime change: funding normalizes ~100x, the max-leverage cap lifts, and the trade.xyz Discovery-Bounds price throttle is removed. The first hours-to-days after conversion are pure price discovery, which often trends in one direction. The edge is catching that flip from the instrument's funding/leverage signature, confirming directional momentum, and letting the discovery move run rather than fading it.",
       "tags": [
         "xyz",
@@ -940,7 +940,7 @@
       "emoji": "🐇",
       "tagline": "A fast BTC/ETH scalper that only trades inside the Asia, London, and US high-volume windows — scoring a 30-minute momentum burst backed by real volume, targeting roughly 1:3 risk-reward at 5-10x. Maker-only entries and a hard per-name cooldown keep it from churning into fees.",
       "belief_plain": "This trades only the two most liquid coins, Bitcoin and Ethereum, and only during the hours when the market is actually busy — the Asia, London, and US sessions. It waits for a quick burst of momentum backed by a real jump in volume, takes a leveraged position aiming to make about three times what it risks, and gets out fast if it's wrong. Crucially, it posts its orders to earn the maker rebate instead of paying to chase, and it refuses to re-enter the same coin for 45 minutes — because at this speed, fees are what kill a scalper.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "A sub-hourly scalper lives or dies on cost. The edge — a volume-backed momentum burst at a session open — is real but small, so the whole design is built to protect it: session gating means it only trades when moves are large enough to matter, a volume floor rejects fee-bait bursts on thin tape, maker-only entries turn the fee from a cost into a rebate, and a hard per-name cooldown plus a daily entry cap make churning structurally impossible. The DSL is tuned for asymmetry — a tight stop, a profit-lock that arms at ~3x the risk — so the winners pay for the losers.",
       "tags": [
         "scalp",
@@ -992,7 +992,7 @@
       "emoji": "🦔",
       "tagline": "Equal-weight BTC + ETH + SOL, each leg independently directional: every asset gets its own Smart-Money-confirmed 4h-trend signal (long OR short), so it can hold BTC long and ETH short at the same time — three slots, three independent positions, each with its own per-position stop.",
       "belief_plain": "Trades only the three biggest crypto majors (BTC, ETH, SOL), one position per coin. For each coin it waits until the 4-hour trend and the best traders agree on the same direction before entering — going long if they're bullish, short if they're bearish — and manages each position on its own, so one coin going wrong doesn't drag the others down.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Most basket strategies force the same direction across every asset; Hedgehog doesn't. Each of BTC/ETH/SOL gets its own independent Smart-Money-confirmed 4h-trend decision, so the diversification benefit is real — the per-asset directions are uncorrelated by construction. For a new user who wants 'exposure to crypto majors without picking one,' Hedgehog does the picking: it enters when the gates pass and lets a per-position DSL ratchet ride each leg on its own merits.",
       "tags": [
         "btc",
@@ -1043,7 +1043,7 @@
       "emoji": "🐔",
       "tagline": "Rooster's companion, for stocks. In the 45 minutes before the US market opens (default 13:30 UTC, weekdays only) it reads the pre-open setup on a big-tech equity basket — NVDA, TSLA, AAPL and nine more — and positions into the open across the 3-4 strongest names at once, not just one. Per name: the pre-open drift sets direction, expanding volume confirms real positioning, a break of the prior session's range adds conviction. Ranks every qualifier by score and takes the best few, long or short, 2-5x, with a session-aware DSL ladder that banks the open move and is flat before the weekend.",
       "belief_plain": "The move that matters often shows itself in the 30-60 minutes before the opening bell — and it rarely shows in just one stock. Hen wakes 45 minutes before the US market opens, checks the whole big-tech basket for names drifting one way on real volume, ranks them, and positions into the open across the 3-4 strongest at once. It only runs on trading days (no bell on weekends means nothing to position into), fires at most once per name per open, banks profit early, and a session timeout means nothing is still holding when the weekend arrives. Where Rooster is one BTC leg into the open, Hen is a small equity book into the same event.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Rooster proved the clock is a signal on one asset; Hen runs the same engine as a breadth play across an equity basket. The US cash open (13:30 UTC in EDT, 14:30 in EST) is the most reliable recurring liquidity event of the day, and pre-open drift-on-volume is a directional tell — but on a basket the edge is picking WHICH names are setting up, so Hen scores every name in the window and commits to the top few by conviction rather than betting one. Two things make it equity-correct and not a naive Rooster clone: a TRADING-DAY gate (a weekend or overnight tick finds no open to position into and emits nothing), and a session hard_timeout that guarantees the book is flat before the Friday-to-Sunday XYZ oracle gap. Universe, session times, pre-open window, basket size and the noise floor are all inputs.",
       "tags": [
         "session",
@@ -1108,7 +1108,7 @@
       "emoji": "🐝",
       "tagline": "A semiconductor / AI-capex supply-chain momentum basket on Hyperliquid XYZ (equipment ASML/AMAT/MRVL, logic NVDA/AMD/AVGO/TSM/QCOM/ARM/INTC/SMH, memory MU/SNDK/SMSN/SKHX/WDC): it only trades when the whole chain confirms as a complex — a sector-breadth gate flips it long-only when most names trend up and short-only when the chain rolls over — then rides the strongest 1-2 names, with an extra edge when the equipment makers lead the move. Flat 18% margin / 4x, wide DSL ratchet capped at 48h so it never camps through the weekend pricing gap.",
       "belief_plain": "Trades the semiconductor supply chain — the chip designers, the memory makers, and the equipment companies that build the factories — as perps on Hyperliquid XYZ, 23/5. AI spending bids the whole chain together, so Hornet refuses to trade single names in isolation: it first checks whether the sector as a whole is trending up or down, and only then takes the strongest 1-2 names in that direction. It pays special attention when the equipment makers move first, since that tends to lead the cycle. It trails a wide stop so a real move can run, but caps each hold at 48 hours so it never sits through the Friday-to-Sunday gap when these names have no external price.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "AI capex doesn't bid one chip name — it bids the entire semiconductor supply chain: equipment makers (ASML, AMAT, MRVL), logic/compute (NVDA, AMD, AVGO, TSM, QCOM, ARM, INTC, SMH), and memory (MU, SNDK, SMSN, SKHX, WDC). A per-name momentum agent can get chopped up taking a single semi that's moving on idiosyncratic news against a flat sector. Hornet's edge is that it requires the chain to confirm as a complex first — a sector-breadth gate (the fraction of the universe whose 4h trend is bullish) flips the agent long-only above 0.55 and short-only below 0.35, and emits nothing in the chop band between. Within an open gate it rides the strongest 1-2 names and adds conviction when the equipment sub-group leads (capex tools bid first, then logic and memory — the classic early-cycle gradient). The 48h hard_timeout is intentional: equity perps reconcile against an internal oracle over the weekend gap where drift accumulates without external price discovery.",
       "tags": [
         "semiconductors",
@@ -1177,7 +1177,7 @@
       "emoji": "🦤",
       "tagline": "Two strategies behind one gate. It first decides whether a market is TRENDING or RANGING on the 4-hour chart (Kaufman efficiency ratio + structure), then applies the entry rule that belongs to that regime: a continuation entry when trending — confirmed by RISING open interest, so it only joins moves new money is committing to — or a fade of the range edge when ranging, skipped outright when funding is extreme. In between the two is a deliberate no-trade band. Long & short, 2-5x.",
       "belief_plain": "Most strategies only work in one kind of market: trend-followers get chopped to pieces in a sideways market, and mean-reverters get run over when a real trend starts. Ibis checks which kind of market it's in before deciding what to do. If price is genuinely travelling in one direction it joins the move — but only if open interest is rising, meaning new money is actually backing it. If price is just bouncing in a range it buys the bottom and sells the top instead — unless funding has gotten extreme, which usually means the range is about to break, in which case it stays out. When it can't tell which regime it's in, it does nothing.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "The regime question comes before the entry question, and most retail strategies never ask it — which is why the same rule that prints in a trend bleeds in chop. The Kaufman efficiency ratio (net move divided by the path actually travelled) separates the two cleanly and cheaply: a directional market covers nearly all of its path, a choppy one retraces itself. Each regime then gets the confirmation that specifically protects it — OI velocity for trend entries, because a breakout on flat OI is short-covering rather than commitment; funding extremes for range fades, because crowded funding precedes the break that kills a fader. The gap between the thresholds is a no-trade band by design: an ambiguous regime gets no rule at all, rather than the closest one.",
       "tags": [
         "regime",
@@ -1228,7 +1228,7 @@
       "emoji": "🐦",
       "tagline": "The textbook RSI + MACD setup, supervised: a MACD signal-line crossover (12/26/9) on 1h candles triggers the entry, RSI(14) confirms (room above 50 for longs, below 50 for shorts) and vetoes it at the overbought/oversold extreme, 4h trend structure adds context. Trades a liquid-majors basket (BTC/ETH/SOL/BNB/XRP/AVAX/LINK/DOGE) long & short at 3-5x with a balanced DSL that locks profit from +8% ROE.",
       "belief_plain": "The two indicators everyone knows, run for you the way the textbook says. It waits for MACD to cross its signal line, checks that RSI agrees and isn't already stretched, prefers trades that line up with the 4-hour trend, then trails a stop that starts protecting profit once you're up ~8%. Classic technical analysis on the big, liquid coins — no black box.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "RSI and MACD are the single most-requested retail build ('a strategy based on RSI and MACD'), yet no template was positioned as one. Kingfisher is that on-ramp: a faithful, well-labelled crossover-plus-confirmation strategy on names deep enough to size into, with the runtime owning execution, sizing, slots, and a disciplined trailing exit — so a familiar chart setup becomes a supervised, always-on strategy instead of a manual watch.",
       "tags": [
         "rsi",
@@ -1288,7 +1288,7 @@
       "emoji": "🦤",
       "tagline": "Trades pre-IPO companies as perpetuals on Hyperliquid XYZ — today just SpaceX (xyz:SPCX). Auto-discovers IPOPs via the trade.xyz funding signature (~100x smaller funding) plus a <=5x pre-listing leverage cap and a $100k liquidity floor, then goes long or short when the 4h trend structure and Smart-Money lean agree. Leverage auto-caps to each name's own ceiling; a moderate DSL lets multi-day theses ride.",
       "belief_plain": "Hyperliquid XYZ is one of the only places retail can trade private companies (like SpaceX) as perpetuals before they IPO. Lemur watches those pre-IPO names, waits for the 4-hour trend and the best traders to point the same way, then takes a single directional position and trails a stop. When a company actually goes public it stops qualifying and Lemur drops it automatically.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Pre-IPO perpetuals (IPOPs) are a structurally distinct product — a 0.005 funding multiplier (vs 0.5 for standard XYZ perps) and Discovery Bounds that throttle price velocity. That structural funding signature reliably identifies them with no hardcoded ticker list, so the universe future-proofs itself as trade.xyz lists new names and de-qualifies any that IPO. On those slow-moving names, a clean 4h trend confirmed by Smart-Money direction is enough edge to hold a directional swing and let a wide DSL ratchet capture the multi-day move.",
       "tags": [
         "pre-ipo",
@@ -1336,7 +1336,7 @@
       "emoji": "🐯",
       "tagline": "A multi-asset momentum holder on liquid majors (BTC/ETH/SOL/HYPE) that learns its own conviction floor: every 6 hours it audits its own closed trades, buckets them by entry score, and ratchets its MIN_SCORE up above any score band that has been losing money — then enters only candidates that clear the learned floor and lets a wide DSL ride the move.",
       "belief_plain": "Trades the big, liquid coins (BTC, ETH, SOL, HYPE) on a simple momentum score. Every six hours it looks back at its own finished trades, figures out which score levels have actually been making money and which have been losing, and raises its own bar so it stops taking the kinds of trades that bled — it only ever raises the bar, never lowers it. When a coin clears the current bar it bets and trails a wide stop so a real move can run.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "A fixed entry threshold is a guess that goes stale: the market regime that made score-6 trades profitable last month may make them losers this month. Instead of an operator hand-tuning MIN_SCORE off a 30-trade table, Lynx bakes that loop into a scheduled audit — it reads its own closed-trade history, buckets by the entry score it logged, and raises the floor above any band whose realized ROE has turned negative with enough samples to trust. It ratchets up only (a floor that worked is never relaxed), caps at a hard ceiling, and otherwise runs a plain momentum scorer so the audit always has clean data to learn from.",
       "tags": [
         "btc",
@@ -1389,7 +1389,7 @@
       "emoji": "🦦",
       "tagline": "A sentry that watches the momentum-event feed and snipes the freshest, highest-tier move the instant it fires: tier (event magnitude) + freshness gate the entry, smart-money alignment and rising volume add conviction, then it takes ONE position in the momentum direction and lets a wide DSL ride the burst.",
       "belief_plain": "Watches a live feed of coins that just made a sharp move in the last few hours, and pounces only on the strongest, freshest ones — before the move is widely known. It sizes one bet in the direction of the move and trails a wide stop so a real burst can keep running, but cuts it loose after about a day and a half if it stalls.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Fresh momentum is the earliest, cleanest edge, and it decays fast — an event that's already 30+ minutes old is half-known and somebody else's trade. So the whole job is speed plus selectivity: only the strongest tiers, only while they're fresh, one position at a time. Smart-money lean and rising volume are confirmation bonuses, not gates, because the event fires faster than that data updates — waiting for confirmation forfeits the edge. A momentum burst pays out fast or it's stale, so a short hard timeout cuts a trade that hasn't moved.",
       "tags": [
         "momentum",
@@ -1435,7 +1435,7 @@
       "emoji": "🐋",
       "tagline": "A universe rank-jump sniper: watches the top-50 smart-money leaderboard every tick and fires only on a fresh FIRST_JUMP — a coin exploding 15+ ranks out of the deep field with 4h trend, 15m freshness, and a volume spike all confirming — then strikes ONE position at a fixed 7x and lets the DSL ride the breakout.",
       "belief_plain": "Watches which coins the best traders are suddenly piling into and only acts when a name rockets up the leaderboard from deep in the pack — a fresh jump, not an already-crowded top name. It wants the move to be young (climbing fast in the last 15 minutes), going the same way the price is, and backed by a real volume spike before it takes a single shot.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "The edge is in the FIRST jump, not the established leader. By the time a coin sits at the top of the smart-money board the move is priced in; the asymmetric entry is the moment a name explodes 15+ ranks out of the deep field (prev-rank >= 25) while its 4h trend, 15m contribution velocity, and 24h volume all confirm the same direction at once. That confluence is rare and decays fast, so the right move is to scan often (90s), strike once at a fixed 7x the instant it fires, skip the already-top names, and let a ratcheting DSL — not a fixed target — decide the exit so the occasional big breakout pays for the quiet weeks.",
       "tags": [
         "smart-money",
@@ -1480,7 +1480,7 @@
       "emoji": "🦦",
       "tagline": "Watches the rate of change of open interest across every liquid Hyperliquid crypto perp and fires at most a couple of positions — only when 1h OI jumps >=5% while price moves >=0.5% the same way (fresh leveraged money entering with conviction), 4h isn't unwinding, and the spread is tight. Sizes margin to conviction at 5/7/10x, then rides the flow 1-3h on a tight DSL.",
       "belief_plain": "Open interest only grows when new leveraged money enters a perp. When that money piles in fast (OI up 5%+ in an hour) AND price moves the same direction, that's real conviction — not just a wick. Otter rides that fresh flow for an hour or three, then trails a tight stop. It does nothing on the much more common days when no coin shows that burst, and it never trades unwinds.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "OI velocity — the delta of open interest over time — is a perp-native conviction signal nobody else in the fleet trades (others read OI only as a static size filter). Fresh OI growth aligned with price (the top two quadrants of the OI/price matrix) is new leveraged positioning with direction; unwinds (the bottom two) are exhaustion and get skipped. Confluence scoring (OI tier, 4h confirmation, price magnitude, smart-money lean, spread, time-of-day) at a high floor keeps it a sniper, and a tight DSL locks profit early because the flow edge is in the first 1-3 hours.",
       "tags": [
         "open-interest",
@@ -1526,7 +1526,7 @@
       "emoji": "🐟",
       "tagline": "Rides forced flow on crypto majors (BTC/ETH/SOL/HYPE): when open interest is unwinding fast (positions being force-closed) AND price is moving violently AND the 5-minute candle is still pushing the same way, it takes ONE position in the direction of the flow, sized 1-5x, and lets a wide DSL ratchet ride the squeeze with a 24h outer bound.",
       "belief_plain": "A liquidation cascade is the cleanest momentum in crypto — it's forced flow, not opinion. When lots of positions are being force-closed at once, price gets shoved hard in one direction and the move feeds on itself until the leverage is flushed. Piranha reads the order flow underneath price (open-interest velocity + order-book depth) to confirm the move is forced, then rides it: OI down + price up = shorts squeezed, go long; OI down + price down = longs liquidated, go short.",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "thesis": "Most agents react to price; the edge is reading the forced flow beneath it. Open interest dropping fast means positions are closing under duress, and when that coincides with a violent move and a thinning book on the side price is running into, there is little resistance left and the cascade continues. That signature is short-horizon and self-resolving, so the right move is one conviction entry in the flow direction, a wide ratchet that lets a squeeze extend, and a 24h hard timeout because if the cascade hasn't paid in a day it's over.",
       "tags": [
         "btc",
@@ -1580,7 +1580,7 @@
       "emoji": "🐍",
       "tagline": "Scans the top 50 Hyperliquid crypto assets by volume and waits for one multi-day setup — 4h trend with macro direction, 1h agreeing, 15m confirming, smart money not opposing, RSI not extreme — then takes a single LONG-biased swing at 3-7x, sizes margin to conviction (25/30/40%), and holds for days behind a wide DSL (96h cap).",
       "belief_plain": "Watches every liquid coin on Hyperliquid and does nothing until one setup lines up across the 4-hour, 1-hour and 15-minute timeframes with the best traders on the same side. Then it takes one well-sized, mostly-long swing and holds it for days behind a wide trailing stop, because the money is in the rare multi-day winner — not in trading often.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Every other agent strikes and rotates within hours; none hold for days, and that's the blind spot. The edge isn't a high win rate — it's NOT MISSING the one big multi-day move: a low win rate with a 3:1 win/loss ratio beats a high win rate with a thin one. So scan broadly, demand a real macro trend confirmed across three timeframes (never fighting a runaway counter-trend or a crowded smart-money side), tilt LONG, size to conviction, and let a wide DSL ride the move for days instead of getting chopped out early.",
       "tags": [
         "momentum",
@@ -1626,7 +1626,7 @@
       "emoji": "🐓",
       "tagline": "Trades the clock, not the chart — BTC's reaction to the US stock-market open. In the 45 minutes before the opening bell (default 13:30 UTC, fully configurable) it reads how BTC is setting up: the drift across the window sets direction, expanding volume confirms real positioning, and a break of the prior session's range adds conviction. Carries the position INTO the open, one signal per session, at 2-5x with a session-aware DSL ladder. The asset (BTC by default) and the session time are separate knobs — point it at another market, or another open.",
       "belief_plain": "When Wall Street opens, the risk-on / risk-off flow spills into crypto — and the move often starts setting up in the 30-60 minutes BEFORE the bell. Rooster's signal is a clock, not a chart: by default it wakes 45 minutes before the US equity open (13:30 UTC), checks whether BTC is actually drifting one way on real volume (not just wandering on thin trade), and takes the position into the open. BTC has no open of its own, so the one it trades is borrowed from the stock market. It fires at most once per session, banks profit early, and lets go if the open comes and goes with nothing happening. Both the asset and the session time are inputs you can change.",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "thesis": "Every other template in the catalog reads price; none reads the clock. Session opens are the most reliable recurring liquidity event in any market, and pre-open drift on expanding volume is a genuine directional tell — but only when it clears a noise floor and only when volume confirms it, which is what separates positioning from wandering. The default session is the US equity cash open (13:30 UTC in EDT, 14:30 in EST); BTC is the default asset because equity-open flows move crypto — but both are inputs. Rooster makes the window itself the strategy: outside it the scanner emits nothing and reads nothing (a cheap idle tick), inside it it scores once and commits. The pre-open window, the session times, and the noise floor are all inputs, because the right window is exactly what a user wants to tune.",
       "tags": [
         "session",
@@ -1676,7 +1676,7 @@
       "emoji": "🐠",
       "tagline": "Always hold the strongest major: ranks BTC/ETH/SOL/HYPE by ~2.7-day relative strength each tick and longs the leader, with a leader-RS floor and a margin-vs-runner-up gate to avoid whipsaw on tight races. Single-position; when the held leader exits via the DSL trail, the next tick re-evaluates and enters the new leader — that's the rotation.",
       "belief_plain": "Trades only the big, liquid coins (BTC, ETH, SOL, HYPE). Each cycle it measures which one has been strongest over the last few days and buys that one — but only if it is clearly ahead of the next-best, not in a photo finish. It never sells on its own; a trailing stop manages the exit, and when one leader is done, the next-strongest takes its place.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Among the majors, leadership tends to persist — when one decisively outperforms the others it usually keeps doing so for days. Rotating into the strongest captures that persistence, while the margin-vs-runner-up gate keeps the agent out of tight, whipsaw-prone races where 'the leader' flips every tick. Rotation is realized through the DSL exit (not a mid-position close), so leadership changes only cost a fill when the old leader is genuinely finished — never on noise.",
       "tags": [
         "btc",
@@ -1728,7 +1728,7 @@
       "emoji": "🦎",
       "tagline": "An onboarding-grade pullback trader on the liquid majors (BTC/ETH/SOL): buys a 3-7% dip inside an established bullish 4h trend (and shorts a 3-7% rally inside a bearish one) only when the smart-money leaderboard agrees with the trend direction, then gives the entry room on a wide Phase 1 while a wide Phase 2 ratchet lets the resumed trend run.",
       "belief_plain": "Watches BTC, ETH and SOL. When one is in a clear up-trend on the 4-hour chart and dips 3-7% on the 1-hour chart while the best traders are still leaning long, it buys the dip; in a down-trend it shorts a 3-7% bounce. It needs all three to line up — trend, dip-in-the-band, and smart money agreeing — then it gives the trade room to work and trails a wide stop so the trend can keep running.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Pullbacks inside an established trend are one of the highest-edge setups: the trend has already proved itself, the counter-move offers a better entry, and a smart-money agreement filter screens out trend-break risk. The 3-7% band is the sweet spot — shallower is noise, deeper means the trend may be breaking, so you don't catch a falling knife. Because a resolved pullback resumes a trend that can run far, the exit is asymmetric: a wide Phase 1 floor lets the dip develop without a premature cut, and a wide Phase 2 ratchet (first lock only at +10% ROE) keeps the continuation that pays for the quiet weeks.",
       "tags": [
         "btc",
@@ -1780,7 +1780,7 @@
       "emoji": "🐑",
       "tagline": "A long-only trend follower for beginners: buys a crypto major (BTC/ETH/SOL/HYPE) only when its fast EMA is above its slow EMA on all three timeframes (15m, 1h, 4h) at once, never shorts, and trails a balanced stop so a clean uptrend can run.",
       "belief_plain": "Only buys when a coin is clearly going up by any chart reader's standard — the fast moving average has to be above the slow one on the 15-minute, 1-hour, AND 4-hour chart simultaneously. It never shorts (so there's no 'what's a short?' to learn), bets a little bigger when the trend is wider and the best traders agree, and then trails a stop so a real uptrend can keep running.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Most trend agents pick a single timeframe; Sheep insists on agreement across three before firing. That is a stricter filter (fewer trades) but each entry is 'obviously up' to any chart reader, which is exactly the property a beginner needs to trust the agent. Long-only by design removes the cognitive load of shorting, making this the onboarding-grade entry point into the fleet.",
       "tags": [
         "btc",
@@ -1835,7 +1835,7 @@
       "emoji": "🐆",
       "tagline": "A patient momentum sniper across the whole crypto market: it watches the smart-money leaderboard tick-over-tick and pounces only on a violent rank explosion — an asset rocketing from rank 20+ into the top 10 in one move while 15m smart-money flow is actively building and 4h price agrees — then sizes leverage to conviction (7/10x) and trails a DSL stop.",
       "belief_plain": "Most of the time it does nothing. It only acts when an asset suddenly leaps up the smart-money rankings — from far down into the top 10 in a single step — with fresh money still piling in and price moving the same way. One amazing trade per day, not a stream of mediocre ones.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "The best traders rotate violently. When a coin jumps from rank 20+ into the top 10 in one tick with 15m contribution still accelerating, that's smart money piling in fast — a rare, high-conviction setup worth a concentrated strike. Chasing every hot coin bleeds fees; waiting for the violent first jump is the edge.",
       "tags": [
         "momentum",
@@ -1878,7 +1878,7 @@
       "emoji": "🐅",
       "tagline": "Longs the structural winners of a K-shaped world (the AI complex on Hyperliquid XYZ + crypto winners HYPE/SOL) and shorts the laggards (the broad U.S. market via SP500 + a gated basket of laggard alts) — both trend-confirmed on separate wallets — plus a ~10% pre-IPO ramp satellite that auto-discovers pre-IPO perpetuals (IPOPs) and rides them into their listing.",
       "belief_plain": "The world is splitting into haves and have-nots: AI companies and crypto's winners keep booming while the broad economy and the rest of crypto struggle. Cub buys the booming side and shorts the struggling side at the same time on separate wallets, so it makes money on the GAP between the two — and keeps a small slice aimed at the next SpaceX before it goes public.",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "thesis": "The edge is K-shaped DISPERSION, not market direction. Long the AI complex + HYPE/SOL only while they're actually trending up; short SP500 + laggard alts only while they're actually rolling over; the P&L is the spread between the two speeds. A ~10% pre-IPO sleeve adds optionality — it discovers IPOPs by their leverage signature (fresh perps launch capped low) and longs the ones ramping into their listing. Tokenized equities trade 24/7 on Hyperliquid, so the book never waits for a market open.",
       "tags": [
         "k-shaped",
@@ -1958,7 +1958,7 @@
       "emoji": "🐜",
       "tagline": "Finds the most heavily-traded perps where longs are paying shorts a rich funding rate, and — only when that crowd of longs looks tired (overbought and rolling over, not still charging) — shorts them to collect the funding, hour after hour. Low leverage, a tight stop in case of a squeeze, and it rotates daily, dropping names once the funding dries up.",
       "belief_plain": "When too many traders pile long into a perp, the funding rate turns positive — longs literally pay shorts every hour to hold. Ant gets on the receiving side of that payment by shorting those names, but it's careful: it only shorts when the long crowd is already exhausted, so it's fading a tired move rather than standing in front of a freight train. It keeps size and leverage modest because the money is in the funding, not in calling the direction, and a tight trailing stop caps the damage if a name squeezes.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Perpetual funding is a harvestable yield: sustained positive funding pays shorts. True cash-and-carry hedges the short with long spot for delta-neutral carry, but Senpi is perps-only (no HyperEVM spot execution), so ant runs the DIRECTIONAL half — short the funding-payer — and manages the price risk with an exhaustion entry gate (RSI/structure), low leverage, a tight DSL squeeze-stop, and a 24h rotation. It ranks the top-OI names, requires annualized funding >= targetApr with multi-hour persistence, and never shorts a name still in a fresh uptrend. Not delta-neutral — the missing spot leg is the residual risk (NOTES.md).",
       "tags": [
         "funding",
@@ -2007,7 +2007,7 @@
       "emoji": "🛡️",
       "tagline": "A sleep-at-night strategy that trades only the biggest, most liquid coins, at low leverage (1-2x), with small position sizes and a high bar for entering — so it makes few, careful trades and protects your money first. Tight stops cut losers fast and lock in gains early, and a hard drawdown halt is the backstop. Built to NOT lose money, not to swing for the fences.",
       "belief_plain": "This is the conservative, capital-preservation option. It sticks to the majors (the deepest, most liquid markets), uses low leverage and small sizes, and only opens a position when a real, strong trend lines up — so most of the time it's patient and does nothing. When it is in a trade, a tight trailing stop protects it: it cuts losers quickly and starts locking in profit early instead of giving gains back. A hard 10% drawdown halt stops everything if things go wrong. It won't shoot the lights out — that's the point.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Most users who ask for 'low risk' don't want the highest return — they want to not lose money and to sleep at night. Armadillo is built for exactly that: restricting to the most liquid majors removes the thin-coin blow-up risk, low leverage (1-2x) and small margin cap the downside on any single trade, and a demanding score floor means it only acts on the strongest setups (few, high-quality entries, low turnover so fees don't bleed it). The momentum entry is Bison's validated multi-factor scorer, ported verbatim; the conservatism is entirely in the configuration — a high entry bar and low sizing — not in new, unproven math. The DSL owns every exit with a tight floor and an early profit-lock ladder, and the runtime drawdown_halt is the equity backstop.",
       "tags": [
         "conservative",
@@ -2053,7 +2053,7 @@
       "emoji": "🐒",
       "tagline": "Reads the whole market once a day — the pulse (risk-on/off, dispersion, gold/dollar/VIX) plus where the proven wallets lean — sets a risk posture, and rotates a long/short book across crypto and tokenized stocks/commodities into that posture. It never sells: a regime change just changes what it buys next, and every position is protected by a ratchet stop that does all the exiting.",
       "belief_plain": "Once a day it looks at everything — are markets risk-on or risk-off, is it a rotation day, what's gold and the dollar doing, where's the smart money — and picks a stance. In risk-on it leans into the leaders; in risk-off it rotates into gold/oil and shorts the weak; on a choppy rotation day it plays winners-vs-losers at smaller size. It never manually closes; a trailing stop protects and exits every position, so old bets wind down on their own as the new stance takes over.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Users already run the market-pulse skill and then hand-pick strategies to fit the read. Chimp automates that loop: it re-runs the pulse + smart-money read on a daily clock, re-derives its posture, and expresses the change only through new entries — never by force-closing, so turnover is set by the market (via DSL), not by a scanner re-deciding every minute. Daily recalibration + a moderate DSL make it the nimble regime-follower; Gorilla is the weekly, more-committed sibling.",
       "tags": [
         "regime",
@@ -2104,7 +2104,7 @@
       "emoji": "🐒",
       "tagline": "Reads the whole market once a day, ranks the sectors — semis, software, crypto, indices, commodities — by how they're moving, and rides the rotation: it buys the leaders of the winning sectors and shorts the laggards of the losing ones, biggest when the market is a clean rotation (index calm while sectors split) and smaller when everything moves together. It never sells manually; a trailing stop does all the exiting, so last rotation's winners wind down on their own as the new leaders take over.",
       "belief_plain": "Money constantly rotates between sectors — out of memory chips into AI logic, out of crypto proxies into software, and so on. Once a day Gibbon looks at which sectors are being bought and which are being sold, then buys the strongest names in the winning sectors and shorts the weakest in the losing ones. It leans in hardest on real rotation days and eases off when the whole market just moves together. It never manually closes — a ratchet stop protects and exits every position, so the book rotates as the market does.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "The market-pulse read repeatedly surfaces sector rotation — memory semis dumped while logic semis are bought, crypto proxies sold while software holds. Gibbon automates trading that structure: it re-ranks the sectors daily and expresses the winning-vs-losing rotation as new long/short entries, sized by how much dispersion there actually is. It never force-closes — turnover is set by the market via DSL. Orangutan is the weekly, more-committed sibling.",
       "tags": [
         "rotation",
@@ -2154,7 +2154,7 @@
       "emoji": "🦍",
       "tagline": "The weekly, more-committed sibling of Chimp. Once a week it reads the whole market — the pulse (risk-on/off, dispersion, gold/dollar/VIX) plus where the proven wallets lean — sets a risk posture, and holds a concentrated long/short book across crypto and tokenized stocks/commodities. It never sells: a regime change just changes what it buys next, and a wide trailing stop does all the exiting, letting winners run for weeks.",
       "belief_plain": "Like Chimp, but slower and more committed. Once a week it decides the stance — risk-on lean into leaders, risk-off rotate into gold/oil and short the weak, rotation week play winners-vs-losers small — and holds fewer, bigger positions. It never manually closes; a wide ratchet stop protects each one and lets the winners run, so the book turns over on the market's schedule, not a scanner's.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Same automated pulse-then-allocate loop as Chimp, on a weekly clock with a wider DSL and higher conviction gate — for users who want a deliberate regime-follower that commits to a view and rides it, rather than re-tilting daily. Never force-closes; turnover is set by the market via DSL. Pair with Chimp for a fast + slow allocator sleeve.",
       "tags": [
         "regime",
@@ -2205,7 +2205,7 @@
       "emoji": "🦎",
       "tagline": "Watches BTC's 4-hour move via market_get_cross_asset_flows and strikes the highest-confidence correlated alt that historically follows BTC but hasn't caught up yet — entering the alt in BTC's direction, sized to the tool's confidence score, with a stop that trails the catchup.",
       "belief_plain": "When Bitcoin makes a big 4-hour move, certain alts that usually follow it lag behind for a while before catching up. Mantis spots those laggards (only the ones that follow Bitcoin reliably, with smart money already starting to rotate in) and buys the gap, betting it closes — bigger when it's more confident, with a stop that trails the move.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "The edge is a statistical lag, not a directional view: alts with an 85%+ historical follow-rate and tight timing variance tend to catch up to a confirmed leader move within their typical lag window. Restricting the leader to BTC (the only asset with pre-computed lag data) and requiring smart-money rotation plus a meaningful gap keeps it to high-probability catchups; sizing scales with the tool's confidence, and a dynamic timeout calibrated to each alt's lag distribution backstops trades where the catchup never materialises.",
       "tags": [
         "crypto",
@@ -2253,7 +2253,7 @@
       "emoji": "🐙",
       "tagline": "Ranks the live liquid main-DEX crypto cross-section by 24h relative strength every tick, then LONGS the strongest names (long book) and SHORTS the weakest (short book) — both trend-confirmed — on two equally-funded wallets so the pair is ~market-neutral and harvests crypto dispersion.",
       "belief_plain": "Buys the strongest crypto coins and shorts the weakest at the same time, on two separate wallets, so it makes money on the GAP between winners and losers instead of betting on the whole market going up or down.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "The edge is dispersion, not direction. In a HYPE-dominates / alts-crushed regime the long book gravitates to the leaders and the short book to the carnage, and the two equally-funded notionals offset market beta — so the return is driven by the spread between strong and weak names. The universe is the live liquid board, not a fixed list, so it always ranks whatever is actually trading and liquid right now.",
       "tags": [
         "crypto",
@@ -2299,7 +2299,7 @@
       "emoji": "🦧",
       "tagline": "The weekly, more-committed sibling of Gibbon. Once a week it ranks the sectors — semis, software, crypto, indices, commodities — and commits to the rotation: long the leaders of the winning sectors, short the laggards of the losing ones, biggest when the rotation is decisive. It never sells manually; a wide trailing stop does all the exiting and lets winners run for weeks, so the book turns over on the market's schedule.",
       "belief_plain": "Like Gibbon, but slower and more committed. Once a week it decides which sectors are winning and which are losing, then holds fewer, bigger positions — long the strongest names, short the weakest — and only commits when the rotation is decisive. It never manually closes; a wide ratchet stop protects each position and lets the winners run, so the book rotates on the market's schedule, not a scanner's.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Same automated rank-the-sectors-and-ride loop as Gibbon, on a weekly clock with a wider DSL and a higher rotation threshold — for users who want a deliberate rotation-follower that commits to a theme and rides it, rather than re-ranking daily. Never force-closes; turnover is set by the market via DSL. Pair with Gibbon for a fast + slow rotation sleeve.",
       "tags": [
         "rotation",
@@ -2344,12 +2344,166 @@
       "sort_order": 8
     },
     {
+      "id": "oryx",
+      "name": "Oryx — XYZ Intraday Breakout",
+      "emoji": "🦌",
+      "tagline": "Trades gold, crude oil, metals and the stock indices during the day rather than holding for weeks. It waits for a market to settle into an opening range, then takes the break when real volume backs it — and skips it if price has already run too far to be worth chasing. These markets trade around the clock, so there is no waiting for a bell.",
+      "belief_plain": "Commodities and indices spend the start of a session finding a range, and the move that breaks that range with volume behind it tends to keep going for a few hours. Oryx watches the range form, buys the break up or sells the break down, and refuses the ones that are already extended or too quiet to cover trading costs. It never sells manually — a profit ratchet locks gains and a fixed stop caps the loss.",
+      "version": "1.0.0",
+      "thesis": "You want to trade gold, oil, or the indices on an intraday clock rather than holding a swing position for weeks. Every XYZ template we ship is swing or position; this is the intraday one. Opening-range break, volume-confirmed, chase-capped, and refused outright when the market is too quiet to pay its own round trip.",
+      "tags": [
+        "intraday",
+        "breakout",
+        "opening-range",
+        "gold",
+        "oil",
+        "commodities",
+        "indices",
+        "equities",
+        "xyz",
+        "session",
+        "fee-aware",
+        "long-short",
+        "dsl-only",
+        "no-close"
+      ],
+      "group": "multi-asset-universe",
+      "archetype": "breakout_momentum",
+      "archetype_label": "Breakout / Momentum",
+      "sub_style": "range_break",
+      "sub_style_label": "Buys/sells the break of a multi-day range.",
+      "asset_classes": [
+        "commodities",
+        "indices",
+        "xyz_equities"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 4,
+      "time_horizon": "scalp",
+      "cadence_seconds": 60,
+      "min_budget": 200,
+      "wallet_count": 1,
+      "min_budget_binding_wallet": "main",
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 4,
+      "branch": "main",
+      "sort_order": 9
+    },
+    {
+      "id": "pilotfish",
+      "name": "Pilotfish — Smart-Money Accumulation",
+      "emoji": "🐟",
+      "tagline": "Follows the wallets with a real track record — but only while they are still building a position, not after everyone can see it. It watches how hard that group is leaning on each coin and buys in when the leaning is actively getting stronger, which is the part of the move that has not been priced in yet.",
+      "belief_plain": "Most copy strategies show you what good traders already hold, which is old news by the time you see it. Pilotfish watches the same group of proven wallets and measures whether their commitment to a coin is still growing. When they are actively piling in, it goes with them; when they have simply been sitting on a position for days, it leaves it alone. It never sells manually — a profit ratchet locks gains and a fixed stop caps the loss.",
+      "version": "1.0.0",
+      "thesis": "You want to be early to where proven money is going, not late to where it already is. A standing position is priced; the DERIVATIVE of that positioning is not. Pilotfish reads the cohort's dollar-weighted net bias per name and fires only while it widens — dominant side only, so a minority leg can never be traded, and discounted when the lean rests on too few wallets to mean anything.",
+      "tags": [
+        "smart-money",
+        "copy-trading",
+        "accumulation",
+        "early",
+        "cohort",
+        "conviction",
+        "follows-traders",
+        "derivative",
+        "universe",
+        "long-short",
+        "dsl-only",
+        "no-close"
+      ],
+      "group": "multi-asset-universe",
+      "archetype": "copy_trading",
+      "archetype_label": "Copy-Trader",
+      "sub_style": "sm_crowding",
+      "sub_style_label": "Fades the crowded smart-money side once price stops following.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts",
+        "universe_crypto"
+      ],
+      "asset_scope": "follows_traders",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 4,
+      "time_horizon": "swing",
+      "cadence_seconds": 900,
+      "min_budget": 125,
+      "wallet_count": 1,
+      "min_budget_binding_wallet": "main",
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 5,
+      "branch": "main",
+      "sort_order": 10
+    },
+    {
+      "id": "puffer",
+      "name": "Puffer — Volatility Squeeze",
+      "emoji": "🐡",
+      "tagline": "Waits for a market to go quiet — unusually quiet for that particular coin — and then trades the move when it finally breaks out. Quiet stretches tend to end in a big move; the trick is being positioned for the break rather than getting chopped up inside the calm. It sits on its hands until the release, and then gives the winner a long leash.",
+      "belief_plain": "When a coin's price action tightens up far more than is normal for it, pressure is building and the next move is usually a big one. Puffer measures how compressed each market is against its own history, ignores the quiet itself, and enters only when price finally breaks out with volume behind it. Then it holds on: a profit ratchet locks gains as they build, and a fixed stop caps the downside if the break fails.",
+      "version": "1.0.0",
+      "thesis": "Volatility is mean-reverting: compression precedes expansion. The edge is in the reference frame — compression is measured against each asset's OWN trailing median, so a coil is detected on a sleepy index and a violent alt alike, which an absolute threshold can never do. Trades the release, never the coil, and runs the widest exit in the catalog because cutting an expansion short forfeits the entire reason for taking it.",
+      "tags": [
+        "volatility",
+        "squeeze",
+        "compression",
+        "expansion",
+        "breakout",
+        "bollinger",
+        "coil",
+        "universe",
+        "long-short",
+        "dsl-only",
+        "no-close"
+      ],
+      "group": "multi-asset-universe",
+      "archetype": "breakout_momentum",
+      "archetype_label": "Breakout / Momentum",
+      "sub_style": "volatility_squeeze",
+      "sub_style_label": "Waits for volatility to compress relative to the asset's OWN history, then trades the expansion when it releases.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts",
+        "universe_crypto"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 75,
+      "wallet_count": 1,
+      "min_budget_binding_wallet": "main",
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 5,
+      "branch": "main",
+      "sort_order": 11
+    },
+    {
       "id": "raven",
       "name": "Raven — Self-Calibrating Momentum",
       "emoji": "🐦‍⬛",
       "tagline": "Runs a momentum book across the most liquid names and gets smarter about ITSELF: twice a day it reads its own closed trades, and if it's been losing it becomes more selective and trades smaller, while if it's been winning it loosens up and presses. You don't tune it — it tunes itself, inside guardrails, and a trailing stop does all the exiting.",
       "belief_plain": "A momentum strategy's edge drifts with the regime — what worked last week can bleed this week. Raven opens positions on the same proven momentum signal every time, but it watches its OWN results: after a cold streak it raises the bar for what it'll trade and cuts its size; after a hot streak it leans back in. It never manually closes — a ratchet stop protects and exits every position — and a hard drawdown halt is the backstop if the self-tuning isn't enough.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Momentum entry quality is regime-dependent, and a fixed score threshold is right only some of the time. Raven treats its realized track record (win-rate, profit-factor, losing streak over the last N closed trades) as a live control signal: it ratchets the entry floor up/down and scales conviction sizing between bounded rails on a slow clock. The momentum thesis itself is Bison's validated weighted scorer, ported verbatim; the novelty is the closed-loop self-calibration on top. DSL owns exits; the runtime drawdown_halt is the equity backstop.",
       "tags": [
         "momentum",
@@ -2390,7 +2544,7 @@
       ],
       "max_slots": 6,
       "branch": "main",
-      "sort_order": 9
+      "sort_order": 12
     },
     {
       "id": "rotator",
@@ -2398,7 +2552,7 @@
       "emoji": "🔁",
       "tagline": "On a fixed clock (default every 3 hours) it re-reads the market and rebalances a deliberately concentrated book — never more than two positions, long OR short — ranking candidates on a blended score of cross-asset flows, the funding regime, and live leaderboard momentum events.",
       "belief_plain": "Every few hours this strategy re-underwrites its whole book from scratch. It looks at which alts are lagging a big Bitcoin move and should catch up, whether the crowd is dangerously one-sided on funding (a contrarian warning), and which coins the best traders are piling into right now — then blends those into a single conviction score and holds only the one or two best long-or-short ideas. Weak positions retire on their stop and the next rebalance fills the freed slot.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Concentration plus a fixed re-underwrite clock beats a sprawling always-on book: a small number of high-conviction positions, re-scored every few hours against the freshest short-horizon data, keeps the book aligned with current conditions instead of yesterday's. The three inputs are deliberately short-horizon (4h flows, live funding, 4h momentum events) — not a long-lookback cohort — so the reads match the timescale of the trades. It rotates by attrition rather than force-closing, so it never fights its own DSL.",
       "tags": [
         "rebalance",
@@ -2437,7 +2591,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 10
+      "sort_order": 13
     },
     {
       "id": "salmon",
@@ -2445,7 +2599,7 @@
       "emoji": "🐟",
       "tagline": "Buys the bounce, not the falling knife. It watches the RSI on liquid majors and only steps in when an oversold coin has actually turned back up — a real cross off the lows with the candle confirming — going long the recovery (or short an overbought coin rolling over). It bets price snaps back to its average, sizes moderately because these turns fail fast, and lets a tight trailing stop do all the exiting.",
       "belief_plain": "Trades the big liquid coins by their RSI. When one gets oversold it waits for it to actually turn back up before buying — not while it's still dropping — and when one gets overbought and starts rolling over it shorts the fade. It's betting the price springs back toward its average, keeps size moderate because these bounces can fail quickly, and never closes by hand: a tight stop protects and exits every trade.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Stretched moves revert. When a liquid major gets pushed to an oversold extreme and then genuinely turns — RSI crossing back up through the line while the last candle confirms — the snap back toward the mean is the trade; the symmetric overbought roll-over is the short. The discipline is refusing to catch a falling knife: a low RSI alone is not a signal, only the confirmed cross-back is. Because reversions fail fast, leverage stays moderate and the DSL exit is tight — lock early, cut small.",
       "tags": [
         "mean-reversion",
@@ -2482,16 +2636,16 @@
       ],
       "max_slots": 5,
       "branch": "main",
-      "sort_order": 11
+      "sort_order": 14
     },
     {
       "id": "starling",
       "name": "Starling — Smart-Money Rotation Follower",
       "emoji": "🐦",
-      "tagline": "Watches a flock of the most profitable wallets on Hyperliquid and moves when they do — the instant several of them start piling into the SAME trade in the SAME direction at the SAME time, it buys (or shorts) alongside them, betting more the more of them agree. It only acts on a rotation that's just forming, not a crowd that's been standing in a name for hours, and it never sells manually — a trailing stop does all the exiting, so last week's follows wind down on their own as the flock rotates into the next name.",
+      "tagline": "Watches a flock of the most profitable wallets on Hyperliquid and moves when they do — the instant several of them start piling into the SAME trade in the SAME direction at the SAME time, it buys (or shorts) alongside them, betting more the more of them agree. It only acts on a rotation that's just forming, not a crowd that's been standing in a name for hours, and it never sells manually — a fixed max-loss floor caps the downside while a profit ratchet that can only ever lock GAINS (never breakeven) protects the upside, so winners are given room to run and last week's follows wind down on their own as the flock rotates into the next name.",
       "belief_plain": "The proven winners on Hyperliquid tend to rotate into the same trades at the same time, and the freshest edge is the moment that agreement is FORMING — not once everyone can already see it. Starling keeps a live shortlist of the wallets with the best all-time track record, watches what they're opening, and when enough of them freshly line up on one name in one direction it opens with them, sizing up when the agreement is strongest. It never manually closes — a ratchet stop protects and exits every position, so the book rotates as the smart money does, and a hard drawdown halt is the backstop.",
-      "version": "1.0.1",
-      "thesis": "Cohort copiers average a pool's standing net bias (already priced); Starling instead trades the DERIVATIVE of that bias — the snapshot-to-snapshot change. Each tick it counts, per name and direction, how many proven wallets hold it, and fires only when that count has just crossed the consensus bar or is still rising (newly-formed / growing), never on a stale standing consensus. Conviction sizing scales with the agreement count. It force-closes nothing — turnover is set by the market via DSL (rotate-by-attrition), the same never-close discipline as the gibbon/orangutan rotation riders.",
+      "version": "1.2.0",
+      "thesis": "Cohort copiers average a pool's standing net bias (already priced); Starling instead trades the DERIVATIVE of that bias — the snapshot-to-snapshot change. Each tick it counts, per name and direction, how many proven wallets hold it, takes ONLY the side more of them are on, and fires when that side's NET MARGIN over the other has just become decisive or is still widening — never on the minority side, and never on a margin that is flat or narrowing. Conviction sizing scales with the agreement count. It force-closes nothing — turnover is set by the market via DSL (rotate-by-attrition), the same never-close discipline as the gibbon/orangutan rotation riders.",
       "tags": [
         "smart-money",
         "copy-trading",
@@ -2532,7 +2686,58 @@
       ],
       "max_slots": 6,
       "branch": "main",
-      "sort_order": 12
+      "sort_order": 15
+    },
+    {
+      "id": "swift",
+      "name": "Swift — Fee-Aware Crypto Scalper",
+      "emoji": "🐦",
+      "tagline": "Trades the fast money on the most liquid crypto names — but only when the market is actually moving enough to be worth the fees. Before it even looks at a setup it asks a blunt question: will this move pay for the cost of trading it? If not, it doesn't trade. Most scalpers lose to their own costs; this one refuses the trades that would.",
+      "belief_plain": "Short bursts of momentum on big crypto names are tradeable, but at this speed you pay a fee every single time you go in and out — so the only setups worth taking are the ones moving enough to cover that cost several times over. Swift measures how much a market is actually moving, compares it to what a round trip costs, and skips everything that doesn't clear the bar. It never sells manually — a profit ratchet locks gains and a fixed stop caps the downside.",
+      "version": "1.0.0",
+      "thesis": "You want to trade fast, and you have watched fees quietly eat a scalper alive. The edge here is not a cleverer indicator — it is a hard cost floor applied BEFORE the signal: expected capture (a fraction of ATR) must exceed the round-trip fee by a configured multiple, or the name is never scored. Entries rest as maker first. The ratchet locks gains only; it can never close a winner at a loss.",
+      "tags": [
+        "scalp",
+        "scalping",
+        "intraday",
+        "fast",
+        "fee-aware",
+        "low-fee",
+        "crypto",
+        "momentum",
+        "universe",
+        "long-short",
+        "dsl-only",
+        "no-close"
+      ],
+      "group": "multi-asset-universe",
+      "archetype": "breakout_momentum",
+      "archetype_label": "Breakout / Momentum",
+      "sub_style": "market_structure",
+      "sub_style_label": "Trades SMC/ICT/Wyckoff structure: break-of-structure, liquidity sweeps, fair-value gaps.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts",
+        "universe_crypto"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "aggressive",
+      "tier": "advanced",
+      "leverage_max": 4,
+      "time_horizon": "scalp",
+      "cadence_seconds": 60,
+      "min_budget": 200,
+      "wallet_count": 1,
+      "min_budget_binding_wallet": "main",
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 4,
+      "branch": "main",
+      "sort_order": 16
     },
     {
       "id": "viper",
@@ -2540,7 +2745,7 @@
       "emoji": "🐍",
       "tagline": "Reads a chart the way a smart-money trader does. It marks the recent peaks and troughs, then waits for price to actually break structure — punch through a prior high (or low) — and only takes the trade when the break is backed by a stop-hunt wick that grabbed liquidity and snapped back, a price gap that shows one-sided pressure, and the bigger-picture 4h trend pointing the same way. A trailing stop does all the exiting; Viper never sells manually.",
       "belief_plain": "Markets move from one pool of resting stop orders to the next, and the honest tell is structure: a 'Break of Structure' is price closing past the last swing high or low in the trend's direction (it's continuing), and a 'Change of Character' is the first close through the OPPOSITE swing (the trend may be flipping). Viper enters on those breaks — but only the high-quality ones, where a liquidity sweep (a wick that runs the stops just past a prior swing then closes back inside) and a fair-value gap (a 3-candle imbalance where price left a gap it tends to revisit) agree with it, and the 4h structure confirms. It never manually closes — a ratchet stop protects and exits every position, and a hard drawdown halt is the backstop.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Price is delivered between liquidity pools, and market structure — not an oscillator — is the cleanest read on which pool is next. Viper maps confirmed swing pivots, classifies each close through the most-recent swing as a Break of Structure (continuation) or Change of Character (reversal), and requires SMC/ICT confluence before committing: a liquidity sweep of a prior swing that closes back inside (the stop-hunt / Wyckoff spring), a 3-candle Fair Value Gap in the break direction, and higher-timeframe (4h) structure agreement. Confluence is scored, conviction-banded, and gated to a minimum; sizing scales with conviction and leverage is clamped to the venue max. The edge is entry QUALITY on structure; the DSL owns exits and the runtime drawdown_halt is the equity backstop.",
       "tags": [
         "smc",
@@ -2580,7 +2785,59 @@
       ],
       "max_slots": 6,
       "branch": "main",
-      "sort_order": 13
+      "sort_order": 17
+    },
+    {
+      "id": "weaver",
+      "name": "Weaver — Range Harvester",
+      "emoji": "🕸️",
+      "tagline": "Built for the sideways market, which is when most strategies have nothing to do. It finds coins stuck in a well-defined band, buys near the bottom of it and sells near the top, and takes small, quick profits. Crucially, it refuses to touch anything that has started trending — that is the one market that turns a range trader into a bagholder.",
+      "belief_plain": "Plenty of the time a market isn't going anywhere — it just swings between a floor and a ceiling. Weaver measures whether a coin is genuinely range-bound or quietly trending, and only trades the ones that are truly stuck: buying near the low end, selling near the high end, banking the bounce quickly. If a range starts to break into a trend, it stops trading that name rather than averaging into the move.",
+      "version": "1.0.0",
+      "thesis": "You have watched a trend book sit on its hands through a week of chop and wondered why nothing fired. This is the strategy for that week. Fades the outer fifth of a contained band, and applies a hard Kaufman efficiency-ratio veto so it never grids a trend — the single failure mode that kills range traders. Small, frequent, bounded wins with a fast profit lock.",
+      "tags": [
+        "range",
+        "range-bound",
+        "mean-reversion",
+        "chop",
+        "sideways",
+        "grid",
+        "fade",
+        "harvester",
+        "always-on",
+        "universe",
+        "long-short",
+        "dsl-only",
+        "no-close"
+      ],
+      "group": "multi-asset-universe",
+      "archetype": "contrarian_fade",
+      "archetype_label": "Contrarian / Fade",
+      "sub_style": "mean_reversion",
+      "sub_style_label": "Buys oversold / sells overbought, betting price reverts to its mean (works in chop, not just trends).",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts",
+        "universe_crypto"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "starter",
+      "leverage_max": 3,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 125,
+      "wallet_count": 1,
+      "min_budget_binding_wallet": "main",
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 5,
+      "branch": "main",
+      "sort_order": 18
     },
     {
       "id": "asia-ai",
@@ -2588,7 +2845,7 @@
       "emoji": "🌏",
       "tagline": "Long the Asian AI/semiconductor complex (TSMC, Samsung, SK Hynix, ARM, ASML) with a broad/US-tech short hedge that strips out market beta.",
       "belief_plain": "Buys the Asian AI chipmakers while they're trending up, and shorts the broad US/tech index when it rolls over — so the bet is on Asia AI outperforming, not just the market going up.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "You think the AI buildout is increasingly an Asia story — Taiwan and Korea fabs, the chip supply chain — and you want a long on that sector with market beta hedged out, not a naked tech long.",
       "tags": [
         "ai",
@@ -2643,7 +2900,7 @@
       "emoji": "🥇",
       "tagline": "Bets on currency debasement: LONGS scarce real assets (GOLD, BTC, SILVER, PLATINUM, PALLADIUM) on the hard-money wallet and SHORTS the paper economy (SP500 + rate-sensitive growth RIVN/DKNG/HIMS) on the paper wallet — each leg trend-confirmed and conviction-sized. The P&L is the real-assets-beat-paper-claims spread.",
       "belief_plain": "Buys gold, bitcoin and other scarce real assets while shorting the broad stock market and rate-sensitive growth stocks at the same time, on two separate wallets, betting that as governments run big deficits and rates stay high, hard money beats paper claims.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Fiscal dominance / currency debasement: as deficits compound and the term premium rises, scarce real assets (gold, BTC, silver) outperform fiat-denominated financial claims. Express it as a long/short — long hard money, short paper — so the edge is the spread, not market direction. Each name only trades when its own absolute 4h/1h trend confirms (cross-sectional relative strength only tilts ranking and size). HONEST CAVEAT: the loosest hedge of the family — in a pure liquidity melt-up gold AND stocks can rise together; the short tilts to rate-sensitive names to tighten it. Best deployed as a tilt, not a market-neutral bet.",
       "tags": [
         "debasement",
@@ -2707,7 +2964,7 @@
       "emoji": "🦌",
       "tagline": "Trend-follows the WHOLE Hyperliquid board across every asset class (crypto, tokenized stocks, indices, metals, energy): longs the confirmed uptrends and shorts the confirmed downtrends on two separate wallets, sizes every position to EQUAL RISK by volatility parity, and caps each asset class at 40% of equity so the book stays diversified. Managed futures, on-chain.",
       "belief_plain": "Follows the trend everywhere at once — crypto, stocks, gold, oil, indices — buying what's going up and shorting what's going down, on two separate wallets. It bets the SAME risk on each position (smaller on wild assets, bigger on calm ones) and never lets any one type of market take over the book, so the curve stays smooth and it can make money even when stocks are crashing.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "You want the most-proven hedge-fund category — managed futures (CTA) — on-chain. Its entire edge is cross-asset diversification: trends show up in different markets at different times, so the more uncorrelated markets you trend-follow, the smoother the curve. Long the uptrends and short the downtrends across uncorrelated classes nets to ~zero market beta and is crisis-positive (the short sleeve shorts the fallers when everything bleeds). Each asset is judged against its OWN history (time-series trend), sized to equal risk, and capped by class.",
       "tags": [
         "managed-futures",
@@ -2758,7 +3015,7 @@
       "emoji": "🐆",
       "tagline": "Ranks the tokenized U.S. equity cross-section on Hyperliquid XYZ by 24h relative strength, then LONGS the strongest names (long book) and SHORTS the weakest (short book) — both trend-confirmed — on two equally-funded wallets so the pair is ~market-neutral and harvests equity dispersion.",
       "belief_plain": "Buys the strongest tokenized U.S. stocks and shorts the weakest at the same time, on two separate wallets, so it makes money on the GAP between winners and losers rather than on the market going up or down.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "You want the classic equity hedge-fund play — long the leaders, short the laggards, market-neutral — but on-chain. The spread between the best and worst U.S. stocks is at a multi-decade extreme, and that dispersion is the edge: stock selection, not market direction. Tokenized equities trade 24/7 on Hyperliquid, so the book never has to wait for a market open.",
       "tags": [
         "equities",
@@ -2823,7 +3080,7 @@
       "emoji": "🐉",
       "tagline": "A two-leg BTC + HYPE book that fuses a dozen weighted signals — trend, volume, OI, funding crowding, smart-money lean, cross-asset flow — into one 0-10 conviction score per asset, and only strikes when the composite is loud.",
       "belief_plain": "No single indicator is trustworthy, but when many independent ones agree — price trend, volume, open interest, funding, what the best traders hold, and BTC pulling HYPE — that agreement is the signal. Bet bigger the louder the agreement, protect every position with a ratchet stop, and stand aside when the picture is mixed.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": null,
       "tags": [
         "composite",
@@ -2873,7 +3130,7 @@
       "emoji": "⚡",
       "tagline": "Bets AI datacenters are a structural new source of electricity demand: LONGS the AI-power complex on Hyperliquid XYZ (uranium, gas-fired power, grid copper, fuel cells, rare-earth) and SHORTS crude oil — both trend-confirmed, on two separate wallets — so the pair is energy-sector-neutral and harvests the electrons-vs-barrels spread.",
       "belief_plain": "Buys the things that make electricity for AI datacenters (uranium, natural gas, copper, fuel cells, rare-earth) and shorts crude oil at the same time, on two separate wallets, so it makes money on power BEATING oil rather than on energy going up or down.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "AI datacenter electricity demand is a structural new bid for the power complex, while crude oil is the legacy transport fuel barely levered to AI. Both legs are energy, so a broad energy move washes out and the P&L is the dispersion — power outperforming oil. Each book only acts when ABSOLUTE trend confirms (long power on a non-bearish 4h; short oil on a non-bullish 4h, with a capitulation guard), with cross-sectional relative strength as a size/rank tiebreaker. Commodities trade ~24/7 on Hyperliquid, so the book never waits for a market open.",
       "tags": [
         "energy",
@@ -2931,7 +3188,7 @@
       "emoji": "🦅",
       "tagline": "A multi-asset non-crypto XYZ breakout rider: scans 12 macro names (oil, gold, S&P/Nasdaq, mega-cap tech) for a >=1.5% 1H breakout, confirms with 4H trend, volume surge, smart-money lean and funding, then sizes leverage to score (3x/5x) and rides the move with a DSL trailing exit. Holds up to 2 positions; trades 24/7 incl weekends.",
       "belief_plain": "Watches a basket of macro markets — crude and Brent oil, gold, the S&P and Nasdaq, and the biggest US tech stocks — and pounces when one breaks out more than 1.5% in an hour with volume behind it. It goes in harder (5x vs 3x) on the cleanest breakouts and trails a stop instead of guessing the exit. These markets trade around the clock, weekends included, so there's no market-hours gate.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Macro assets move on discrete catalysts — an inventory print, a Fed headline, an earnings beat — and a sharp 1H breakout with volume confirmation usually continues for one to three hours before the move matures. A scanner watching a focused 12-name macro universe can catch that breakout early across commodities, indices and mega-cap equities, weight the 1H magnitude heaviest, confirm with the 4H trend, smart-money lean and funding, and let a trailing DSL lock the move before it fades.",
       "tags": [
         "xyz",
@@ -2993,7 +3250,7 @@
       "emoji": "🪁",
       "tagline": "Trades the ICT/SMC playbook on BTC, ETH, SOL and FARTCOIN: it maps 3-bar fractal swings, waits for a break of structure, then enters on the 0.618 fibonacci retracement of that move with invalidation behind 0.786 — only when an RSI divergence confirms. Every entry carries its stop and 1R/2R/3R targets.",
       "belief_plain": "This speaks the language of smart-money-concept traders. It watches for the market to break its own structure — taking out a prior swing high or low — which signals a real shift. Then, instead of chasing, it waits for price to pull back to the 0.618 fibonacci level of that move, checks that momentum (RSI) is diverging in its favour, and enters there with a clear invalidation just beyond the 0.786 level. It works out its 1x, 2x and 3x reward targets up front and manages the trade with a ladder that locks in gains in thirds as each target is reached.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "A break of structure marks where order flow shifted; the 0.618 retracement is where that move offers the best risk-reward to rejoin, and the 0.786 is where the idea is simply wrong. Requiring an RSI divergence at the retracement filters the continuations that have already exhausted. The result is a defined-risk, defined-target structure trade — the exact methodology a whole trader subculture uses by hand — automated across a few liquid names. The step-up profit ladder approximates a 33/33/33 scale-out; true partial take-profit lands with the native DSL scale-out capability.",
       "tags": [
         "smc",
@@ -3048,7 +3305,7 @@
       "emoji": "🦁",
       "tagline": "Bets on a K-shaped divergence: LONGS the structural winners (the AI complex on Hyperliquid XYZ + the crypto winners HYPE/SOL) on the 'haves' wallet, and SHORTS the laggards (the broad U.S. market via SP500 + a gated basket of laggard alts) on the 'have-nots' wallet. Both trend-confirmed on absolute structure, with relative strength as a tiebreaker and per-name conviction sizing (HYPE big, SOL small, SP500 core). The edge is the DISPERSION between the two speeds, not market direction.",
       "belief_plain": "Buys the booming AI stocks and crypto winners while shorting the broad stock market and the alts losing ground, each on its own wallet — so it makes money on the GAP between the world's fast lane and slow lane rather than on the market going up or down. It only buys names actually trending up and only shorts names actually rolling over, and bets bigger on its highest-conviction picks.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "The world is splitting into two speeds: the AI complex and HYPE/SOL keep booming while the broad U.S. economy and the rest of crypto struggle. Express it as one thematic long/short book — long the haves, short the have-nots — and the P&L is the dispersion between the two, not the market's direction. The hard gate is ABSOLUTE trend (never long a downtrend, never short an uptrend, even for a thesis name); cross-sectional relative strength only tilts size and ranking. Net exposure is the operator's dial (default modest net-long), set by how much capital each wallet holds.",
       "tags": [
         "k-shaped",
@@ -3138,7 +3395,7 @@
       "emoji": "🏛️",
       "tagline": "A diversified, long-only, NO-LEVERAGE basket across crypto blue chips, equity indices and blue-chip names, metals, and energy — sized to a hard per-position cap, gated by a fee hurdle so it only trades when the expected move beats the cost, and diversified with a per-class limit. Capital preservation first.",
       "belief_plain": "This is a conservative, institution-style portfolio, not a punt. It holds a diversified spread of blue-chip crypto and real-world assets (stock indices, big-cap names, gold, silver, oil), never uses leverage, and never puts more than a small capped slice into any one position. It only opens a position when the trend is genuinely there on both the 4-hour and daily view AND the expected move is large enough to be worth the trading cost — otherwise it does nothing. Doing nothing is a valid decision.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "For capital preservation, what you DON'T do matters more than what you do. No leverage means a bad position can't wipe the book; hard per-position and per-class caps mean no single name or theme can sink it; a fee hurdle means small, cost-eroding edges are declined rather than churned. The result is a low-volatility diversified compounder across crypto and RWA that trades rarely and holds patiently, cutting a real breakdown early and locking gains before giving them back.",
       "tags": [
         "capital-preservation",
@@ -3202,7 +3459,7 @@
       "emoji": "🪙",
       "tagline": "Bets money is migrating on-chain: LONGS the on-chain financial rails (HYPE the venue + Circle/CRCL + Coinbase/COIN + Robinhood/HOOD + BTC treasuries MSTR/PURRDAT) on one wallet and SHORTS legacy finance + broad financial-beta (Blackstone/BX + SP500) on another — both trend-confirmed on absolute 4h/1h structure — so the P&L is the disruptor-vs-incumbent spread.",
       "belief_plain": "Buys the companies and tokens that are pulling finance on-chain (the crypto exchange, the stablecoin issuer, the BTC treasuries) and at the same time shorts the old-finance incumbents and the broad market, on two separate wallets. It only buys names that are actually trending up and only shorts names actually rolling over, and it bets bigger on its highest-conviction picks (HYPE and Circle).",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Money is migrating on-chain — stablecoins, crypto exchanges and BTC treasuries are eating legacy financial rails. You want to own the disruptors and short the incumbents so the return is the GAP between them, not the direction of the market. HONEST CAVEAT: the hedge is cross-sector and the short universe is thin (few pure legacy-finance names list on the venue yet), so the short leg leans on the broad index — it nets down market beta rather than perfectly isolating the pair, and the long book is the strong, high-conviction side.",
       "tags": [
         "on-chain-finance",
@@ -3261,7 +3518,7 @@
       "emoji": "🐂",
       "tagline": "A vol-balanced all-weather LONG basket across asset classes (crypto majors + equity indices + metals + energy + FX), each sleeve sized by inverse realized volatility so no single class dominates risk — plus a defensive ballast book that scales up when the tape turns risk-off.",
       "belief_plain": "Holds a steady, always-invested basket spread across crypto, stock indices, gold, oil and currencies, and quietly puts more weight on the calm assets and less on the wild ones so nothing can blow up the whole book. A second smaller book buys defensives (gold, yen) and doubles up when markets get nervous.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "You want a low-drama core holding to sit under your more aggressive bets — always invested, diversified across asset classes, and risk-balanced by volatility rather than a directional view. Not a market-timing bet; a steady, all-weather core with a built-in defensive cushion.",
       "tags": [
         "risk_parity",
@@ -3322,7 +3579,7 @@
       "emoji": "🦏",
       "tagline": "Carries cheap convexity across two books: an always-on small LONG carry in the crisis-beneficiary complex (gold / oil / dollar / yen), plus a dormant, stress-gated leveraged add that goes LONG the spiking crisis assets and SHORT the cratering risk assets the moment a shared cross-asset stress detector confirms a shock — then banks the spike.",
       "belief_plain": "Built to lose a little in calm and win big in a crisis. One book quietly holds gold/oil/dollar/yen as standing insurance whenever they're trending up. The other sits in cash until a shock hits — oil spiking, stocks breaking down, Bitcoin rolling over — then piles into the crisis winners and shorts the risky stuff, and takes profit fast because crises reverse hard.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "You want the part of the portfolio that's green on the days everything else is red. Not a fixed war bet you switch on, and not a macro trend-follower — Rhino is always-on insurance that self-activates a leveraged convex leg on a measured stress signal, with no view required.",
       "tags": [
         "tail-risk",
@@ -3386,7 +3643,7 @@
       "emoji": "🦂",
       "tagline": "Hunts trend-following entries across a curated crypto + XYZ basket (BTC/ETH/majors, mid-caps, plus crude oil, Brent, gold and the S&P): enters only when smart money is concentrated in a direction AND 4h price agrees, scores SM dominance + multi-timeframe momentum, and rides maker-optimized exits with a let-winners-run trailing ladder.",
       "belief_plain": "Trades a hand-picked set of coins and commodities/indices. It only acts when the best traders are crowded on one side and the 4-hour price is already moving that way, then trails a profit-locking stop and pays cheaper maker fees on the way out.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "The strongest, lowest-noise trends show up where smart-money concentration and 4h price direction agree — across BOTH crypto and the XYZ commodities/indices that most agents ignore. Score that agreement, gate hard on it, and let the DSL ride the winners while maker-preferred exits claw back the fee drag that kills high-turnover active traders.",
       "tags": [
         "momentum",
@@ -3455,7 +3712,7 @@
       "emoji": "🕷️",
       "tagline": "An AI/Tech momentum long book plus a macro/majors mean-reversion book — two legs, two wallets, one package.",
       "belief_plain": "AI/tech equities and crypto majors trend over days, while majors and energy snap back from short-term extremes — run both books side by side.",
-      "version": "6.0.3",
+      "version": "6.1.0",
       "thesis": null,
       "tags": [
         "ai",
@@ -3520,7 +3777,7 @@
       "emoji": "🎯",
       "tagline": "One wallet expresses a macro view as a long/short basket — but it only presses a name when the market is confirming that direction (4h/1h trend + 24h momentum aligned), and the DSL + drawdown gate de-risk when the thesis stops working. Default preset: risk_off (long gold/silver, short SP500/XYZ100/BTC). Swap the basket inputs to express recovery, war_escalation/war_recovery, hype_vs_market, gold_over_btc/btc_over_gold.",
       "belief_plain": "You pick what you think will happen — say, a risk-off shock — and the fund holds the basket that expresses it: long the assets that win, short the ones that lose. But it doesn't blindly hold: it only buys a name while the market is actually moving its way, and trails a stop to cut names that stop working.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "You bring the market VIEW; the fund expresses it with discipline. Instead of picking a trading style, you pick what you believe will happen — and one wallet trades the long/short basket that expresses it, pressing each name only when the tape confirms the thesis direction rather than fighting it.",
       "tags": [
         "macro",
@@ -3579,7 +3836,7 @@
       "emoji": "🦅",
       "tagline": "Scans a whitelist of ~25 small/mid-cap Hyperliquid perps that no other agent covers (majors and XYZ are banned), and enters when smart-money concentration aligns with a fresh 4h trend, the 1h confirms it isn't a false breakout, and 15m velocity is accelerating — then sizes leverage to conviction (5x, 7x apex), cuts losers fast and rides the right-tail winners for days on a trailing stop.",
       "belief_plain": "Hunts the small coins the rest of the fleet ignores. It only buys (or shorts) one when the best traders are crowding in, the 4-hour trend agrees, the 1-hour isn't already rolling over, and short-term momentum is building — then goes in harder on the strongest setups and trails a stop. Most trades are tiny losses cut fast; the occasional big winner pays for everything.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "The biggest blind spot on Hyperliquid is the small/mid-cap long tail — every other agent is locked to the majors or a single asset, so nobody is reading smart-money flow on HEMI, WLD, XPL, AIXBT and the rest. Small caps have a thicker trader-count signal-to-noise ratio than the majors: when smart-money concentration on one aligns with a fresh 4h trend and accelerating 15m velocity, that's a momentum entry with a long right tail. A low win rate is fine when the winners are several times the size of the losers.",
       "tags": [
         "small-cap",
@@ -3652,7 +3909,7 @@
       "emoji": "🐺",
       "tagline": "Two books on two wallets that read one shared cross-asset regime (equities, oil, gold, BTC, the dollar). The RISK-ON book longs beaten-down beta in a confirmed risk-on regime; the RISK-OFF book longs defensives and shorts risk in a confirmed risk-off regime — capital rotates to whichever the macro favors.",
       "belief_plain": "Watches the whole macro complex — stocks, oil, gold, BTC, the dollar — and waits for them to agree on which way the wind is blowing. When it's risk-on it buys the beaten-down risk assets that are turning up; when it's risk-off it buys safe havens and shorts risk. No single asset can flip it; the whole complex has to lean one way.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "You think the edge is in trading the macro TURN, not a fixed view and not per-asset trend. You want a fund that detects which way the regime is shifting across the whole cross-asset complex and rotates its two books to that side, standing down entirely when nothing agrees.",
       "tags": [
         "regime",
@@ -3714,7 +3971,7 @@
       "emoji": "🐺",
       "tagline": "A single-asset BTC bet driven by a macro-regime read: each tick it measures BTC's 7-day trend strength and annualized realized volatility (plus cross-asset dispersion for context) and classifies the market into TREND_UP, TREND_DOWN or CHOP — going long BTC in a calm uptrend, short BTC in a high-vol crash, and staying out otherwise, then letting a balanced DSL ride the regime.",
       "belief_plain": "Coyote first asks 'what kind of market are we in?' It looks at how far Bitcoin has moved over the last week and how violent that move has been. A steady 5%+ climb with calm volatility means uptrend — it goes long BTC. A sharp 5%+ drop with a volatility spike means a panic crash — it goes short BTC. Anything in between is chop, so it stays out. Real regimes last days, so it trades rarely and lets the trend run.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Most agents re-implement their own 'should I be active right now?' check; Coyote makes the macro regime a first-class decision. BTC's 7-day move sets the direction and realized vol confirms the character — demanding HIGH vol for a short distinguishes a panic crash worth fading-with from an orderly grind-down that's really just chop. Because regimes are persistent, the right behavior is a slow cadence, a 6h cooldown and a max of 2 entries/day so it never churns on noise, then a wide DSL trail so a real regime move runs for days.",
       "tags": [
         "btc",
@@ -3762,7 +4019,7 @@
       "emoji": "🦎",
       "tagline": "A relative-value pairs trader on correlated crypto majors: for each pair (ETH/BTC, SOL/ETH, SOL/BTC) it z-scores the latest price ratio vs its 48-bar (1h) mean, and when the ratio stretches >=2 sigma AND starts reverting, it takes a directional bet on the high-beta leg in the snap-back direction — sizing one slot and letting a tight mean-reversion DSL bank the reversion.",
       "belief_plain": "Trades the spread between two coins, not the market. When ETH gets expensive relative to BTC (or SOL vs ETH), the ratio stretches far from its usual level — and ratios snap back more reliably than outright prices. Chameleon measures how stretched a pair is, waits until the ratio starts turning back, then bets on the high-beta coin (ETH or SOL) in the direction that profits from the snap-back, and trails a tight stop to bank the reversion.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Correlated majors trade as a pack, but their ratios oscillate around a mean. A 3-sigma ETH/BTC extension is a cleaner edge than guessing ETH's absolute direction — the pair's correlation does the work. The Senpi runtime is single-position, so instead of a two-leg market-neutral spread Chameleon takes a directional bet on the high-beta leg; it captures most of the reversion edge without spread-level position management, and the move is bounded, so a tight ladder banks the snap-back rather than holding for a trend.",
       "tags": [
         "eth",
@@ -3813,7 +4070,7 @@
       "emoji": "🦫",
       "tagline": "An onboarding-tier BTC specialist: enters only when the 4h candle structure is trending AND Senpi's Smart-Money leaderboard agrees with that direction — then takes one flat-5x position and lets a wide DSL ladder ride the trend.",
       "belief_plain": "Trades only BTC. It asks two questions — is BTC trending on the 4-hour chart, and does smart money agree? If both are yes it opens one position and trails a stop instead of guessing the exit. Built for first-time users.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "New users want one clean answer, not a scattergun across the market. BTC is the most liquid, most legible asset on Hyperliquid; 'is it trending and does smart money agree?' is the simplest honest edge — and a wide trailing stop lets a real trend run multi-day without micromanagement.",
       "tags": [
         "btc",
@@ -3859,7 +4116,7 @@
       "emoji": "🐈",
       "tagline": "A big-tech equity-perp trend follower on Hyperliquid XYZ (NVDA/TSLA/AAPL/META/MSFT/GOOGL/AMZN/AMD/MU/INTC/TSM/ORCL): enters the single strongest name when its 4h trend is non-neutral AND smart-money leans the same way (tilt >= 55%), sizes a flat 20% margin at 5x, and lets a wide DSL ratchet ride the move — with a 48h cap so positions don't camp through the weekend pricing gap.",
       "belief_plain": "Trades the big tech stocks you already know — NVDA, TSLA, AAPL and nine more — as perps on Hyperliquid XYZ, 23/5. It only enters when a stock's 4-hour trend and the best traders are pointing the same way, holds the single strongest setup, and trails a stop so a real move can run — but caps each hold at 48 hours so it never sits through the Friday-to-Sunday gap when these names have no external price.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Big tech is the most-traded equity sector, and Hyperliquid XYZ surfaces these names as leveraged perps with 23/5 hours. A clean trend + smart-money confluence on the highest-liquidity XYZ equities catches directional moves without the small-cap noise of a broad scanner. The 48h hard_timeout is intentional: equity perps reconcile against an internal oracle over the weekend gap, where drift accumulates without external price discovery — so winners are let to run on the 4h timescale but never held through the full Fri-Sun window.",
       "tags": [
         "big-tech",
@@ -3920,7 +4177,7 @@
       "emoji": "🦡",
       "tagline": "A single-asset Brent crude (xyz:BRENTOIL) specialist: enters only when 5m/15m/1h/4h trend all agree AND smart-money (mark/oracle premium) leans the same way, then stacks OI velocity, volume spikes and price cleanliness into a conviction score — sizing leverage to conviction (3/5/7/10x) and letting the DSL ride the news move.",
       "belief_plain": "Trades only Brent crude oil. It waits until every timeframe from 5 minutes to 4 hours is pointing the same way and order flow agrees, then goes in harder when more signals line up — and trails a stop instead of guessing the exit. Oil trades around the clock, weekends included.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Oil moves on discrete news — OPEC decisions, geopolitics, inventory releases — with sharp 2-5% directional bursts and violent reversals after overshoot. An agent that watches only Brent can read its 4-timeframe structure, order-flow premium, OI and volume far more tightly than a broad scanner, catch the clean move early, and lock profit before the snap-back.",
       "tags": [
         "oil",
@@ -3968,7 +4225,7 @@
       "emoji": "🦎",
       "tagline": "Point it at any liquid coin you name and it trades just that one: it scores trend structure, momentum and funding into a single confluence read on that name, goes long or short when enough signals line up — sizing conviction to the strength of the setup — and trails a stop instead of guessing the exit.",
       "belief_plain": "You pick the coin; Gecko trades only that coin. It waits until the 1-hour and 4-hour trend, momentum and funding all point the same way, then goes in — harder when more of them agree — and never guesses the exit: a trailing stop does all the closing. One coin, one position, done well.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Most people don't want a scattergun across the whole market — they want their coin traded properly. Gecko is bison's validated confluence scorer pointed at a single user-named asset: trend structure (1h/4h), momentum, RSI and funding are summed into one conviction score, direction resolves from the timeframe waterfall, and leverage/margin scale to the score. One asset, one high-conviction slot; the DSL owns every exit and the drawdown_halt is the backstop. It fills the long tail of 'make me a strategy for <my coin>' without a bespoke build each time.",
       "tags": [
         "configurable",
@@ -4015,7 +4272,7 @@
       "emoji": "🐻",
       "tagline": "A single-asset BTC specialist: enters only when 4h and 1h trend structure agree, 15m momentum confirms, smart money leans the same way, and a macro V-recovery gate proves the move isn't a fade right off the 24h extreme — then sizes leverage to conviction (7/10/10x) and lets the DSL ride the winner.",
       "belief_plain": "Trades only BTC. It waits for the 4-hour and 1-hour trend to agree, momentum to confirm, and the best traders to be leaning the same way — and it refuses to short right off a 24h low (or long right off a 24h high) because those fades whipsaw. It goes in harder when more factors line up, and trails a stop instead of guessing the exit.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "BTC has the deepest liquidity on Hyperliquid and the cleanest trend structure. An agent that watches only BTC can read its multi-timeframe structure, smart-money flow, and funding far more tightly than a broad scanner — and BTC's 4h structure metric lags V-recoveries, so a distance-from-24h-extreme gate stops it from fading a reversal that the candle structure hasn't caught up to yet.",
       "tags": [
         "btc",
@@ -4061,7 +4318,7 @@
       "emoji": "🐦",
       "tagline": "An onboarding-tier single-asset ETH trend follower: enters only when the 4h candle structure is trending AND Senpi's Smart-Money leaderboard agrees with that direction — then holds one position at a fixed 5x and lets a wide DSL ladder ride the trend for multi-day moves.",
       "belief_plain": "Trades only ETH. It asks two simple questions — is ETH trending on the 4-hour chart, and do the best traders agree with that direction? If both say yes it opens one position and trails a stop instead of guessing the exit. Built for first-time users.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "New users want one clean question answered well, not a scattergun across the market. ETH has the liquidity and the smart-money depth, and a simple agent that watches only ETH — checking 4h structure and the leaderboard's net lean — gives a beginner a clear directional position without funding-rate math or multi-asset tuning.",
       "tags": [
         "eth",
@@ -4106,7 +4363,7 @@
       "emoji": "🪶",
       "tagline": "An onboarding-tier single-asset HYPE specialist: enters only when the 4h trend structure is directional AND Senpi's Smart-Money leaderboard agrees with that direction (tilt >= 60%) — then holds one flat-5x position and lets a wide DSL ladder ride the trend.",
       "belief_plain": "Trades only HYPE. It asks two simple questions — is HYPE trending on the 4-hour chart, and do the best traders agree with that direction? If both are yes, it opens one position and trails a wide stop instead of guessing the exit, so winning trends can run for days.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "New users want one clean decision, not a scattergun across the market. HYPE has the liquidity and the moves, and a one-asset, one-direction strategy with a Smart-Money confirmation gate is the simplest honest answer to 'I'm new to Senpi, where do I start?'",
       "tags": [
         "hype",
@@ -4151,7 +4408,7 @@
       "emoji": "🦎",
       "tagline": "A broad-index trend-follower on the XYZ equity indices (xyz:SP500 + xyz:XYZ100): each tick measures the 4-day move of each index, picks the stronger one past the trend floor, and rides it in that direction — no stock-picking, no commodities. The closest thing to an index fund, but 24/7 on Hyperliquid.",
       "belief_plain": "Trades only the two broad stock-market indices (S&P 500 and the XYZ 100). Every few minutes it checks which index has the bigger 4-day move; if that move is large enough it goes that way (up = long, down = short), bets bigger when the move is strong and volume is rising, and then trails a stop. The simplest stock-market exposure on Hyperliquid — no individual stocks.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "You want broad stock-market exposure on Hyperliquid without picking individual stocks, commodities, or pre-IPO names. Two liquid index instruments, one decision per tick: trend-follow whichever index has the clearer 4-day direction. The edge is in the slow index drift, so a wide DSL rides it for days and a 48h hard-timeout caps the XYZ weekend pricing-gap risk.",
       "tags": [
         "sp500",
@@ -4201,7 +4458,7 @@
       "emoji": "🐨",
       "tagline": "The simplest agent in the catalog: pick one asset (default BTC), fire LONG once on deploy, then hold with an ultra-wide DSL trail (max_loss 30%, retrace, 90-day timeout). No scoring, no scheduling — the choice to deploy Koala IS the bet.",
       "belief_plain": "Trades only the one coin you pick (BTC by default). It buys once when you turn it on, then just holds — never adding, never trading around it — with a very wide safety stop that only releases on a catastrophic reversal or after three months. The whole idea is to own the coin and have a net under it.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Some users do not want a market-reading agent at all — they just want to own one asset and have a safety net. Koala is that answer in code: one asset, one entry, one stop. Fire-once by default (a true buy-and-forget), with an optional re-entry cycle for operators who want 'buy / DSL-exits / buy again' on a long cooldown.",
       "tags": [
         "btc",
@@ -4248,7 +4505,7 @@
       "emoji": "🐻",
       "tagline": "A single-asset SOL specialist: enters only when 4h and 1h trend structure agree, 15m momentum confirms, and smart-money lean, funding, and BTC all line up — then sizes leverage to conviction (5/6/7x) and lets the DSL ride the winner.",
       "belief_plain": "Trades only SOL. It waits for the 4-hour and 1-hour trend to agree, momentum to confirm, and the best traders to be leaning the same way — then goes in harder when more of those line up, and trails a stop instead of guessing the exit.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "You want one coin done really well, not a scattergun across the market. SOL has the liquidity and the moves, and an agent that watches only SOL can read its structure, smart-money flow, and funding far more tightly than a broad universe scanner ever could.",
       "tags": [
         "sol",
@@ -4293,7 +4550,7 @@
       "emoji": "🐟",
       "tagline": "Top-down structure trading on FX pairs (EUR / GBP / JPY), the way it's taught: the Daily, 4-hour and 1-hour charts must all agree on trend direction, the 4-hour marks the area price is expected to retest, and the 15-minute times the entry off a break of structure inside that zone. If the timeframes disagree, or price isn't at the level, or there's no 15-minute trigger, it does nothing. Long & short, low leverage scaled to how small FX moves are.",
       "belief_plain": "This is how structure traders actually read a chart: start wide, then zoom in. First it checks that the Daily, 4-hour and 1-hour charts are all pointing the same way — if they disagree, there's no trade. Then on the 4-hour it marks the zone price is likely to pull back to. Then it waits, on the 15-minute chart, for price to actually reach that zone AND break in the trend direction before entering. Three things have to line up: direction, location, and timing. Miss any one and it stands aside. It trades the major currency pairs, which move in small percentages, so it uses the leverage that matches.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Multi-timeframe / ICT-style structure trading is one of the largest retail methodologies and the catalog had no expression of it — nor any FX template at all, despite Hyperliquid listing EUR, GBP and JPY. Manta encodes the top-down cascade faithfully: each timeframe answers exactly one question (higher frames = bias, 4h = location, 15m = timing) and is not allowed to answer another, which is the discipline the method is really about. The confluence is mandatory, not additive — a signal requires all three, because a 15m break outside the zone is noise and a zone touch with no break is a falling knife. Thresholds are FX-scaled throughout: a 0.5% daily move is a big FX day, so a crypto-sized structure filter would call every currency chart neutral forever.",
       "tags": [
         "fx",
@@ -4348,7 +4605,7 @@
       "emoji": "🧊",
       "tagline": "A single-asset ETH specialist: smart-money concentration picks the side first, then 4h and 1h trend structure must agree, 15m momentum confirms, and funding, open interest, BTC and RSI all add conviction — then sizes leverage to score (5/7/10x) and lets the DSL ride the winner.",
       "belief_plain": "Trades only ETH. It first looks at which way the best traders are leaning hard, then only takes it if the 4-hour and 1-hour trend agree and momentum confirms — going in harder when more factors line up, and trailing a stop instead of guessing the exit.",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "thesis": "You want one coin done really well, not a scattergun across the market. ETH has the liquidity and smart-money depth, and a hybrid agent that watches only ETH can read the leaderboard's net lean, candle structure, funding and open interest far more tightly than a broad universe scanner ever could.",
       "tags": [
         "eth",
@@ -4394,7 +4651,7 @@
       "emoji": "🐏",
       "tagline": "A single-asset gold (xyz:GOLD) specialist: goes long when gold's trend lines up across the 1h and 4h and momentum agrees — and leans in harder when the market turns risk-off and money is looking for a safe haven — and can short a clean downtrend. Holds one position at a time and trails a stop instead of guessing the exit.",
       "belief_plain": "Trades only gold. It buys when gold is trending up and, especially, when the market gets defensive and flows into safe havens; it can short a clear downtrend. It never picks a top or bottom by hand — a trailing stop does all the exiting. Gold trades around the clock, weekends included.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Gold is the market's safe-haven anchor: it trends on real-rate and risk-regime shifts and gets bid hardest when risk assets wobble. An agent that watches only gold can read its 1h/4h trend structure, momentum and RSI far more tightly than a broad scanner, and add a safe-haven tilt when a risk-off funding regime shows up — catching the defensive bid early and locking profit as the move matures. Concentration by conviction on one asset, with the DSL owning every exit.",
       "tags": [
         "gold",
@@ -4440,7 +4697,7 @@
       "emoji": "🦌",
       "tagline": "Watches a small whitelist of large-cap crypto for a real parabolic setup — established uptrend, a 7-day move of 25%+ on surging volume that's still accelerating, with smart money piled long — then goes long and hands the trade to the widest stop in the catalog so it can ride the whole run through the violent intraday pullbacks.",
       "belief_plain": "Only buys when a coin is genuinely going parabolic, not just trending. It waits for a big multi-week move that's still speeding up on heavy volume with the best traders leaning long, then uses a very loose trailing stop so the position survives the 5-8% dips that would shake out a normal trend trade.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "The hard part of a parabolic run isn't entering — it's not getting chopped out. A standard trend trail makes local-volatility decisions and exits on the first 5-8% pullback, missing the rest of a +60% move. Stag pairs a strict entry filter (so it only fires on a real parabolic) with the deliberately wide parabolic_runner DSL (so the trade survives the gyrations). The trade-off is honest: it bleeds in chop, which is exactly why the filter is strict.",
       "tags": [
         "parabolic",
@@ -4490,7 +4747,7 @@
       "emoji": "🐢",
       "tagline": "The Turtle breakout, rebuilt with our DSL. It enters when price breaks its 20-day high (long) or low (short) and MACD agrees, then ADDS units as the move extends — a second at +½N, a third at +1N, a fourth at +1½N (N = 20-day ATR). Each unit is its own wallet with its own trailing stop, calibrated to its rung: the base breathes widest and carries the trend, the tip locks tightest and peels off first, so the pyramid unwinds top-down instead of all at once. One asset (BTC by default), long or short, four units.",
       "belief_plain": "This is the classic Turtle trading system with a modern exit. It waits for a real breakout — price pushing past its highest level in 20 days — and only takes it if momentum (MACD) agrees, which filters out the false breaks that trap breakout buyers. Then, the Turtle move: as the trend keeps running in your favor, it adds more size in steps, building a bigger position into a winner. The twist is how it gets out. The original Turtles dumped the whole stack at one stop; Terrapin gives each added chunk its own trailing stop — the first, safest chunk rides the longest, while the chunks added late (which have the least cushion) protect their profit fastest and exit first if it turns. You fund it once and it splits across four sub-wallets, one per chunk.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "The Turtle breakout is one of the most documented trend-following systems in existence, and the catalog had no expression of it — because a faithful pyramid needs to ADD to a winning position, and Hyperliquid nets positions per coin per wallet, so a single-wallet build can only ever hold the first unit. Terrapin solves that structurally: four units, four wallets, each arming off the same statelessly-computed frozen breakout anchor so the ½N ladder is consistent without any cross-wallet coordination. The deliberate modernization is the exit. Turtle's unified 2N / 10-day-low stop becomes four independent DSL ladders, progressively tighter up the pyramid — which is not just faithful-enough but arguably better: the position unwinds from the top on a reversal, banking the exposed upper units while the base rides, instead of giving the whole stack back at one level. The MACD filter is the user's requested addition ('turtle con MACD') and does real work — it vetoes the momentum-less breakout that is the system's classic whipsaw.",
       "tags": [
         "turtle",
@@ -4543,7 +4800,7 @@
       "emoji": "🦡",
       "tagline": "A single-asset HYPE specialist: six-gate trend entry (4h structure, 1h non-opposition, 15m momentum, base-tech floor, 4h magnitude) layered with a market-wide funding-regime + funding-persistence macro gate and a smart-money HARD BLOCK — then sizes leverage to conviction (3/5x) and lets the DSL ride the winner.",
       "belief_plain": "Trades only HYPE. It waits for the 4-hour trend to be strong, the 1-hour to not be fighting it, and short-term momentum to confirm — then checks the broader funding 'crowding' regime and refuses to trade when the best traders are leaning the other way. It goes in harder when more factors line up, and trails a stop instead of guessing the exit.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "HYPE is one of the highest-volatility majors on Hyperliquid. A specialist that watches only HYPE can read its trend structure, smart-money flow, funding regime and persistence far more tightly than a broad scanner — and the macro funding-regime gate keeps it out of crowded, liquidation-prone setups that single-asset momentum alone would walk into.",
       "tags": [
         "hype",
@@ -4590,7 +4847,7 @@
       "emoji": "🐉",
       "tagline": "A long-term conviction book on ONE major (the thesis coin: ETH/SOL/HYPE), ridden through volatility on a catastrophic-only stop, plus a tactical dip-buyer that presses the pullbacks — cushioned by a diversified short of OTHER assets that are actually breaking down, so the hedge protects market risk without ever betting against your thesis.",
       "belief_plain": "Holds one major you believe in for the long haul and adds on its dips, while shorting a basket of other coins/indices whenever they roll over — so a market selloff that would hurt your coin is offset by profits on the short side, and you never short the coin you're bullish on.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "You have a high-conviction long-term view on one major and want to ride it through normal volatility instead of being stopped out — but you still want a real cushion in a broad selloff. So you hold the thesis on a wide disaster-only stop, press its dips, and hedge by shorting OTHER assets that are confirmed breaking down (vol-parity sized, sized up when your own coin is breaking too). Long the conviction, short the carnage elsewhere.",
       "tags": [
         "conviction",
@@ -4649,7 +4906,7 @@
       "emoji": "🐆",
       "tagline": "A patient universe sniper: scans the top-100 smart-money markets every tick and refuses to fire unless smart-money consensus, velocity, acceleration, dual-price confirmation, volume, quality-trader alignment, and rank-climb all line up — then takes ONE position, sized 3-8x by conviction, and lets the DSL ride the winner.",
       "belief_plain": "Watches where the best traders are crowding across the whole market, but waits for everything to agree at once — the smart money, the price, the volume, the speed of the move — before taking a single, high-conviction bet. Most of the time it does nothing; that patience is the point.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Any one signal is noise. Real edge shows up only when smart-money consensus, momentum, acceleration, price, volume, and proven-trader alignment all confirm the same direction on the same coin at the same moment. That confluence is rare, so the right move is to sit on one slot, wait for it, strike once at conviction-scaled leverage, and let a ratcheting trailing stop — not a fixed target — decide the exit so the rare big trend pays for the quiet weeks.",
       "tags": [
         "smart-money",
@@ -4693,7 +4950,7 @@
       "emoji": "🐦",
       "tagline": "Auto-discovers the platform's top-performing strategies, then trades the asset + direction they agree on most — performance-weighted, so a stronger strategy gets more say (capped so one outlier can't dominate).",
       "belief_plain": "Lets the best strategies on the platform do the work. Every few minutes it finds the top performers, looks at what they're holding right now, and copies whatever the most (and best) of them are piling into together — going long what they're long and short what they're short.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Following one trader or one leaderboard is one layer; Cuckoo is a layer above it. The strategies it follows are themselves copy/algo/trader-following strategies, so it captures the consensus of the consensus. When the best strategies independently pile into the same asset+direction, that agreement is a strong, self-cleaning signal — underperformers fall out of the top-N automatically, so the pool refreshes toward whatever is working.",
       "tags": [
         "copy-trading",
@@ -4737,7 +4994,7 @@
       "emoji": "🐕",
       "tagline": "A patient contrarian on BTC/ETH/SOL/HYPE: waits for a major to move 3%+ in 4h while smart money piles in heavily, then fades the crowded, exhausted side — but only when the funding regime confirms the unwind and the move is still fresh. Conservative 7-10x leverage, wide DSL to let the reversal develop.",
       "belief_plain": "When a big coin runs hard and the best traders are all crowded onto the same side, the crowd is maximum exposed and the unwind is the trade. Dog bets against that exhausted consensus on BTC, ETH, SOL and HYPE — but only when the move has genuinely overextended, the crowding is still building, and market-wide funding shows the crowd really is one-sided. Most of the time it waits.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Hyperliquid is dominated by leverage traders chasing momentum. When a major moves 3%+ in four hours and smart-money consensus piles in 15%+, the late entrants are maximally exposed and funding pressure plus mean reversion force the unwind. Dog's edge is being on the unwind side before capitulation accelerates — so it scores the smart-money direction, hard-gates on exhaustion (>=3% 4h move), freshness (15m contribution still rising), trader depth (>=30), and a funding regime that confirms the crowd is one-sided, then emits the OPPOSITE direction at conservative leverage and lets a wide ratcheting stop ride the reversal rather than banking too early.",
       "tags": [
         "smart-money",
@@ -4792,7 +5049,7 @@
       "emoji": "🐦",
       "tagline": "Fades an exhausted crowd: when 70%+ of top traders are piled onto one side of BTC/ETH/SOL/HYPE but price refuses to follow (it stalls or rolls over against the crowd), the crowded side is out of fuel — Egret takes the other side, sized flat at 15% / <=5x, and banks the bounded snapback with a tight ratchet.",
       "belief_plain": "When almost everyone good is leaning the same way on a coin but the price won't move with them, the trade is crowded and out of buyers (or sellers). Egret bets on the snap-back the other way, and because that bounce is small and quick, it locks in profit fast instead of holding for a big trend.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Smart-money concentration is usually a confirmation signal — but at an extreme, with price refusing to confirm, it flips contrarian: a maximally-crowded side with no one left to push has only one way to resolve, the unwind. The edge is the bounded snapback, so the right design is the inverse of a momentum holder: maker-only non-urgent entry, a tight ratchet that banks the bounce, and time-cuts that exit a fade that didn't resolve quickly.",
       "tags": [
         "btc",
@@ -4847,7 +5104,7 @@
       "emoji": "🐺",
       "tagline": "A short-only crypto defense sleeve on majors (BTC/ETH/SOL/HYPE) plus crypto-proxy equities (xyz:MSTR/COIN/CRCL): shorts the block ONLY when risk-off confirms — the market-wide funding regime is LONG_CROWDED (crowded longs = squeeze fuel), smart money is rotating OUT of the name, and the 4h trend is breaking down. Conservative 4x, tight short-side DSL, 30h cap because squeezes resolve fast. CAVEAT: this is a hedge that pairs with long crypto exposure — it idles and emits nothing whenever risk-off conditions are not met.",
       "belief_plain": "Most of the time the safe trade on crypto is no trade. But when the best traders are all crowded long, smart money starts rotating out, and price begins rolling over together, that crowded long is fuel for a squeeze to the downside. Hyena bets against that exhausted crowd — short only — on Bitcoin, Ether, Solana, HYPE, and the crypto-proxy stocks MicroStrategy, Coinbase and Circle. It is a defense sleeve you run alongside your long crypto bets to cushion a downturn; when the risk-off picture is not there, it does nothing and waits.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "The fleet has no dedicated short-biased crypto agent — every directional engine is long-or-long/short, so there is no clean defensive sleeve for a risk-off turn. Hyena fills that gap. It treats the market-wide funding regime as a master gate: it only opens new shorts when funding shows the crowd is one-sided LONG (LONG_CROWDED), because a crowded long is the squeeze that a short monetizes. On top of that gate it requires, per name, that smart money is net-SHORT (rotating out) AND that the 4h structure is making lower highs (price confirming the unwind). All three must agree, so it sits idle in normal markets and only acts on genuine risk-off confluence. It is short_only by design — a hedge meant to be paired with long crypto exposure, sized conservatively (15% margin, 4x) with a tight short-side DSL and a 30h hold cap because short squeezes resolve fast.",
       "tags": [
         "short-only",
@@ -4911,7 +5168,7 @@
       "emoji": "🐟",
       "tagline": "Reads the L2 order book on BTC/ETH/SOL/HYPE — when resting depth is lopsided (bids far heavier than asks, or the reverse) that's directional pressure, but it only fires when 15m momentum and smart money agree, then hands the position to a wide DSL and lets the move run (it does not scalp).",
       "belief_plain": "Looks at how much resting buy vs sell interest is stacked in the order book of the big, liquid coins. A heavily one-sided book signals pressure in that direction — but a lopsided book alone is noise, so it only acts when short-term price momentum and the best traders are pointing the same way. Then it holds the trade with a wide trailing stop instead of flipping in and out.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Order-book imbalance is a genuine microstructure edge, but trading it as a per-tick scalp just bleeds fees. Marlin uses the imbalance differently — as the entry-timing signal on a momentum thesis: the book says which side has pressure right now, momentum and smart money confirm the move is real, and then you hold it with a wide ratchet and let it work. Restricting the universe to four liquid majors keeps the imbalance reading reliable (thin books give garbage ratios), and a 24h hard timeout caps the short-horizon thesis without choking a real run.",
       "tags": [
         "btc",
@@ -4964,7 +5221,7 @@
       "emoji": "🐦",
       "tagline": "Maintains a daily-refreshed pool of the most consistent (ELITE/RELIABLE) Hyperliquid traders, reads each one's open book, and mirrors ONLY their single highest-conviction bet — and only when that one position dominates their whole book (e.g. ~98% of capital in one 3x position). Leans hardest when several elite traders independently pile into the same concentrated trade.",
       "belief_plain": "Looks past the leaderboard noise and keeps a shortlist of the steadiest, most-proven traders on Hyperliquid. Instead of copying everything they do, Oxpecker copies only the trade they're betting their whole book on — the one position that makes up most of their capital. When more than one of those proven traders is all-in on the same trade in the same direction, it bets harder, then trails a wide stop so the conviction can run.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "A proven trader's signal is loudest exactly when they concentrate. Cohort copiers average a pool and whale mirrors ride a fixed name list; Oxpecker does neither — it screens for the highest consistency tier (ELITE/RELIABLE) and then, within that elite set, only acts on positions that represent real conviction: where one bet is the overwhelming majority of the trader's book. A reliable trader with ~98% of their capital in one short is telling you something an opaque cohort average buries. Quality-tier x position-concentration is the whole edge — consensus across multiple elite traders on the same concentrated trade is the strongest signal there is, and the wide let-winners-run DSL respects that conviction rather than scalping it.",
       "tags": [
         "copy-trading",
@@ -5011,7 +5268,7 @@
       "emoji": "🦅",
       "tagline": "Hunts ELITE/RELIABLE traders who are winning big this week, reads the single bet driving their streak, confirms the smart-money crowd agrees and the asset hasn't already run away from the whale's entry, then piggybacks the same trade — sizing leverage to conviction (7/8/10x).",
       "belief_plain": "Finds the traders who are crushing it right now AND have a proven track record, figures out which position is making them the money, checks the smart-money crowd is leaning the same way, and copies that trade — but skips it if the price already ran too far past where the whale got in.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "A trader who is both proven (ELITE/RELIABLE) and hot right now is the best signal you can ride. Don't average a cohort and don't chase one-week wonders — find the quality account on a live streak, isolate the conviction bet driving it, confirm the smart-money crowd and recent price action agree, and follow only if you can still get in near the whale's entry.",
       "tags": [
         "smart-money",
@@ -5054,7 +5311,7 @@
       "emoji": "🐟",
       "tagline": "Autonomous smart-money whale mirror — auto-builds a top-trader cohort and mirrors their highest-conviction positions; optionally mirror specific whales you name via inputs.whales. Like a remora fish riding a shark, it leans hardest when several whales pile into the same trade (consensus) or when a whale is ELITE/RELIABLE tier.",
       "belief_plain": "Out of the box, Remora finds the most proven traders on Hyperliquid, watches their open positions, and copies the strongest bets — betting bigger when several of them are in the same trade and one has an elite track record. Prefer to ride specific traders you trust? Name them and Remora mirrors exactly those instead. Either way it trails a wide stop so the trade can run.",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "thesis": "Riding the highest-conviction position of proven traders keeps your exposure tracking real smart money, and the consensus multiplier means it leans hardest exactly when those traders independently agree — one whale can be wrong, three agreeing is a much stronger signal. By default Remora is autonomous: it auto-builds a top-trader cohort (all-time realized PnL, refreshed daily) so it always has whales to mirror — no config required. Name your own whales to make it ride exactly the traders you choose. Whales hold winners, so the exit lets the mirror run and only caps staleness.",
       "tags": [
         "whale",
@@ -5100,7 +5357,7 @@
       "emoji": "🪳",
       "tagline": "A patient striker: watches the top-50 smart-money leaderboard and fires only on violent FIRST_JUMP / IMMEDIATE_MOVER rank explosions confirmed by 4h trend, 1h price, fresh 15m velocity, and a 1.5x volume spike — then sizes one bet and lets a tight ratchet ride it. Long silences are expected and correct.",
       "belief_plain": "Cockroaches survive by not moving when there's nothing to chase. Roach watches which coins the best traders are suddenly piling into — a coin violently jumping up the leaderboard — and only buys when that rank-jump is backed by the 4-hour trend, the last hour's price, fresh momentum, and a real volume spike all agreeing. Most of the time it does nothing; the patience is the edge.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Most leaderboard movement is noise. Real edge is a violent, fresh rank-jump — a coin exploding from #25+ into the top of the smart-money board in a single scan — but only when it's confirmed by trend, price, fresh velocity, and volume at the same instant. Those explosions are rare, so the right move is to ban equities, demand a high composite score with multiple confirmations, take the few that qualify at fixed 7x sizing, and let a ratcheting DSL stop bank the move. Stalker-style accumulation entries were removed — fewer, higher-quality strikes beat more, mixed ones.",
       "tags": [
         "smart-money",
@@ -5146,7 +5403,7 @@
       "emoji": "🕶️",
       "tagline": "Watches a handful of vetted Hyperliquid traders and mirrors only the positions they NEWLY open — never inheriting a stale book mid-move — with a hard entry-slippage guard so you never chase a fill that already ran, plus budget-relative sizing with a min-notional floor.",
       "belief_plain": "Instead of copying one trader's whole account — and inheriting trades already deep in profit or loss at a worse price than they got — Shadow watches two or three proven traders and only acts when one of them OPENS a brand-new position. It checks how far price has already moved from their entry and skips the trade if it is too late to get a comparable fill. It sizes each mirror to your budget with a floor so a position is never too small to matter, and it manages its own exit.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "The failure mode of naive mirroring is entry drift: you inherit a book at a 1-5% worse price than the trader got, so the same trade is a loss for you. Shadow fires ONLY on fresh opens (a snapshot-diff against a seeded book, so nothing pre-existing is ever inherited), rejects any entry whose price has already run past a slippage cap, and can require multi-trader confirmation before committing size. You follow proven money at their price, not yesterday's book at yours. Leverage is capped, so a trader's 40x book becomes something survivable.",
       "tags": [
         "copy-trading",
@@ -5190,7 +5447,7 @@
       "emoji": "🐠",
       "tagline": "Reads the entire smart-money board every tick, ranks every asset by net smart-money conviction (tilt x notional x breadth), then rides the rotation — LONG the assets the best traders are crowding into and SHORT the ones they're fleeing, gated by price so it never fights a hard trend. Captures days like 'long semis/indices, short the crypto block'.",
       "belief_plain": "Most copy-trading bots ask 'are the best traders long this one coin?'. Stingray instead looks at the whole market at once and asks 'what are the best traders rotating INTO, and what are they rotating OUT OF?'. It buys the crowd's new favorites and sells the ones they're abandoning — but only when the price chart isn't already screaming the other way — then trails a wide stop so a real rotation can run for days.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Smart money doesn't just pick coins, it rotates capital across the whole board — out of one asset class and into another. Per-asset copy-traders miss this because they evaluate each market in isolation; they can't see that the SAME flow leaving crypto is funding the bid in indices. Stingray ranks the entire board by net tilt (long_ratio - 50) weighted by notional and trader breadth, so a strong, deep, widely-held lean outranks a thin spike, then takes BOTH sides at once — long the inflows, short the outflows — for a market-neutral-ish rotation book. A price-confirmation gate (no longs into a hard 4h downtrend, no shorts into a hard uptrend) keeps it from fighting price, and a DSL ratchet lets the winning legs run while cutting the losers.",
       "tags": [
         "smart-money",
@@ -5239,7 +5496,7 @@
       "emoji": "🐋",
       "tagline": "Buckets Hyperliquid traders by lifetime realized PnL into a smart-money cohort and a crowd, then positions WITH the smartest money — and against the crowd — wherever the smart cohort is heavily net-directional and adding to it daily.",
       "belief_plain": "Looks at where the most profitable traders on Hyperliquid are putting their money as a group, and copies that lean — going long what they're loading up on and short what they're dumping, especially when the average crowd is on the other side.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "You trust the aggregate of proven winners over any single guru or your own read. When the >$1M-realized crowd is piling into a coin day after day while the small accounts fade it, that divergence is the edge — so follow the smart cohort, not one whale, and hedge the book with a separate short sleeve.",
       "tags": [
         "smart-money",
@@ -5284,7 +5541,7 @@
       "emoji": "🦅",
       "tagline": "When BTC moves hard, crypto-correlated equities on Hyperliquid XYZ (Coinbase, MicroStrategy) follow late: Osprey self-computes each proxy's catch-up gap (leader move x its beta minus the move it has actually made), and when a proxy still owes a gap in the leader's direction it enters the proxy that way and lets a wide DSL ride the catch-up.",
       "belief_plain": "When Bitcoin makes a big move, the crypto-flavored stocks on the XYZ exchange (Coinbase, MicroStrategy) usually move the same way — but a beat late, because they are priced on a different venue. Osprey works out how far behind each one is and bets it catches up, then trails a wide stop so the catch-up can run for a day or two.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "A crypto-correlated equity has a known beta to BTC (COIN ~1.8x, MSTR ~2.5x), so a BTC move implies an expected proxy move. But XYZ pricing trails spot crypto around its reference windows, so the proxy's actual move lags — a measurable, tradeable gap. Trading the lag (not the leader) means entering in the leader's confirmed direction only when the proxy still owes catch-up, which sidesteps the chase-the-leader failure mode and lets the structural pricing lag, not a directional guess, be the edge.",
       "tags": [
         "xyz",
@@ -5333,7 +5590,7 @@
       "emoji": "🦝",
       "tagline": "Trades only the weekend, only on tokenized stocks & commodities (XYZ): while the underlying markets are closed and XYZ runs on an internal oracle, Raccoon positions in the direction sentiment has been pushing the price — and captures the snap-back when real external pricing resumes Monday open. Sizes 15% / 3x and rides a tight DSL with a 48h Monday-exit cap.",
       "belief_plain": "From Friday evening to Sunday evening the real stock and commodity markets are closed, so tokenized versions on XYZ drift on an internal estimate instead of a live price. When trading resumes Monday, that estimate snaps to the true market price. Raccoon bets in the direction the weekend drift (plus the best traders) is leaning, and exits into that Monday snap — and only ever runs on the weekend.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Fri 17:00 ET -> Sun 18:00 ET, trade.xyz has no external price feed for equities/commodities and runs a 30-min EWMA internal oracle that drifts on impact-price activity. Accumulated weekend sentiment (>= 2% move + volume + smart-money agreement) shows up as directional oracle drift; when external pricing resumes Sunday evening the implied price reconciles to the real value. Positioning into that gap and exiting at the Monday-open snap is the edge — and confining all activity to the weekend window avoids weekday false signals and Lemur's 24/7 IPOP territory.",
       "tags": [
         "xyz",

--- a/strategies/catalog.json
+++ b/strategies/catalog.json
@@ -1,6 +1,6 @@
 {
   "_version": "2.1",
-  "_updated": "2026-08-13",
+  "_updated": "2026-08-28",
   "_generated": true,
   "_instructions": "GENERATED from each strategy package's strategy.yaml — do not hand-edit; run senpi-trading-runtime/scripts/gen_catalog.py. Agents read this via senpi-strategy-discover (scripts/discover.py). DECLARED fields (archetype, sub_style, asset_classes, asset_scope, risk_level, tier, belief_plain, direction) are author-set in strategy.yaml `catalog:`; DERIVED fields (assets, leverage_max, funding_split, instance_count, cadence_seconds, time_horizon, max_slots) are computed from instances/params. Labels/glosses come from senpi-strategy-discover/references/glossary.yaml. 'min_budget' is the machine-COMPUTED minimum total budget at which the design functions (min_budget.py) — the smallest budget where every wallet funds and its smallest slot clears the $12 bumped notional; 'wallet_count' + 'min_budget_binding_wallet' explain it. It is NOT authored — deleting an authored min_budget is a no-op; use min_budget_floor to RAISE it. Positions scale with budget above the min. A strategy is a deployable package; install via senpi-strategy-ops.",
   "skills": [
@@ -10,7 +10,7 @@
       "emoji": "🦈",
       "tagline": null,
       "belief_plain": "Continuously scans every liquid crypto and xyz: equity perp for breakouts and breakdowns, opens with the strongest momentum in either direction (confirmed by smart-money positioning, funding squeeze and rising open interest, with a size bonus for the harder-pumping small caps), lets winners run on a trailing stop, and banks the whole book once total profit hits its target.\n",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "You want an always-on screener that hunts the hottest moves across the entire market — long the breakouts, short the breakdowns — instead of watching a fixed basket, and you accept the higher turnover and leverage that pump-chasing implies.\n",
       "tags": [
         "breakout",
@@ -62,7 +62,7 @@
       "emoji": "🦅",
       "tagline": "An onboarding-grade breakout trader on the liquid majors (BTC/ETH/SOL): goes LONG when price breaks above its 7-day high AND smart-money is net long, SHORT when it breaks below the 7-day low AND smart-money is net short, then cuts failed breakouts fast (tight 8% Phase 1) while letting a real one run on a wide Phase 2 ratchet.",
       "belief_plain": "Watches BTC, ETH and SOL. When one of them breaks above its highest price of the last week and the best traders are also leaning long, it buys; when one breaks below its weekly low and the best traders are leaning short, it sells short. A fake breakout gets cut quickly, but a real one is given lots of room to run.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Most breakout strategies lose because they fight the trend, chase fake breakouts into stop-hunts, or hold failed breakouts too long. Hawk requires three things at once — a genuine break of the 7-day range, the 4h trend pointing the same way, and the smart-money leaderboard net in the breakout direction — so it only fires on confirmed breaks. Then the asymmetry does the work: an 8% Phase 1 floor cuts a breakout that fails immediately, while a wide Phase 2 ladder (first lock only at +10% ROE) keeps the rare breakout that runs, because that tail pays for the quiet weeks.",
       "tags": [
         "btc",
@@ -113,7 +113,7 @@
       "emoji": "🐫",
       "tagline": "Harvests funding carry across the liquid main-DEX crypto cross-section: the HARVEST book SHORTS the most-positive-funding names (longs pay shorts → short collects) and the PAYOUT book LONGS the most-negative-funding names (shorts pay longs → paid to hold) — both gated to EXHAUSTING crowds (4h trend + RSI confirmation) so price doesn't fight the carry — on two equally-funded wallets that net the fund slightly market-neutral.",
       "belief_plain": "On Hyperliquid you get paid (or pay) funding every hour for holding a perp. Camel always takes the side that COLLECTS that payment — it shorts coins where longs are paying through the nose, and longs coins where shorts are paying — but only on crowds that are running out of steam, so the price doesn't move against it while it banks the funding.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Funding is a recurring, structural inefficiency: when a trade gets too crowded, the funding rate blows out and the collecting side gets paid to hold. The edge is that carry, not market direction — so Camel ranks the whole liquid crypto board by funding and takes the most-extreme collecting side, but only when the crowded trade is exhausting (4h rolling over for shorts / capitulating for longs, RSI confirming) so price doesn't fight the carry. Taking some shorts and some longs also skews the fund net-neutral as a by-product.",
       "tags": [
         "funding",
@@ -160,7 +160,7 @@
       "emoji": "🦅",
       "tagline": "A contrarian fader on the 6 deepest XYZ macro markets (oil, brent, gold, silver, SP500, XYZ100): when smart money is piled into one side AND the 4h move is exhausting, it takes the OPPOSITE side and lets a wide DSL ride the mean-reversion for hours.",
       "belief_plain": "Trades only macro markets — oil, gold, silver, and the big stock indices — that run around the clock. When the best traders have all crowded into one direction and the move over the last few hours is already stretched, it bets on the snap-back the other way, sizes up when more signals agree, and trails a wide stop so a slow reversal has hours to play out.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Macro assets on Hyperliquid attract directional momentum traders who load up after a clean 1-3% intraday move. By the time smart-money concentration crosses 10-20% on a 4h-extended move, the trade is usually exhausted — mean reversion is the positive-edge play. Bald Eagle scores SM crowding + contribution velocity + move exhaustion, hard-gates on tight book spread, fades the crowd, and gives commodities the wide exit they need to revert.",
       "tags": [
         "xyz",
@@ -217,7 +217,7 @@
       "emoji": "🍋",
       "tagline": "Watches where the worst, most crowded traders are piling in across a fixed basket of 12 crypto majors and 4 commodity/index names — and once that one-sided crowd stops following through (its 15-minute momentum rolls over), takes the OTHER side at conviction-scaled leverage and lets a wide ratcheting stop ride the snap-back.",
       "belief_plain": "When a lot of low-quality traders crowd hard onto one side of a coin and the move starts running out of steam, that crowd usually gets unwound. Lemon waits for the crowding to actually start fading on the 15-minute clock, blocks the trade if it's really a genuine trend (big BTC move or the asset itself ripping), then bets the OPPOSITE direction and trails a wide stop while the over-stretched move mean-reverts.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Hyperliquid is full of high-leverage retail that piles into exhausted moves. A crowded smart-money consensus is only a fade setup once it STOPS following through — so Lemon gates on 15m exhaustion, not just crowding, and refuses to fade a real run (crypto MACRO gate on |BTC 4h|>3%, per-asset gate on |4h|>5%) because fading genuine trend is how a contrarian dies. Concentration + velocity-fade + overextension + reversal compound into a score; it fires the single best fade at score >=9, sizes leverage to conviction, and lets a wide DSL ride the mean reversion since reversals take hours, not minutes.",
       "tags": [
         "degen-fader",
@@ -283,7 +283,7 @@
       "emoji": "🦉",
       "tagline": "Scans every liquid Hyperliquid crypto perp (OI > $3M) for one-sided crowding — extreme funding + lopsided smart money + concentrated OI — then waits for that crowding to persist 1h+ AND for exhaustion to fire (volume fading, price stalling, RSI divergence) before fading the crowd. Conviction-scaled leverage (7/8/10) at 25% margin, with a macro gate that stands down when BTC's 4h move is extreme.",
       "belief_plain": "The crowd is wrong at the extremes. When everyone piles onto one side of a coin — paying punishing funding, the best traders all leaning the same way, open interest stacking up — and the price then stops following through, the unwind is violent and predictable. Owl waits for both the crowded state AND the exhaustion trigger, then takes the other side. Most days it does nothing, because most days one or both is missing.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Crowded trades unwind violently. Owl's edge is timing the unwind: it never fades on crowding alone (which can persist and grind), it waits for crowding to PERSIST 1h+ and for distinct exhaustion signals (declining volume under extreme funding, price stalling against the crowd, capitulation wicks, 4h RSI divergence) to confirm the move is dying. Mean reversion fails in trending macro, so a hard gate blocks all fades when |BTC 4h| > 3%. XYZ banned — the funding/smart-money scoring is calibrated on crypto data shape.",
       "tags": [
         "contrarian",
@@ -329,7 +329,7 @@
       "emoji": "🦔",
       "tagline": "Scans every liquid perp for funding that has stayed extreme for hours — the crowd piled onto one side and is paying to hold it — then fades that crowd at exhaustion, collecting funding while the over-stretched position mean-reverts.",
       "belief_plain": "When everyone crowds the same side of a trade and keeps paying a steep funding fee to stay there for hours, that crowd usually unwinds. Pangolin waits for the crowding to actually persist, checks the smartest traders aren't on the crowd's side, then takes the OTHER side and gets paid funding while it waits for the snap-back.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Persistent extreme funding is a crowding signal, not noise. A fresh funding spike means nothing — but funding that stays extreme for 3+ hours means real positioning that has to unwind. Fade the crowd only once the regime confirms (or is at least neutral), size conservatively because crowded unwinds are violent, and let the funding you collect pay you to be patient through a 24-48h mean reversion.",
       "tags": [
         "funding-fade",
@@ -373,7 +373,7 @@
       "emoji": "🐺",
       "tagline": "Maintains a daily-refreshed pool of the top-ROI Hyperliquid traders (win-rate + age + 30d-ROI filtered, quality-scored toward tail-winner trend-followers), watches for the moment a pool member opens a fresh position, and mirrors only the freshest entries (< 10 min old) when pool consensus and independent TA confirm — sized to the source trader's quality and ridden on its own wide DSL.",
       "belief_plain": "Keeps a shortlist of the most profitable traders on Hyperliquid and refreshes it every day. The instant one of them opens a new trade, Jackal copies that trade in the same direction — but only if the entry is brand new, other shortlisted traders are leaning the same way, and the chart agrees. It bets a bit more behind the highest-quality traders and then trails a wide stop so a good copy can run for days.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "High-quality traders telegraph alpha, but naive copy-trading loses because winners regress, signals lag, and style mismatches amplify risk. Jackal only copies the freshest entries (< 10 min, before the alpha is public) from a pool ranked toward tail-winner trend-followers (ROI 35% / gain-to-pain 25% / age 15% / win-rate 10% — deliberately NOT high-win-rate scalpers), and confirms each copy with pool consensus + independent multi-timeframe TA + funding regime before sizing to the source's quality and riding its OWN DSL rather than the source trader's.",
       "tags": [
         "copy-trading",
@@ -418,7 +418,7 @@
       "emoji": "🐢",
       "tagline": "A time-triggered dollar-cost-averaging scheduler on a small basket (BTC/ETH/SOL): no price prediction, no scoring, no timing — each tick it buys a fixed % of budget on whichever asset is most overdue past its DCA interval, always LONG, and lets a wide DSL ratchet ride the accumulation for days.",
       "belief_plain": "Buys a fixed slice of your budget on a strict schedule — by default every 24 hours, one of BTC, ETH or SOL at a time. It predicts nothing; it just keeps accumulating on cadence and trails a wide stop so the position can run instead of getting churned. The most-overdue coin goes first.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Dollar-cost averaging is the single most accessible trade in crypto and needs zero prediction skill. Every other agent makes a directional call; Tortoise makes none — it buys on a clock. Cadence IS the signal: when an asset has gone longer than the interval since its last buy it is due, never-bought assets are always due, and the most-overdue wins. A very wide let-winners-run DSL (30d hard_timeout) lets the accumulated longs compound while Phase-2 locks bank gains gradually.",
       "tags": [
         "btc",
@@ -470,7 +470,7 @@
       "emoji": "🐦",
       "tagline": "Trades the full pre-IPO → listing → graduation arc of tokenized equities on Hyperliquid XYZ: a pre-listing book accumulates pre-IPO perpetuals (IPOPs) into the IPO, and a graduation book rides the explosive post-conversion price discovery — the SpaceX $1.4B-day-1 pattern.",
       "belief_plain": "Auto-finds brand-new pre-IPO contracts (like a SpaceX-before-it-lists perp) by their tell-tale tiny funding and low leverage cap, rides the trend into the IPO, then detects the moment they convert to a full equity perp and rides the fireworks of the first few days of free price discovery.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "You think the biggest, most repeatable edge on Hyperliquid right now is the new-listing EVENT itself, not the ongoing equity market. Pre-IPO perpetuals trade throttled and quiet; the instant they graduate to a standard equity perp the funding jumps ~100x, the leverage cap lifts and price discovery goes vertical. Capture both halves of that arc with two books on two wallets so the slow accumulation and the explosive pop never fight over the same margin.",
       "tags": [
         "ipo",
@@ -519,7 +519,7 @@
       "emoji": "🐘",
       "tagline": "Trades the cross-asset macro complex — equity indices, precious metals, energy, FX (all on XYZ) plus BTC — on two books and two wallets: the TREND book rides the durable multi-timeframe macro trend (both directions); the FADE book fades short-TF over-extensions back to regime (both directions, with a knife guard). The edge is GLOBAL MACRO — the complex moves on regime, not crypto noise.",
       "belief_plain": "Trades the big global markets — stock indices, gold/silver/copper, oil and gas, the major currencies, and Bitcoin. One book rides the slow, durable trends (buying things going up, shorting things going down); a second book on a separate wallet bets on stretched moves snapping back. It only fades a snap-back when the bigger trend isn't fighting it.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Crypto-only funds all crowd the same coins; the cross-asset macro complex (indices / metals / energy / FX) moves on macro regime — oil on geopolitics, indices on the AI-equity bid, metals on risk-off — and is uncorrelated with crypto noise. Running a trend book AND a mean-reversion book on the same macro whitelist, on two wallets, harvests both the durable direction and the over-extensions without the two conflicting. These markets trade 24/7 on Hyperliquid XYZ, so the fund never has to wait for a market open.",
       "tags": [
         "macro",
@@ -589,7 +589,7 @@
       "emoji": "🦡",
       "tagline": "Only takes the breakout the order flow confirms: enters a prior-24h range break on BTC/ETH/SOL/HYPE only when open interest is RISING (new money committing) AND smart money agrees with the break — then sizes 20% / 5x and lets a wide DSL ratchet ride the move for days.",
       "belief_plain": "Most price breakouts fail. The single best filter for whether a breakout will follow through is open interest: if price breaks its prior 24-hour high (or low) while open interest is rising, new money is committing and the move has conviction. If open interest is flat or falling, it's just stops and short-covering — a fakeout — and Badger skips it. It also checks that the best traders are leaning the same way before it commits.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Open interest is the fuel of a breakout. A price push beyond the recent range confirmed by rising OI = new positions opening in the breakout direction = real follow-through; a breakout on flat/declining OI is shorts covering or stops triggering, with no new money behind it. Gating breakouts on OI velocity (plus smart-money agreement) filters the fakeouts that kill a naive breakout buyer, and a wide let-winners-run exit ladder means the rare confirmed breakout that runs far pays for the ones that don't.",
       "tags": [
         "btc",
@@ -641,7 +641,7 @@
       "emoji": "🦪",
       "tagline": "An autonomous decoupler on Hyperliquid XYZ equity/commodity/index perps: it finds names quietly DECOUPLING from the broad market — outperforming the xyz index on persistent rising volume with shallow, bought dips (relentless accumulation, not a one-bar spike) — and rides the grind. No calendar, no event feed: the catalyst footprint is read straight from the tape. LONG up-accumulation, SHORT down-distribution; a wide DSL ratchet lets winners run.",
       "belief_plain": "Big catalysts — a stock getting added to an index, a buyout brewing, a sector run-up — all leave the same tell in the chart before anyone needs to know the news: the name starts beating the broad market on steady, rising volume, and every dip gets bought instead of selling off. That is accumulation, and Barnacle hunts for it automatically across the stocks, commodities and indices on Hyperliquid XYZ. It doesn't need you to feed it a calendar — it reads the footprint itself, goes long the quiet climbers (or short the quiet bleeders), and trails a stop so a real move can run for days.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "You don't need to know WHY a name is being accumulated to trade the accumulation. Index inclusions, M&A targets, and catalyst run-ups share one observable signature: the name decouples from its benchmark (positive excess return vs the broad xyz market) on PERSISTENT rising volume, and the largest pullback within the move stays shallow because the dips are bought — a grind, not a volatile breakout. Barnacle measures exactly that footprint from market data: excess return vs xyz:XYZ100 sets direction and conviction, 4h volume persistence and a shallow-deepest-dip confirm it's accumulation not noise, 4h/1h trend structure confirms the path, and a smart-money lean nudges the score. Because the edge is read from the tape rather than an event date, the agent needs no operator calendar and the DSL owns the exit — a wide let-winners-run ratchet rides the grind, with a 48h cap so equity/index perps don't camp through the weekend pricing gap.",
       "tags": [
         "accumulation",
@@ -694,7 +694,7 @@
       "emoji": "🦬",
       "tagline": "A patient multi-asset momentum holder on liquid majors (BTC/ETH/SOL): enters only when a 9-factor composite (4h/1h trend structure, 1h/4h momentum, smart-money lean, funding, volume, OI proxy, RSI) clears a high conviction floor, then sizes margin to conviction (25/31/37%) and lets a wide DSL ratchet ride the move for days.",
       "belief_plain": "Trades only the big, liquid coins (BTC, ETH, SOL). It waits until the 4-hour and 1-hour trend, momentum, the best traders, and funding all line up the same way before entering, bets bigger when more of them agree, and then trails a wide stop so a real move can run for days instead of getting chopped out early.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "You want few, high-conviction trades on coins deep enough to size into, not a scattergun across thin small-caps. Restricting to BTC/ETH/SOL kills the small-cap-volume-spike failure mode (a thin coin spiking into the universe and consuming a slot), and a demanding multi-factor floor means the agent only acts when a real directional thesis exists — then it holds, because the edge is in the tail of the move, not the entry.",
       "tags": [
         "btc",
@@ -744,7 +744,7 @@
       "emoji": "🐕",
       "tagline": "Scans the whole liquid market for the patterns traders actually draw and trades whichever way the pattern points. A double bottom goes long once price reclaims the peak between the two lows; a double top goes short on a break of the trough; intact higher-high or lower-low structure is traded as continuation. Every pattern must clear a depth and magnitude floor so noise can't manufacture one, and each coin+pattern fires at most once per 6 hours.",
       "belief_plain": "Instead of watching one coin, this hunts the entire liquid market for recognisable chart setups — the double bottom (a W), the double top (an M), and clean staircase trends. It doesn't take the pattern on faith: the two lows have to be at genuinely the same level, the shape has to be deep enough to matter, and price has to actually break the confirmation line before it commits. It has no opinion on direction — if the chart says down, it shorts. And it won't keep re-entering the same setup, because a pattern that's on the chart today is still there tomorrow.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Pattern recognition is the most common way retail traders actually read a chart, and the catalog had no equivalent — the closest template reads market structure on a single name rather than hunting setups across a universe. The engineering that matters is not finding patterns but refusing bad ones: swing pivots come from a symmetric fractal window (so a pivot needs bars of hindsight on both sides and cannot be invented at the live edge), the two lows of a W must sit within a tolerance of each other and be separated by real time, the shape must clear a depth floor, and continuation structure must STEP by a minimum percent — without that last gate random data produces a clean 'lower low' about half the time. Direction is an output of the pattern, never an input.",
       "tags": [
         "pattern",
@@ -796,7 +796,7 @@
       "emoji": "🐱",
       "tagline": "Two volatility books on two wallets — one scans liquid crypto, the other scans tokenized stocks/commodities/indices (XYZ) — for names coiled in a low-volatility squeeze that break their recent range with an expansion surge, then rides the break direction (LONG up / SHORT down). It trades MOVEMENT, not a view: the edge is that compression precedes expansion.",
       "belief_plain": "Watches the market for coins and stocks that have gone quiet (price barely moving), then pounces the moment one breaks out of its quiet range with a big jump — going long if it breaks up, short if it breaks down. It runs two separate pots: one for crypto, one for tokenized stocks and commodities. The bet is on the size of the move, not its direction.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Volatility is the edge. A breakout FROM a low-volatility coil has far higher follow-through than a breakout in already-volatile tape — compression precedes expansion. Caracal only fires when a name has been coiling (recent ATR << baseline ATR) AND breaks its range AND the breakout bar is an outsized move, then rides whichever way it broke. Splitting crypto (breakout book) from tokenized stocks/commodities/indices (catalyst book) lets it capture oil-geopolitics and AI-infra moves 24/7 alongside crypto vol, on two separately-funded wallets that net to a direction-agnostic volatility harvester.",
       "tags": [
         "volatility",
@@ -851,7 +851,7 @@
       "emoji": "🦅",
       "tagline": "Scans the top 50 Hyperliquid crypto assets by volume and fires at most one position at a time — only when 4h, 1h and 15m momentum all align, the smart-money leaderboard is leaning the same way on a market it is actually concentrated in, and the move isn't a runaway counter-trend. Sizes margin to conviction (50/70/80%) at 10x, then rides a wide DSL.",
       "belief_plain": "Watches every liquid coin on Hyperliquid and waits, doing nothing until ONE setup is near-perfect: the trend, the momentum and the best traders all pointing the same direction at once. Then it takes a single, well-sized swing and trails a stop instead of guessing the top.",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "thesis": "The biggest swings happen when 4h + 1h + 15m momentum are perfectly unified AND the smart-money leaderboard is leaning that same way on a market it has meaningful skin in — a runaway trend's continuation, not a reversal. One amazing trade a day beats a scattergun: scan broadly, fire rarely, size to conviction, and never fight a trend already up >10% on the 4h.",
       "tags": [
         "momentum",
@@ -895,7 +895,7 @@
       "emoji": "🦅",
       "tagline": "Watches every Hyperliquid XYZ pre-IPO perpetual and fires the moment one converts to a normal equity perp — when the company IPOs, funding jumps ~100x, the leverage cap lifts and the price throttle comes off, opening a window of free price discovery. Falcon catches that flip and rides the post-conversion momentum with a wide let-winners-run stop (7d).",
       "belief_plain": "A pre-IPO name on Hyperliquid is deliberately pinned — its price can barely move. The instant the company goes public the brakes come off all at once and the name often trends hard for days. Falcon detects that exact handover from a tell in the funding rate, then takes a single position in the direction it's already running and trails a wide stop so a real move can run.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "The IPOP->equity conversion is a detectable regime change: funding normalizes ~100x, the max-leverage cap lifts, and the trade.xyz Discovery-Bounds price throttle is removed. The first hours-to-days after conversion are pure price discovery, which often trends in one direction. The edge is catching that flip from the instrument's funding/leverage signature, confirming directional momentum, and letting the discovery move run rather than fading it.",
       "tags": [
         "xyz",
@@ -940,7 +940,7 @@
       "emoji": "🐇",
       "tagline": "A fast BTC/ETH scalper that only trades inside the Asia, London, and US high-volume windows — scoring a 30-minute momentum burst backed by real volume, targeting roughly 1:3 risk-reward at 5-10x. Maker-only entries and a hard per-name cooldown keep it from churning into fees.",
       "belief_plain": "This trades only the two most liquid coins, Bitcoin and Ethereum, and only during the hours when the market is actually busy — the Asia, London, and US sessions. It waits for a quick burst of momentum backed by a real jump in volume, takes a leveraged position aiming to make about three times what it risks, and gets out fast if it's wrong. Crucially, it posts its orders to earn the maker rebate instead of paying to chase, and it refuses to re-enter the same coin for 45 minutes — because at this speed, fees are what kill a scalper.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "A sub-hourly scalper lives or dies on cost. The edge — a volume-backed momentum burst at a session open — is real but small, so the whole design is built to protect it: session gating means it only trades when moves are large enough to matter, a volume floor rejects fee-bait bursts on thin tape, maker-only entries turn the fee from a cost into a rebate, and a hard per-name cooldown plus a daily entry cap make churning structurally impossible. The DSL is tuned for asymmetry — a tight stop, a profit-lock that arms at ~3x the risk — so the winners pay for the losers.",
       "tags": [
         "scalp",
@@ -992,7 +992,7 @@
       "emoji": "🦔",
       "tagline": "Equal-weight BTC + ETH + SOL, each leg independently directional: every asset gets its own Smart-Money-confirmed 4h-trend signal (long OR short), so it can hold BTC long and ETH short at the same time — three slots, three independent positions, each with its own per-position stop.",
       "belief_plain": "Trades only the three biggest crypto majors (BTC, ETH, SOL), one position per coin. For each coin it waits until the 4-hour trend and the best traders agree on the same direction before entering — going long if they're bullish, short if they're bearish — and manages each position on its own, so one coin going wrong doesn't drag the others down.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Most basket strategies force the same direction across every asset; Hedgehog doesn't. Each of BTC/ETH/SOL gets its own independent Smart-Money-confirmed 4h-trend decision, so the diversification benefit is real — the per-asset directions are uncorrelated by construction. For a new user who wants 'exposure to crypto majors without picking one,' Hedgehog does the picking: it enters when the gates pass and lets a per-position DSL ratchet ride each leg on its own merits.",
       "tags": [
         "btc",
@@ -1043,7 +1043,7 @@
       "emoji": "🐔",
       "tagline": "Rooster's companion, for stocks. In the 45 minutes before the US market opens (default 13:30 UTC, weekdays only) it reads the pre-open setup on a big-tech equity basket — NVDA, TSLA, AAPL and nine more — and positions into the open across the 3-4 strongest names at once, not just one. Per name: the pre-open drift sets direction, expanding volume confirms real positioning, a break of the prior session's range adds conviction. Ranks every qualifier by score and takes the best few, long or short, 2-5x, with a session-aware DSL ladder that banks the open move and is flat before the weekend.",
       "belief_plain": "The move that matters often shows itself in the 30-60 minutes before the opening bell — and it rarely shows in just one stock. Hen wakes 45 minutes before the US market opens, checks the whole big-tech basket for names drifting one way on real volume, ranks them, and positions into the open across the 3-4 strongest at once. It only runs on trading days (no bell on weekends means nothing to position into), fires at most once per name per open, banks profit early, and a session timeout means nothing is still holding when the weekend arrives. Where Rooster is one BTC leg into the open, Hen is a small equity book into the same event.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Rooster proved the clock is a signal on one asset; Hen runs the same engine as a breadth play across an equity basket. The US cash open (13:30 UTC in EDT, 14:30 in EST) is the most reliable recurring liquidity event of the day, and pre-open drift-on-volume is a directional tell — but on a basket the edge is picking WHICH names are setting up, so Hen scores every name in the window and commits to the top few by conviction rather than betting one. Two things make it equity-correct and not a naive Rooster clone: a TRADING-DAY gate (a weekend or overnight tick finds no open to position into and emits nothing), and a session hard_timeout that guarantees the book is flat before the Friday-to-Sunday XYZ oracle gap. Universe, session times, pre-open window, basket size and the noise floor are all inputs.",
       "tags": [
         "session",
@@ -1108,7 +1108,7 @@
       "emoji": "🐝",
       "tagline": "A semiconductor / AI-capex supply-chain momentum basket on Hyperliquid XYZ (equipment ASML/AMAT/MRVL, logic NVDA/AMD/AVGO/TSM/QCOM/ARM/INTC/SMH, memory MU/SNDK/SMSN/SKHX/WDC): it only trades when the whole chain confirms as a complex — a sector-breadth gate flips it long-only when most names trend up and short-only when the chain rolls over — then rides the strongest 1-2 names, with an extra edge when the equipment makers lead the move. Flat 18% margin / 4x, wide DSL ratchet capped at 48h so it never camps through the weekend pricing gap.",
       "belief_plain": "Trades the semiconductor supply chain — the chip designers, the memory makers, and the equipment companies that build the factories — as perps on Hyperliquid XYZ, 23/5. AI spending bids the whole chain together, so Hornet refuses to trade single names in isolation: it first checks whether the sector as a whole is trending up or down, and only then takes the strongest 1-2 names in that direction. It pays special attention when the equipment makers move first, since that tends to lead the cycle. It trails a wide stop so a real move can run, but caps each hold at 48 hours so it never sits through the Friday-to-Sunday gap when these names have no external price.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "AI capex doesn't bid one chip name — it bids the entire semiconductor supply chain: equipment makers (ASML, AMAT, MRVL), logic/compute (NVDA, AMD, AVGO, TSM, QCOM, ARM, INTC, SMH), and memory (MU, SNDK, SMSN, SKHX, WDC). A per-name momentum agent can get chopped up taking a single semi that's moving on idiosyncratic news against a flat sector. Hornet's edge is that it requires the chain to confirm as a complex first — a sector-breadth gate (the fraction of the universe whose 4h trend is bullish) flips the agent long-only above 0.55 and short-only below 0.35, and emits nothing in the chop band between. Within an open gate it rides the strongest 1-2 names and adds conviction when the equipment sub-group leads (capex tools bid first, then logic and memory — the classic early-cycle gradient). The 48h hard_timeout is intentional: equity perps reconcile against an internal oracle over the weekend gap where drift accumulates without external price discovery.",
       "tags": [
         "semiconductors",
@@ -1177,7 +1177,7 @@
       "emoji": "🦤",
       "tagline": "Two strategies behind one gate. It first decides whether a market is TRENDING or RANGING on the 4-hour chart (Kaufman efficiency ratio + structure), then applies the entry rule that belongs to that regime: a continuation entry when trending — confirmed by RISING open interest, so it only joins moves new money is committing to — or a fade of the range edge when ranging, skipped outright when funding is extreme. In between the two is a deliberate no-trade band. Long & short, 2-5x.",
       "belief_plain": "Most strategies only work in one kind of market: trend-followers get chopped to pieces in a sideways market, and mean-reverters get run over when a real trend starts. Ibis checks which kind of market it's in before deciding what to do. If price is genuinely travelling in one direction it joins the move — but only if open interest is rising, meaning new money is actually backing it. If price is just bouncing in a range it buys the bottom and sells the top instead — unless funding has gotten extreme, which usually means the range is about to break, in which case it stays out. When it can't tell which regime it's in, it does nothing.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "The regime question comes before the entry question, and most retail strategies never ask it — which is why the same rule that prints in a trend bleeds in chop. The Kaufman efficiency ratio (net move divided by the path actually travelled) separates the two cleanly and cheaply: a directional market covers nearly all of its path, a choppy one retraces itself. Each regime then gets the confirmation that specifically protects it — OI velocity for trend entries, because a breakout on flat OI is short-covering rather than commitment; funding extremes for range fades, because crowded funding precedes the break that kills a fader. The gap between the thresholds is a no-trade band by design: an ambiguous regime gets no rule at all, rather than the closest one.",
       "tags": [
         "regime",
@@ -1228,7 +1228,7 @@
       "emoji": "🐦",
       "tagline": "The textbook RSI + MACD setup, supervised: a MACD signal-line crossover (12/26/9) on 1h candles triggers the entry, RSI(14) confirms (room above 50 for longs, below 50 for shorts) and vetoes it at the overbought/oversold extreme, 4h trend structure adds context. Trades a liquid-majors basket (BTC/ETH/SOL/BNB/XRP/AVAX/LINK/DOGE) long & short at 3-5x with a balanced DSL that locks profit from +8% ROE.",
       "belief_plain": "The two indicators everyone knows, run for you the way the textbook says. It waits for MACD to cross its signal line, checks that RSI agrees and isn't already stretched, prefers trades that line up with the 4-hour trend, then trails a stop that starts protecting profit once you're up ~8%. Classic technical analysis on the big, liquid coins — no black box.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "RSI and MACD are the single most-requested retail build ('a strategy based on RSI and MACD'), yet no template was positioned as one. Kingfisher is that on-ramp: a faithful, well-labelled crossover-plus-confirmation strategy on names deep enough to size into, with the runtime owning execution, sizing, slots, and a disciplined trailing exit — so a familiar chart setup becomes a supervised, always-on strategy instead of a manual watch.",
       "tags": [
         "rsi",
@@ -1288,7 +1288,7 @@
       "emoji": "🦤",
       "tagline": "Trades pre-IPO companies as perpetuals on Hyperliquid XYZ — today just SpaceX (xyz:SPCX). Auto-discovers IPOPs via the trade.xyz funding signature (~100x smaller funding) plus a <=5x pre-listing leverage cap and a $100k liquidity floor, then goes long or short when the 4h trend structure and Smart-Money lean agree. Leverage auto-caps to each name's own ceiling; a moderate DSL lets multi-day theses ride.",
       "belief_plain": "Hyperliquid XYZ is one of the only places retail can trade private companies (like SpaceX) as perpetuals before they IPO. Lemur watches those pre-IPO names, waits for the 4-hour trend and the best traders to point the same way, then takes a single directional position and trails a stop. When a company actually goes public it stops qualifying and Lemur drops it automatically.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Pre-IPO perpetuals (IPOPs) are a structurally distinct product — a 0.005 funding multiplier (vs 0.5 for standard XYZ perps) and Discovery Bounds that throttle price velocity. That structural funding signature reliably identifies them with no hardcoded ticker list, so the universe future-proofs itself as trade.xyz lists new names and de-qualifies any that IPO. On those slow-moving names, a clean 4h trend confirmed by Smart-Money direction is enough edge to hold a directional swing and let a wide DSL ratchet capture the multi-day move.",
       "tags": [
         "pre-ipo",
@@ -1336,7 +1336,7 @@
       "emoji": "🐯",
       "tagline": "A multi-asset momentum holder on liquid majors (BTC/ETH/SOL/HYPE) that learns its own conviction floor: every 6 hours it audits its own closed trades, buckets them by entry score, and ratchets its MIN_SCORE up above any score band that has been losing money — then enters only candidates that clear the learned floor and lets a wide DSL ride the move.",
       "belief_plain": "Trades the big, liquid coins (BTC, ETH, SOL, HYPE) on a simple momentum score. Every six hours it looks back at its own finished trades, figures out which score levels have actually been making money and which have been losing, and raises its own bar so it stops taking the kinds of trades that bled — it only ever raises the bar, never lowers it. When a coin clears the current bar it bets and trails a wide stop so a real move can run.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "A fixed entry threshold is a guess that goes stale: the market regime that made score-6 trades profitable last month may make them losers this month. Instead of an operator hand-tuning MIN_SCORE off a 30-trade table, Lynx bakes that loop into a scheduled audit — it reads its own closed-trade history, buckets by the entry score it logged, and raises the floor above any band whose realized ROE has turned negative with enough samples to trust. It ratchets up only (a floor that worked is never relaxed), caps at a hard ceiling, and otherwise runs a plain momentum scorer so the audit always has clean data to learn from.",
       "tags": [
         "btc",
@@ -1389,7 +1389,7 @@
       "emoji": "🦦",
       "tagline": "A sentry that watches the momentum-event feed and snipes the freshest, highest-tier move the instant it fires: tier (event magnitude) + freshness gate the entry, smart-money alignment and rising volume add conviction, then it takes ONE position in the momentum direction and lets a wide DSL ride the burst.",
       "belief_plain": "Watches a live feed of coins that just made a sharp move in the last few hours, and pounces only on the strongest, freshest ones — before the move is widely known. It sizes one bet in the direction of the move and trails a wide stop so a real burst can keep running, but cuts it loose after about a day and a half if it stalls.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Fresh momentum is the earliest, cleanest edge, and it decays fast — an event that's already 30+ minutes old is half-known and somebody else's trade. So the whole job is speed plus selectivity: only the strongest tiers, only while they're fresh, one position at a time. Smart-money lean and rising volume are confirmation bonuses, not gates, because the event fires faster than that data updates — waiting for confirmation forfeits the edge. A momentum burst pays out fast or it's stale, so a short hard timeout cuts a trade that hasn't moved.",
       "tags": [
         "momentum",
@@ -1435,7 +1435,7 @@
       "emoji": "🐋",
       "tagline": "A universe rank-jump sniper: watches the top-50 smart-money leaderboard every tick and fires only on a fresh FIRST_JUMP — a coin exploding 15+ ranks out of the deep field with 4h trend, 15m freshness, and a volume spike all confirming — then strikes ONE position at a fixed 7x and lets the DSL ride the breakout.",
       "belief_plain": "Watches which coins the best traders are suddenly piling into and only acts when a name rockets up the leaderboard from deep in the pack — a fresh jump, not an already-crowded top name. It wants the move to be young (climbing fast in the last 15 minutes), going the same way the price is, and backed by a real volume spike before it takes a single shot.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "The edge is in the FIRST jump, not the established leader. By the time a coin sits at the top of the smart-money board the move is priced in; the asymmetric entry is the moment a name explodes 15+ ranks out of the deep field (prev-rank >= 25) while its 4h trend, 15m contribution velocity, and 24h volume all confirm the same direction at once. That confluence is rare and decays fast, so the right move is to scan often (90s), strike once at a fixed 7x the instant it fires, skip the already-top names, and let a ratcheting DSL — not a fixed target — decide the exit so the occasional big breakout pays for the quiet weeks.",
       "tags": [
         "smart-money",
@@ -1480,7 +1480,7 @@
       "emoji": "🦦",
       "tagline": "Watches the rate of change of open interest across every liquid Hyperliquid crypto perp and fires at most a couple of positions — only when 1h OI jumps >=5% while price moves >=0.5% the same way (fresh leveraged money entering with conviction), 4h isn't unwinding, and the spread is tight. Sizes margin to conviction at 5/7/10x, then rides the flow 1-3h on a tight DSL.",
       "belief_plain": "Open interest only grows when new leveraged money enters a perp. When that money piles in fast (OI up 5%+ in an hour) AND price moves the same direction, that's real conviction — not just a wick. Otter rides that fresh flow for an hour or three, then trails a tight stop. It does nothing on the much more common days when no coin shows that burst, and it never trades unwinds.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "OI velocity — the delta of open interest over time — is a perp-native conviction signal nobody else in the fleet trades (others read OI only as a static size filter). Fresh OI growth aligned with price (the top two quadrants of the OI/price matrix) is new leveraged positioning with direction; unwinds (the bottom two) are exhaustion and get skipped. Confluence scoring (OI tier, 4h confirmation, price magnitude, smart-money lean, spread, time-of-day) at a high floor keeps it a sniper, and a tight DSL locks profit early because the flow edge is in the first 1-3 hours.",
       "tags": [
         "open-interest",
@@ -1526,7 +1526,7 @@
       "emoji": "🐟",
       "tagline": "Rides forced flow on crypto majors (BTC/ETH/SOL/HYPE): when open interest is unwinding fast (positions being force-closed) AND price is moving violently AND the 5-minute candle is still pushing the same way, it takes ONE position in the direction of the flow, sized 1-5x, and lets a wide DSL ratchet ride the squeeze with a 24h outer bound.",
       "belief_plain": "A liquidation cascade is the cleanest momentum in crypto — it's forced flow, not opinion. When lots of positions are being force-closed at once, price gets shoved hard in one direction and the move feeds on itself until the leverage is flushed. Piranha reads the order flow underneath price (open-interest velocity + order-book depth) to confirm the move is forced, then rides it: OI down + price up = shorts squeezed, go long; OI down + price down = longs liquidated, go short.",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "thesis": "Most agents react to price; the edge is reading the forced flow beneath it. Open interest dropping fast means positions are closing under duress, and when that coincides with a violent move and a thinning book on the side price is running into, there is little resistance left and the cascade continues. That signature is short-horizon and self-resolving, so the right move is one conviction entry in the flow direction, a wide ratchet that lets a squeeze extend, and a 24h hard timeout because if the cascade hasn't paid in a day it's over.",
       "tags": [
         "btc",
@@ -1580,7 +1580,7 @@
       "emoji": "🐍",
       "tagline": "Scans the top 50 Hyperliquid crypto assets by volume and waits for one multi-day setup — 4h trend with macro direction, 1h agreeing, 15m confirming, smart money not opposing, RSI not extreme — then takes a single LONG-biased swing at 3-7x, sizes margin to conviction (25/30/40%), and holds for days behind a wide DSL (96h cap).",
       "belief_plain": "Watches every liquid coin on Hyperliquid and does nothing until one setup lines up across the 4-hour, 1-hour and 15-minute timeframes with the best traders on the same side. Then it takes one well-sized, mostly-long swing and holds it for days behind a wide trailing stop, because the money is in the rare multi-day winner — not in trading often.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Every other agent strikes and rotates within hours; none hold for days, and that's the blind spot. The edge isn't a high win rate — it's NOT MISSING the one big multi-day move: a low win rate with a 3:1 win/loss ratio beats a high win rate with a thin one. So scan broadly, demand a real macro trend confirmed across three timeframes (never fighting a runaway counter-trend or a crowded smart-money side), tilt LONG, size to conviction, and let a wide DSL ride the move for days instead of getting chopped out early.",
       "tags": [
         "momentum",
@@ -1626,7 +1626,7 @@
       "emoji": "🐓",
       "tagline": "Trades the clock, not the chart — BTC's reaction to the US stock-market open. In the 45 minutes before the opening bell (default 13:30 UTC, fully configurable) it reads how BTC is setting up: the drift across the window sets direction, expanding volume confirms real positioning, and a break of the prior session's range adds conviction. Carries the position INTO the open, one signal per session, at 2-5x with a session-aware DSL ladder. The asset (BTC by default) and the session time are separate knobs — point it at another market, or another open.",
       "belief_plain": "When Wall Street opens, the risk-on / risk-off flow spills into crypto — and the move often starts setting up in the 30-60 minutes BEFORE the bell. Rooster's signal is a clock, not a chart: by default it wakes 45 minutes before the US equity open (13:30 UTC), checks whether BTC is actually drifting one way on real volume (not just wandering on thin trade), and takes the position into the open. BTC has no open of its own, so the one it trades is borrowed from the stock market. It fires at most once per session, banks profit early, and lets go if the open comes and goes with nothing happening. Both the asset and the session time are inputs you can change.",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "thesis": "Every other template in the catalog reads price; none reads the clock. Session opens are the most reliable recurring liquidity event in any market, and pre-open drift on expanding volume is a genuine directional tell — but only when it clears a noise floor and only when volume confirms it, which is what separates positioning from wandering. The default session is the US equity cash open (13:30 UTC in EDT, 14:30 in EST); BTC is the default asset because equity-open flows move crypto — but both are inputs. Rooster makes the window itself the strategy: outside it the scanner emits nothing and reads nothing (a cheap idle tick), inside it it scores once and commits. The pre-open window, the session times, and the noise floor are all inputs, because the right window is exactly what a user wants to tune.",
       "tags": [
         "session",
@@ -1676,7 +1676,7 @@
       "emoji": "🐠",
       "tagline": "Always hold the strongest major: ranks BTC/ETH/SOL/HYPE by ~2.7-day relative strength each tick and longs the leader, with a leader-RS floor and a margin-vs-runner-up gate to avoid whipsaw on tight races. Single-position; when the held leader exits via the DSL trail, the next tick re-evaluates and enters the new leader — that's the rotation.",
       "belief_plain": "Trades only the big, liquid coins (BTC, ETH, SOL, HYPE). Each cycle it measures which one has been strongest over the last few days and buys that one — but only if it is clearly ahead of the next-best, not in a photo finish. It never sells on its own; a trailing stop manages the exit, and when one leader is done, the next-strongest takes its place.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Among the majors, leadership tends to persist — when one decisively outperforms the others it usually keeps doing so for days. Rotating into the strongest captures that persistence, while the margin-vs-runner-up gate keeps the agent out of tight, whipsaw-prone races where 'the leader' flips every tick. Rotation is realized through the DSL exit (not a mid-position close), so leadership changes only cost a fill when the old leader is genuinely finished — never on noise.",
       "tags": [
         "btc",
@@ -1728,7 +1728,7 @@
       "emoji": "🦎",
       "tagline": "An onboarding-grade pullback trader on the liquid majors (BTC/ETH/SOL): buys a 3-7% dip inside an established bullish 4h trend (and shorts a 3-7% rally inside a bearish one) only when the smart-money leaderboard agrees with the trend direction, then gives the entry room on a wide Phase 1 while a wide Phase 2 ratchet lets the resumed trend run.",
       "belief_plain": "Watches BTC, ETH and SOL. When one is in a clear up-trend on the 4-hour chart and dips 3-7% on the 1-hour chart while the best traders are still leaning long, it buys the dip; in a down-trend it shorts a 3-7% bounce. It needs all three to line up — trend, dip-in-the-band, and smart money agreeing — then it gives the trade room to work and trails a wide stop so the trend can keep running.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Pullbacks inside an established trend are one of the highest-edge setups: the trend has already proved itself, the counter-move offers a better entry, and a smart-money agreement filter screens out trend-break risk. The 3-7% band is the sweet spot — shallower is noise, deeper means the trend may be breaking, so you don't catch a falling knife. Because a resolved pullback resumes a trend that can run far, the exit is asymmetric: a wide Phase 1 floor lets the dip develop without a premature cut, and a wide Phase 2 ratchet (first lock only at +10% ROE) keeps the continuation that pays for the quiet weeks.",
       "tags": [
         "btc",
@@ -1780,7 +1780,7 @@
       "emoji": "🐑",
       "tagline": "A long-only trend follower for beginners: buys a crypto major (BTC/ETH/SOL/HYPE) only when its fast EMA is above its slow EMA on all three timeframes (15m, 1h, 4h) at once, never shorts, and trails a balanced stop so a clean uptrend can run.",
       "belief_plain": "Only buys when a coin is clearly going up by any chart reader's standard — the fast moving average has to be above the slow one on the 15-minute, 1-hour, AND 4-hour chart simultaneously. It never shorts (so there's no 'what's a short?' to learn), bets a little bigger when the trend is wider and the best traders agree, and then trails a stop so a real uptrend can keep running.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Most trend agents pick a single timeframe; Sheep insists on agreement across three before firing. That is a stricter filter (fewer trades) but each entry is 'obviously up' to any chart reader, which is exactly the property a beginner needs to trust the agent. Long-only by design removes the cognitive load of shorting, making this the onboarding-grade entry point into the fleet.",
       "tags": [
         "btc",
@@ -1835,7 +1835,7 @@
       "emoji": "🐆",
       "tagline": "A patient momentum sniper across the whole crypto market: it watches the smart-money leaderboard tick-over-tick and pounces only on a violent rank explosion — an asset rocketing from rank 20+ into the top 10 in one move while 15m smart-money flow is actively building and 4h price agrees — then sizes leverage to conviction (7/10x) and trails a DSL stop.",
       "belief_plain": "Most of the time it does nothing. It only acts when an asset suddenly leaps up the smart-money rankings — from far down into the top 10 in a single step — with fresh money still piling in and price moving the same way. One amazing trade per day, not a stream of mediocre ones.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "The best traders rotate violently. When a coin jumps from rank 20+ into the top 10 in one tick with 15m contribution still accelerating, that's smart money piling in fast — a rare, high-conviction setup worth a concentrated strike. Chasing every hot coin bleeds fees; waiting for the violent first jump is the edge.",
       "tags": [
         "momentum",
@@ -1878,7 +1878,7 @@
       "emoji": "🐅",
       "tagline": "Longs the structural winners of a K-shaped world (the AI complex on Hyperliquid XYZ + crypto winners HYPE/SOL) and shorts the laggards (the broad U.S. market via SP500 + a gated basket of laggard alts) — both trend-confirmed on separate wallets — plus a ~10% pre-IPO ramp satellite that auto-discovers pre-IPO perpetuals (IPOPs) and rides them into their listing.",
       "belief_plain": "The world is splitting into haves and have-nots: AI companies and crypto's winners keep booming while the broad economy and the rest of crypto struggle. Cub buys the booming side and shorts the struggling side at the same time on separate wallets, so it makes money on the GAP between the two — and keeps a small slice aimed at the next SpaceX before it goes public.",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "thesis": "The edge is K-shaped DISPERSION, not market direction. Long the AI complex + HYPE/SOL only while they're actually trending up; short SP500 + laggard alts only while they're actually rolling over; the P&L is the spread between the two speeds. A ~10% pre-IPO sleeve adds optionality — it discovers IPOPs by their leverage signature (fresh perps launch capped low) and longs the ones ramping into their listing. Tokenized equities trade 24/7 on Hyperliquid, so the book never waits for a market open.",
       "tags": [
         "k-shaped",
@@ -1958,7 +1958,7 @@
       "emoji": "🐜",
       "tagline": "Finds the most heavily-traded perps where longs are paying shorts a rich funding rate, and — only when that crowd of longs looks tired (overbought and rolling over, not still charging) — shorts them to collect the funding, hour after hour. Low leverage, a tight stop in case of a squeeze, and it rotates daily, dropping names once the funding dries up.",
       "belief_plain": "When too many traders pile long into a perp, the funding rate turns positive — longs literally pay shorts every hour to hold. Ant gets on the receiving side of that payment by shorting those names, but it's careful: it only shorts when the long crowd is already exhausted, so it's fading a tired move rather than standing in front of a freight train. It keeps size and leverage modest because the money is in the funding, not in calling the direction, and a tight trailing stop caps the damage if a name squeezes.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Perpetual funding is a harvestable yield: sustained positive funding pays shorts. True cash-and-carry hedges the short with long spot for delta-neutral carry, but Senpi is perps-only (no HyperEVM spot execution), so ant runs the DIRECTIONAL half — short the funding-payer — and manages the price risk with an exhaustion entry gate (RSI/structure), low leverage, a tight DSL squeeze-stop, and a 24h rotation. It ranks the top-OI names, requires annualized funding >= targetApr with multi-hour persistence, and never shorts a name still in a fresh uptrend. Not delta-neutral — the missing spot leg is the residual risk (NOTES.md).",
       "tags": [
         "funding",
@@ -2007,7 +2007,7 @@
       "emoji": "🛡️",
       "tagline": "A sleep-at-night strategy that trades only the biggest, most liquid coins, at low leverage (1-2x), with small position sizes and a high bar for entering — so it makes few, careful trades and protects your money first. Tight stops cut losers fast and lock in gains early, and a hard drawdown halt is the backstop. Built to NOT lose money, not to swing for the fences.",
       "belief_plain": "This is the conservative, capital-preservation option. It sticks to the majors (the deepest, most liquid markets), uses low leverage and small sizes, and only opens a position when a real, strong trend lines up — so most of the time it's patient and does nothing. When it is in a trade, a tight trailing stop protects it: it cuts losers quickly and starts locking in profit early instead of giving gains back. A hard 10% drawdown halt stops everything if things go wrong. It won't shoot the lights out — that's the point.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Most users who ask for 'low risk' don't want the highest return — they want to not lose money and to sleep at night. Armadillo is built for exactly that: restricting to the most liquid majors removes the thin-coin blow-up risk, low leverage (1-2x) and small margin cap the downside on any single trade, and a demanding score floor means it only acts on the strongest setups (few, high-quality entries, low turnover so fees don't bleed it). The momentum entry is Bison's validated multi-factor scorer, ported verbatim; the conservatism is entirely in the configuration — a high entry bar and low sizing — not in new, unproven math. The DSL owns every exit with a tight floor and an early profit-lock ladder, and the runtime drawdown_halt is the equity backstop.",
       "tags": [
         "conservative",
@@ -2053,7 +2053,7 @@
       "emoji": "🐒",
       "tagline": "Reads the whole market once a day — the pulse (risk-on/off, dispersion, gold/dollar/VIX) plus where the proven wallets lean — sets a risk posture, and rotates a long/short book across crypto and tokenized stocks/commodities into that posture. It never sells: a regime change just changes what it buys next, and every position is protected by a ratchet stop that does all the exiting.",
       "belief_plain": "Once a day it looks at everything — are markets risk-on or risk-off, is it a rotation day, what's gold and the dollar doing, where's the smart money — and picks a stance. In risk-on it leans into the leaders; in risk-off it rotates into gold/oil and shorts the weak; on a choppy rotation day it plays winners-vs-losers at smaller size. It never manually closes; a trailing stop protects and exits every position, so old bets wind down on their own as the new stance takes over.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Users already run the market-pulse skill and then hand-pick strategies to fit the read. Chimp automates that loop: it re-runs the pulse + smart-money read on a daily clock, re-derives its posture, and expresses the change only through new entries — never by force-closing, so turnover is set by the market (via DSL), not by a scanner re-deciding every minute. Daily recalibration + a moderate DSL make it the nimble regime-follower; Gorilla is the weekly, more-committed sibling.",
       "tags": [
         "regime",
@@ -2104,7 +2104,7 @@
       "emoji": "🐒",
       "tagline": "Reads the whole market once a day, ranks the sectors — semis, software, crypto, indices, commodities — by how they're moving, and rides the rotation: it buys the leaders of the winning sectors and shorts the laggards of the losing ones, biggest when the market is a clean rotation (index calm while sectors split) and smaller when everything moves together. It never sells manually; a trailing stop does all the exiting, so last rotation's winners wind down on their own as the new leaders take over.",
       "belief_plain": "Money constantly rotates between sectors — out of memory chips into AI logic, out of crypto proxies into software, and so on. Once a day Gibbon looks at which sectors are being bought and which are being sold, then buys the strongest names in the winning sectors and shorts the weakest in the losing ones. It leans in hardest on real rotation days and eases off when the whole market just moves together. It never manually closes — a ratchet stop protects and exits every position, so the book rotates as the market does.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "The market-pulse read repeatedly surfaces sector rotation — memory semis dumped while logic semis are bought, crypto proxies sold while software holds. Gibbon automates trading that structure: it re-ranks the sectors daily and expresses the winning-vs-losing rotation as new long/short entries, sized by how much dispersion there actually is. It never force-closes — turnover is set by the market via DSL. Orangutan is the weekly, more-committed sibling.",
       "tags": [
         "rotation",
@@ -2154,7 +2154,7 @@
       "emoji": "🦍",
       "tagline": "The weekly, more-committed sibling of Chimp. Once a week it reads the whole market — the pulse (risk-on/off, dispersion, gold/dollar/VIX) plus where the proven wallets lean — sets a risk posture, and holds a concentrated long/short book across crypto and tokenized stocks/commodities. It never sells: a regime change just changes what it buys next, and a wide trailing stop does all the exiting, letting winners run for weeks.",
       "belief_plain": "Like Chimp, but slower and more committed. Once a week it decides the stance — risk-on lean into leaders, risk-off rotate into gold/oil and short the weak, rotation week play winners-vs-losers small — and holds fewer, bigger positions. It never manually closes; a wide ratchet stop protects each one and lets the winners run, so the book turns over on the market's schedule, not a scanner's.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Same automated pulse-then-allocate loop as Chimp, on a weekly clock with a wider DSL and higher conviction gate — for users who want a deliberate regime-follower that commits to a view and rides it, rather than re-tilting daily. Never force-closes; turnover is set by the market via DSL. Pair with Chimp for a fast + slow allocator sleeve.",
       "tags": [
         "regime",
@@ -2205,7 +2205,7 @@
       "emoji": "🦎",
       "tagline": "Watches BTC's 4-hour move via market_get_cross_asset_flows and strikes the highest-confidence correlated alt that historically follows BTC but hasn't caught up yet — entering the alt in BTC's direction, sized to the tool's confidence score, with a stop that trails the catchup.",
       "belief_plain": "When Bitcoin makes a big 4-hour move, certain alts that usually follow it lag behind for a while before catching up. Mantis spots those laggards (only the ones that follow Bitcoin reliably, with smart money already starting to rotate in) and buys the gap, betting it closes — bigger when it's more confident, with a stop that trails the move.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "The edge is a statistical lag, not a directional view: alts with an 85%+ historical follow-rate and tight timing variance tend to catch up to a confirmed leader move within their typical lag window. Restricting the leader to BTC (the only asset with pre-computed lag data) and requiring smart-money rotation plus a meaningful gap keeps it to high-probability catchups; sizing scales with the tool's confidence, and a dynamic timeout calibrated to each alt's lag distribution backstops trades where the catchup never materialises.",
       "tags": [
         "crypto",
@@ -2253,7 +2253,7 @@
       "emoji": "🐙",
       "tagline": "Ranks the live liquid main-DEX crypto cross-section by 24h relative strength every tick, then LONGS the strongest names (long book) and SHORTS the weakest (short book) — both trend-confirmed — on two equally-funded wallets so the pair is ~market-neutral and harvests crypto dispersion.",
       "belief_plain": "Buys the strongest crypto coins and shorts the weakest at the same time, on two separate wallets, so it makes money on the GAP between winners and losers instead of betting on the whole market going up or down.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "The edge is dispersion, not direction. In a HYPE-dominates / alts-crushed regime the long book gravitates to the leaders and the short book to the carnage, and the two equally-funded notionals offset market beta — so the return is driven by the spread between strong and weak names. The universe is the live liquid board, not a fixed list, so it always ranks whatever is actually trading and liquid right now.",
       "tags": [
         "crypto",
@@ -2299,7 +2299,7 @@
       "emoji": "🦧",
       "tagline": "The weekly, more-committed sibling of Gibbon. Once a week it ranks the sectors — semis, software, crypto, indices, commodities — and commits to the rotation: long the leaders of the winning sectors, short the laggards of the losing ones, biggest when the rotation is decisive. It never sells manually; a wide trailing stop does all the exiting and lets winners run for weeks, so the book turns over on the market's schedule.",
       "belief_plain": "Like Gibbon, but slower and more committed. Once a week it decides which sectors are winning and which are losing, then holds fewer, bigger positions — long the strongest names, short the weakest — and only commits when the rotation is decisive. It never manually closes; a wide ratchet stop protects each position and lets the winners run, so the book rotates on the market's schedule, not a scanner's.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Same automated rank-the-sectors-and-ride loop as Gibbon, on a weekly clock with a wider DSL and a higher rotation threshold — for users who want a deliberate rotation-follower that commits to a theme and rides it, rather than re-ranking daily. Never force-closes; turnover is set by the market via DSL. Pair with Gibbon for a fast + slow rotation sleeve.",
       "tags": [
         "rotation",
@@ -2344,12 +2344,166 @@
       "sort_order": 8
     },
     {
+      "id": "oryx",
+      "name": "Oryx — XYZ Intraday Breakout",
+      "emoji": "🦌",
+      "tagline": "Trades gold, crude oil, metals and the stock indices during the day rather than holding for weeks. It waits for a market to settle into an opening range, then takes the break when real volume backs it — and skips it if price has already run too far to be worth chasing. These markets trade around the clock, so there is no waiting for a bell.",
+      "belief_plain": "Commodities and indices spend the start of a session finding a range, and the move that breaks that range with volume behind it tends to keep going for a few hours. Oryx watches the range form, buys the break up or sells the break down, and refuses the ones that are already extended or too quiet to cover trading costs. It never sells manually — a profit ratchet locks gains and a fixed stop caps the loss.",
+      "version": "1.0.0",
+      "thesis": "You want to trade gold, oil, or the indices on an intraday clock rather than holding a swing position for weeks. Every XYZ template we ship is swing or position; this is the intraday one. Opening-range break, volume-confirmed, chase-capped, and refused outright when the market is too quiet to pay its own round trip.",
+      "tags": [
+        "intraday",
+        "breakout",
+        "opening-range",
+        "gold",
+        "oil",
+        "commodities",
+        "indices",
+        "equities",
+        "xyz",
+        "session",
+        "fee-aware",
+        "long-short",
+        "dsl-only",
+        "no-close"
+      ],
+      "group": "multi-asset-universe",
+      "archetype": "breakout_momentum",
+      "archetype_label": "Breakout / Momentum",
+      "sub_style": "range_break",
+      "sub_style_label": "Buys/sells the break of a multi-day range.",
+      "asset_classes": [
+        "commodities",
+        "indices",
+        "xyz_equities"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 4,
+      "time_horizon": "scalp",
+      "cadence_seconds": 60,
+      "min_budget": 200,
+      "wallet_count": 1,
+      "min_budget_binding_wallet": "main",
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 4,
+      "branch": "main",
+      "sort_order": 9
+    },
+    {
+      "id": "pilotfish",
+      "name": "Pilotfish — Smart-Money Accumulation",
+      "emoji": "🐟",
+      "tagline": "Follows the wallets with a real track record — but only while they are still building a position, not after everyone can see it. It watches how hard that group is leaning on each coin and buys in when the leaning is actively getting stronger, which is the part of the move that has not been priced in yet.",
+      "belief_plain": "Most copy strategies show you what good traders already hold, which is old news by the time you see it. Pilotfish watches the same group of proven wallets and measures whether their commitment to a coin is still growing. When they are actively piling in, it goes with them; when they have simply been sitting on a position for days, it leaves it alone. It never sells manually — a profit ratchet locks gains and a fixed stop caps the loss.",
+      "version": "1.0.0",
+      "thesis": "You want to be early to where proven money is going, not late to where it already is. A standing position is priced; the DERIVATIVE of that positioning is not. Pilotfish reads the cohort's dollar-weighted net bias per name and fires only while it widens — dominant side only, so a minority leg can never be traded, and discounted when the lean rests on too few wallets to mean anything.",
+      "tags": [
+        "smart-money",
+        "copy-trading",
+        "accumulation",
+        "early",
+        "cohort",
+        "conviction",
+        "follows-traders",
+        "derivative",
+        "universe",
+        "long-short",
+        "dsl-only",
+        "no-close"
+      ],
+      "group": "multi-asset-universe",
+      "archetype": "copy_trading",
+      "archetype_label": "Copy-Trader",
+      "sub_style": "sm_crowding",
+      "sub_style_label": "Fades the crowded smart-money side once price stops following.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts",
+        "universe_crypto"
+      ],
+      "asset_scope": "follows_traders",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 4,
+      "time_horizon": "swing",
+      "cadence_seconds": 900,
+      "min_budget": 125,
+      "wallet_count": 1,
+      "min_budget_binding_wallet": "main",
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 5,
+      "branch": "main",
+      "sort_order": 10
+    },
+    {
+      "id": "puffer",
+      "name": "Puffer — Volatility Squeeze",
+      "emoji": "🐡",
+      "tagline": "Waits for a market to go quiet — unusually quiet for that particular coin — and then trades the move when it finally breaks out. Quiet stretches tend to end in a big move; the trick is being positioned for the break rather than getting chopped up inside the calm. It sits on its hands until the release, and then gives the winner a long leash.",
+      "belief_plain": "When a coin's price action tightens up far more than is normal for it, pressure is building and the next move is usually a big one. Puffer measures how compressed each market is against its own history, ignores the quiet itself, and enters only when price finally breaks out with volume behind it. Then it holds on: a profit ratchet locks gains as they build, and a fixed stop caps the downside if the break fails.",
+      "version": "1.0.0",
+      "thesis": "Volatility is mean-reverting: compression precedes expansion. The edge is in the reference frame — compression is measured against each asset's OWN trailing median, so a coil is detected on a sleepy index and a violent alt alike, which an absolute threshold can never do. Trades the release, never the coil, and runs the widest exit in the catalog because cutting an expansion short forfeits the entire reason for taking it.",
+      "tags": [
+        "volatility",
+        "squeeze",
+        "compression",
+        "expansion",
+        "breakout",
+        "bollinger",
+        "coil",
+        "universe",
+        "long-short",
+        "dsl-only",
+        "no-close"
+      ],
+      "group": "multi-asset-universe",
+      "archetype": "breakout_momentum",
+      "archetype_label": "Breakout / Momentum",
+      "sub_style": "volatility_squeeze",
+      "sub_style_label": "Waits for volatility to compress relative to the asset's OWN history, then trades the expansion when it releases.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts",
+        "universe_crypto"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 75,
+      "wallet_count": 1,
+      "min_budget_binding_wallet": "main",
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 5,
+      "branch": "main",
+      "sort_order": 11
+    },
+    {
       "id": "raven",
       "name": "Raven — Self-Calibrating Momentum",
       "emoji": "🐦‍⬛",
       "tagline": "Runs a momentum book across the most liquid names and gets smarter about ITSELF: twice a day it reads its own closed trades, and if it's been losing it becomes more selective and trades smaller, while if it's been winning it loosens up and presses. You don't tune it — it tunes itself, inside guardrails, and a trailing stop does all the exiting.",
       "belief_plain": "A momentum strategy's edge drifts with the regime — what worked last week can bleed this week. Raven opens positions on the same proven momentum signal every time, but it watches its OWN results: after a cold streak it raises the bar for what it'll trade and cuts its size; after a hot streak it leans back in. It never manually closes — a ratchet stop protects and exits every position — and a hard drawdown halt is the backstop if the self-tuning isn't enough.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Momentum entry quality is regime-dependent, and a fixed score threshold is right only some of the time. Raven treats its realized track record (win-rate, profit-factor, losing streak over the last N closed trades) as a live control signal: it ratchets the entry floor up/down and scales conviction sizing between bounded rails on a slow clock. The momentum thesis itself is Bison's validated weighted scorer, ported verbatim; the novelty is the closed-loop self-calibration on top. DSL owns exits; the runtime drawdown_halt is the equity backstop.",
       "tags": [
         "momentum",
@@ -2390,7 +2544,7 @@
       ],
       "max_slots": 6,
       "branch": "main",
-      "sort_order": 9
+      "sort_order": 12
     },
     {
       "id": "rotator",
@@ -2398,7 +2552,7 @@
       "emoji": "🔁",
       "tagline": "On a fixed clock (default every 3 hours) it re-reads the market and rebalances a deliberately concentrated book — never more than two positions, long OR short — ranking candidates on a blended score of cross-asset flows, the funding regime, and live leaderboard momentum events.",
       "belief_plain": "Every few hours this strategy re-underwrites its whole book from scratch. It looks at which alts are lagging a big Bitcoin move and should catch up, whether the crowd is dangerously one-sided on funding (a contrarian warning), and which coins the best traders are piling into right now — then blends those into a single conviction score and holds only the one or two best long-or-short ideas. Weak positions retire on their stop and the next rebalance fills the freed slot.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Concentration plus a fixed re-underwrite clock beats a sprawling always-on book: a small number of high-conviction positions, re-scored every few hours against the freshest short-horizon data, keeps the book aligned with current conditions instead of yesterday's. The three inputs are deliberately short-horizon (4h flows, live funding, 4h momentum events) — not a long-lookback cohort — so the reads match the timescale of the trades. It rotates by attrition rather than force-closing, so it never fights its own DSL.",
       "tags": [
         "rebalance",
@@ -2437,7 +2591,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 10
+      "sort_order": 13
     },
     {
       "id": "salmon",
@@ -2445,7 +2599,7 @@
       "emoji": "🐟",
       "tagline": "Buys the bounce, not the falling knife. It watches the RSI on liquid majors and only steps in when an oversold coin has actually turned back up — a real cross off the lows with the candle confirming — going long the recovery (or short an overbought coin rolling over). It bets price snaps back to its average, sizes moderately because these turns fail fast, and lets a tight trailing stop do all the exiting.",
       "belief_plain": "Trades the big liquid coins by their RSI. When one gets oversold it waits for it to actually turn back up before buying — not while it's still dropping — and when one gets overbought and starts rolling over it shorts the fade. It's betting the price springs back toward its average, keeps size moderate because these bounces can fail quickly, and never closes by hand: a tight stop protects and exits every trade.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Stretched moves revert. When a liquid major gets pushed to an oversold extreme and then genuinely turns — RSI crossing back up through the line while the last candle confirms — the snap back toward the mean is the trade; the symmetric overbought roll-over is the short. The discipline is refusing to catch a falling knife: a low RSI alone is not a signal, only the confirmed cross-back is. Because reversions fail fast, leverage stays moderate and the DSL exit is tight — lock early, cut small.",
       "tags": [
         "mean-reversion",
@@ -2482,16 +2636,16 @@
       ],
       "max_slots": 5,
       "branch": "main",
-      "sort_order": 11
+      "sort_order": 14
     },
     {
       "id": "starling",
       "name": "Starling — Smart-Money Rotation Follower",
       "emoji": "🐦",
-      "tagline": "Watches a flock of the most profitable wallets on Hyperliquid and moves when they do — the instant several of them start piling into the SAME trade in the SAME direction at the SAME time, it buys (or shorts) alongside them, betting more the more of them agree. It only acts on a rotation that's just forming, not a crowd that's been standing in a name for hours, and it never sells manually — a trailing stop does all the exiting, so last week's follows wind down on their own as the flock rotates into the next name.",
+      "tagline": "Watches a flock of the most profitable wallets on Hyperliquid and moves when they do — the instant several of them start piling into the SAME trade in the SAME direction at the SAME time, it buys (or shorts) alongside them, betting more the more of them agree. It only acts on a rotation that's just forming, not a crowd that's been standing in a name for hours, and it never sells manually — a fixed max-loss floor caps the downside while a profit ratchet that can only ever lock GAINS (never breakeven) protects the upside, so winners are given room to run and last week's follows wind down on their own as the flock rotates into the next name.",
       "belief_plain": "The proven winners on Hyperliquid tend to rotate into the same trades at the same time, and the freshest edge is the moment that agreement is FORMING — not once everyone can already see it. Starling keeps a live shortlist of the wallets with the best all-time track record, watches what they're opening, and when enough of them freshly line up on one name in one direction it opens with them, sizing up when the agreement is strongest. It never manually closes — a ratchet stop protects and exits every position, so the book rotates as the smart money does, and a hard drawdown halt is the backstop.",
-      "version": "1.0.1",
-      "thesis": "Cohort copiers average a pool's standing net bias (already priced); Starling instead trades the DERIVATIVE of that bias — the snapshot-to-snapshot change. Each tick it counts, per name and direction, how many proven wallets hold it, and fires only when that count has just crossed the consensus bar or is still rising (newly-formed / growing), never on a stale standing consensus. Conviction sizing scales with the agreement count. It force-closes nothing — turnover is set by the market via DSL (rotate-by-attrition), the same never-close discipline as the gibbon/orangutan rotation riders.",
+      "version": "1.2.0",
+      "thesis": "Cohort copiers average a pool's standing net bias (already priced); Starling instead trades the DERIVATIVE of that bias — the snapshot-to-snapshot change. Each tick it counts, per name and direction, how many proven wallets hold it, takes ONLY the side more of them are on, and fires when that side's NET MARGIN over the other has just become decisive or is still widening — never on the minority side, and never on a margin that is flat or narrowing. Conviction sizing scales with the agreement count. It force-closes nothing — turnover is set by the market via DSL (rotate-by-attrition), the same never-close discipline as the gibbon/orangutan rotation riders.",
       "tags": [
         "smart-money",
         "copy-trading",
@@ -2532,7 +2686,58 @@
       ],
       "max_slots": 6,
       "branch": "main",
-      "sort_order": 12
+      "sort_order": 15
+    },
+    {
+      "id": "swift",
+      "name": "Swift — Fee-Aware Crypto Scalper",
+      "emoji": "🐦",
+      "tagline": "Trades the fast money on the most liquid crypto names — but only when the market is actually moving enough to be worth the fees. Before it even looks at a setup it asks a blunt question: will this move pay for the cost of trading it? If not, it doesn't trade. Most scalpers lose to their own costs; this one refuses the trades that would.",
+      "belief_plain": "Short bursts of momentum on big crypto names are tradeable, but at this speed you pay a fee every single time you go in and out — so the only setups worth taking are the ones moving enough to cover that cost several times over. Swift measures how much a market is actually moving, compares it to what a round trip costs, and skips everything that doesn't clear the bar. It never sells manually — a profit ratchet locks gains and a fixed stop caps the downside.",
+      "version": "1.0.0",
+      "thesis": "You want to trade fast, and you have watched fees quietly eat a scalper alive. The edge here is not a cleverer indicator — it is a hard cost floor applied BEFORE the signal: expected capture (a fraction of ATR) must exceed the round-trip fee by a configured multiple, or the name is never scored. Entries rest as maker first. The ratchet locks gains only; it can never close a winner at a loss.",
+      "tags": [
+        "scalp",
+        "scalping",
+        "intraday",
+        "fast",
+        "fee-aware",
+        "low-fee",
+        "crypto",
+        "momentum",
+        "universe",
+        "long-short",
+        "dsl-only",
+        "no-close"
+      ],
+      "group": "multi-asset-universe",
+      "archetype": "breakout_momentum",
+      "archetype_label": "Breakout / Momentum",
+      "sub_style": "market_structure",
+      "sub_style_label": "Trades SMC/ICT/Wyckoff structure: break-of-structure, liquidity sweeps, fair-value gaps.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts",
+        "universe_crypto"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "aggressive",
+      "tier": "advanced",
+      "leverage_max": 4,
+      "time_horizon": "scalp",
+      "cadence_seconds": 60,
+      "min_budget": 200,
+      "wallet_count": 1,
+      "min_budget_binding_wallet": "main",
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 4,
+      "branch": "main",
+      "sort_order": 16
     },
     {
       "id": "viper",
@@ -2540,7 +2745,7 @@
       "emoji": "🐍",
       "tagline": "Reads a chart the way a smart-money trader does. It marks the recent peaks and troughs, then waits for price to actually break structure — punch through a prior high (or low) — and only takes the trade when the break is backed by a stop-hunt wick that grabbed liquidity and snapped back, a price gap that shows one-sided pressure, and the bigger-picture 4h trend pointing the same way. A trailing stop does all the exiting; Viper never sells manually.",
       "belief_plain": "Markets move from one pool of resting stop orders to the next, and the honest tell is structure: a 'Break of Structure' is price closing past the last swing high or low in the trend's direction (it's continuing), and a 'Change of Character' is the first close through the OPPOSITE swing (the trend may be flipping). Viper enters on those breaks — but only the high-quality ones, where a liquidity sweep (a wick that runs the stops just past a prior swing then closes back inside) and a fair-value gap (a 3-candle imbalance where price left a gap it tends to revisit) agree with it, and the 4h structure confirms. It never manually closes — a ratchet stop protects and exits every position, and a hard drawdown halt is the backstop.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Price is delivered between liquidity pools, and market structure — not an oscillator — is the cleanest read on which pool is next. Viper maps confirmed swing pivots, classifies each close through the most-recent swing as a Break of Structure (continuation) or Change of Character (reversal), and requires SMC/ICT confluence before committing: a liquidity sweep of a prior swing that closes back inside (the stop-hunt / Wyckoff spring), a 3-candle Fair Value Gap in the break direction, and higher-timeframe (4h) structure agreement. Confluence is scored, conviction-banded, and gated to a minimum; sizing scales with conviction and leverage is clamped to the venue max. The edge is entry QUALITY on structure; the DSL owns exits and the runtime drawdown_halt is the equity backstop.",
       "tags": [
         "smc",
@@ -2580,7 +2785,59 @@
       ],
       "max_slots": 6,
       "branch": "main",
-      "sort_order": 13
+      "sort_order": 17
+    },
+    {
+      "id": "weaver",
+      "name": "Weaver — Range Harvester",
+      "emoji": "🕸️",
+      "tagline": "Built for the sideways market, which is when most strategies have nothing to do. It finds coins stuck in a well-defined band, buys near the bottom of it and sells near the top, and takes small, quick profits. Crucially, it refuses to touch anything that has started trending — that is the one market that turns a range trader into a bagholder.",
+      "belief_plain": "Plenty of the time a market isn't going anywhere — it just swings between a floor and a ceiling. Weaver measures whether a coin is genuinely range-bound or quietly trending, and only trades the ones that are truly stuck: buying near the low end, selling near the high end, banking the bounce quickly. If a range starts to break into a trend, it stops trading that name rather than averaging into the move.",
+      "version": "1.0.0",
+      "thesis": "You have watched a trend book sit on its hands through a week of chop and wondered why nothing fired. This is the strategy for that week. Fades the outer fifth of a contained band, and applies a hard Kaufman efficiency-ratio veto so it never grids a trend — the single failure mode that kills range traders. Small, frequent, bounded wins with a fast profit lock.",
+      "tags": [
+        "range",
+        "range-bound",
+        "mean-reversion",
+        "chop",
+        "sideways",
+        "grid",
+        "fade",
+        "harvester",
+        "always-on",
+        "universe",
+        "long-short",
+        "dsl-only",
+        "no-close"
+      ],
+      "group": "multi-asset-universe",
+      "archetype": "contrarian_fade",
+      "archetype_label": "Contrarian / Fade",
+      "sub_style": "mean_reversion",
+      "sub_style_label": "Buys oversold / sells overbought, betting price reverts to its mean (works in chop, not just trends).",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts",
+        "universe_crypto"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "starter",
+      "leverage_max": 3,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 125,
+      "wallet_count": 1,
+      "min_budget_binding_wallet": "main",
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 5,
+      "branch": "main",
+      "sort_order": 18
     },
     {
       "id": "asia-ai",
@@ -2588,7 +2845,7 @@
       "emoji": "🌏",
       "tagline": "Long the Asian AI/semiconductor complex (TSMC, Samsung, SK Hynix, ARM, ASML) with a broad/US-tech short hedge that strips out market beta.",
       "belief_plain": "Buys the Asian AI chipmakers while they're trending up, and shorts the broad US/tech index when it rolls over — so the bet is on Asia AI outperforming, not just the market going up.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "You think the AI buildout is increasingly an Asia story — Taiwan and Korea fabs, the chip supply chain — and you want a long on that sector with market beta hedged out, not a naked tech long.",
       "tags": [
         "ai",
@@ -2643,7 +2900,7 @@
       "emoji": "🥇",
       "tagline": "Bets on currency debasement: LONGS scarce real assets (GOLD, BTC, SILVER, PLATINUM, PALLADIUM) on the hard-money wallet and SHORTS the paper economy (SP500 + rate-sensitive growth RIVN/DKNG/HIMS) on the paper wallet — each leg trend-confirmed and conviction-sized. The P&L is the real-assets-beat-paper-claims spread.",
       "belief_plain": "Buys gold, bitcoin and other scarce real assets while shorting the broad stock market and rate-sensitive growth stocks at the same time, on two separate wallets, betting that as governments run big deficits and rates stay high, hard money beats paper claims.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Fiscal dominance / currency debasement: as deficits compound and the term premium rises, scarce real assets (gold, BTC, silver) outperform fiat-denominated financial claims. Express it as a long/short — long hard money, short paper — so the edge is the spread, not market direction. Each name only trades when its own absolute 4h/1h trend confirms (cross-sectional relative strength only tilts ranking and size). HONEST CAVEAT: the loosest hedge of the family — in a pure liquidity melt-up gold AND stocks can rise together; the short tilts to rate-sensitive names to tighten it. Best deployed as a tilt, not a market-neutral bet.",
       "tags": [
         "debasement",
@@ -2707,7 +2964,7 @@
       "emoji": "🦌",
       "tagline": "Trend-follows the WHOLE Hyperliquid board across every asset class (crypto, tokenized stocks, indices, metals, energy): longs the confirmed uptrends and shorts the confirmed downtrends on two separate wallets, sizes every position to EQUAL RISK by volatility parity, and caps each asset class at 40% of equity so the book stays diversified. Managed futures, on-chain.",
       "belief_plain": "Follows the trend everywhere at once — crypto, stocks, gold, oil, indices — buying what's going up and shorting what's going down, on two separate wallets. It bets the SAME risk on each position (smaller on wild assets, bigger on calm ones) and never lets any one type of market take over the book, so the curve stays smooth and it can make money even when stocks are crashing.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "You want the most-proven hedge-fund category — managed futures (CTA) — on-chain. Its entire edge is cross-asset diversification: trends show up in different markets at different times, so the more uncorrelated markets you trend-follow, the smoother the curve. Long the uptrends and short the downtrends across uncorrelated classes nets to ~zero market beta and is crisis-positive (the short sleeve shorts the fallers when everything bleeds). Each asset is judged against its OWN history (time-series trend), sized to equal risk, and capped by class.",
       "tags": [
         "managed-futures",
@@ -2758,7 +3015,7 @@
       "emoji": "🐆",
       "tagline": "Ranks the tokenized U.S. equity cross-section on Hyperliquid XYZ by 24h relative strength, then LONGS the strongest names (long book) and SHORTS the weakest (short book) — both trend-confirmed — on two equally-funded wallets so the pair is ~market-neutral and harvests equity dispersion.",
       "belief_plain": "Buys the strongest tokenized U.S. stocks and shorts the weakest at the same time, on two separate wallets, so it makes money on the GAP between winners and losers rather than on the market going up or down.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "You want the classic equity hedge-fund play — long the leaders, short the laggards, market-neutral — but on-chain. The spread between the best and worst U.S. stocks is at a multi-decade extreme, and that dispersion is the edge: stock selection, not market direction. Tokenized equities trade 24/7 on Hyperliquid, so the book never has to wait for a market open.",
       "tags": [
         "equities",
@@ -2823,7 +3080,7 @@
       "emoji": "🐉",
       "tagline": "A two-leg BTC + HYPE book that fuses a dozen weighted signals — trend, volume, OI, funding crowding, smart-money lean, cross-asset flow — into one 0-10 conviction score per asset, and only strikes when the composite is loud.",
       "belief_plain": "No single indicator is trustworthy, but when many independent ones agree — price trend, volume, open interest, funding, what the best traders hold, and BTC pulling HYPE — that agreement is the signal. Bet bigger the louder the agreement, protect every position with a ratchet stop, and stand aside when the picture is mixed.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": null,
       "tags": [
         "composite",
@@ -2873,7 +3130,7 @@
       "emoji": "⚡",
       "tagline": "Bets AI datacenters are a structural new source of electricity demand: LONGS the AI-power complex on Hyperliquid XYZ (uranium, gas-fired power, grid copper, fuel cells, rare-earth) and SHORTS crude oil — both trend-confirmed, on two separate wallets — so the pair is energy-sector-neutral and harvests the electrons-vs-barrels spread.",
       "belief_plain": "Buys the things that make electricity for AI datacenters (uranium, natural gas, copper, fuel cells, rare-earth) and shorts crude oil at the same time, on two separate wallets, so it makes money on power BEATING oil rather than on energy going up or down.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "AI datacenter electricity demand is a structural new bid for the power complex, while crude oil is the legacy transport fuel barely levered to AI. Both legs are energy, so a broad energy move washes out and the P&L is the dispersion — power outperforming oil. Each book only acts when ABSOLUTE trend confirms (long power on a non-bearish 4h; short oil on a non-bullish 4h, with a capitulation guard), with cross-sectional relative strength as a size/rank tiebreaker. Commodities trade ~24/7 on Hyperliquid, so the book never waits for a market open.",
       "tags": [
         "energy",
@@ -2931,7 +3188,7 @@
       "emoji": "🦅",
       "tagline": "A multi-asset non-crypto XYZ breakout rider: scans 12 macro names (oil, gold, S&P/Nasdaq, mega-cap tech) for a >=1.5% 1H breakout, confirms with 4H trend, volume surge, smart-money lean and funding, then sizes leverage to score (3x/5x) and rides the move with a DSL trailing exit. Holds up to 2 positions; trades 24/7 incl weekends.",
       "belief_plain": "Watches a basket of macro markets — crude and Brent oil, gold, the S&P and Nasdaq, and the biggest US tech stocks — and pounces when one breaks out more than 1.5% in an hour with volume behind it. It goes in harder (5x vs 3x) on the cleanest breakouts and trails a stop instead of guessing the exit. These markets trade around the clock, weekends included, so there's no market-hours gate.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Macro assets move on discrete catalysts — an inventory print, a Fed headline, an earnings beat — and a sharp 1H breakout with volume confirmation usually continues for one to three hours before the move matures. A scanner watching a focused 12-name macro universe can catch that breakout early across commodities, indices and mega-cap equities, weight the 1H magnitude heaviest, confirm with the 4H trend, smart-money lean and funding, and let a trailing DSL lock the move before it fades.",
       "tags": [
         "xyz",
@@ -2993,7 +3250,7 @@
       "emoji": "🪁",
       "tagline": "Trades the ICT/SMC playbook on BTC, ETH, SOL and FARTCOIN: it maps 3-bar fractal swings, waits for a break of structure, then enters on the 0.618 fibonacci retracement of that move with invalidation behind 0.786 — only when an RSI divergence confirms. Every entry carries its stop and 1R/2R/3R targets.",
       "belief_plain": "This speaks the language of smart-money-concept traders. It watches for the market to break its own structure — taking out a prior swing high or low — which signals a real shift. Then, instead of chasing, it waits for price to pull back to the 0.618 fibonacci level of that move, checks that momentum (RSI) is diverging in its favour, and enters there with a clear invalidation just beyond the 0.786 level. It works out its 1x, 2x and 3x reward targets up front and manages the trade with a ladder that locks in gains in thirds as each target is reached.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "A break of structure marks where order flow shifted; the 0.618 retracement is where that move offers the best risk-reward to rejoin, and the 0.786 is where the idea is simply wrong. Requiring an RSI divergence at the retracement filters the continuations that have already exhausted. The result is a defined-risk, defined-target structure trade — the exact methodology a whole trader subculture uses by hand — automated across a few liquid names. The step-up profit ladder approximates a 33/33/33 scale-out; true partial take-profit lands with the native DSL scale-out capability.",
       "tags": [
         "smc",
@@ -3048,7 +3305,7 @@
       "emoji": "🦁",
       "tagline": "Bets on a K-shaped divergence: LONGS the structural winners (the AI complex on Hyperliquid XYZ + the crypto winners HYPE/SOL) on the 'haves' wallet, and SHORTS the laggards (the broad U.S. market via SP500 + a gated basket of laggard alts) on the 'have-nots' wallet. Both trend-confirmed on absolute structure, with relative strength as a tiebreaker and per-name conviction sizing (HYPE big, SOL small, SP500 core). The edge is the DISPERSION between the two speeds, not market direction.",
       "belief_plain": "Buys the booming AI stocks and crypto winners while shorting the broad stock market and the alts losing ground, each on its own wallet — so it makes money on the GAP between the world's fast lane and slow lane rather than on the market going up or down. It only buys names actually trending up and only shorts names actually rolling over, and bets bigger on its highest-conviction picks.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "The world is splitting into two speeds: the AI complex and HYPE/SOL keep booming while the broad U.S. economy and the rest of crypto struggle. Express it as one thematic long/short book — long the haves, short the have-nots — and the P&L is the dispersion between the two, not the market's direction. The hard gate is ABSOLUTE trend (never long a downtrend, never short an uptrend, even for a thesis name); cross-sectional relative strength only tilts size and ranking. Net exposure is the operator's dial (default modest net-long), set by how much capital each wallet holds.",
       "tags": [
         "k-shaped",
@@ -3138,7 +3395,7 @@
       "emoji": "🏛️",
       "tagline": "A diversified, long-only, NO-LEVERAGE basket across crypto blue chips, equity indices and blue-chip names, metals, and energy — sized to a hard per-position cap, gated by a fee hurdle so it only trades when the expected move beats the cost, and diversified with a per-class limit. Capital preservation first.",
       "belief_plain": "This is a conservative, institution-style portfolio, not a punt. It holds a diversified spread of blue-chip crypto and real-world assets (stock indices, big-cap names, gold, silver, oil), never uses leverage, and never puts more than a small capped slice into any one position. It only opens a position when the trend is genuinely there on both the 4-hour and daily view AND the expected move is large enough to be worth the trading cost — otherwise it does nothing. Doing nothing is a valid decision.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "For capital preservation, what you DON'T do matters more than what you do. No leverage means a bad position can't wipe the book; hard per-position and per-class caps mean no single name or theme can sink it; a fee hurdle means small, cost-eroding edges are declined rather than churned. The result is a low-volatility diversified compounder across crypto and RWA that trades rarely and holds patiently, cutting a real breakdown early and locking gains before giving them back.",
       "tags": [
         "capital-preservation",
@@ -3202,7 +3459,7 @@
       "emoji": "🪙",
       "tagline": "Bets money is migrating on-chain: LONGS the on-chain financial rails (HYPE the venue + Circle/CRCL + Coinbase/COIN + Robinhood/HOOD + BTC treasuries MSTR/PURRDAT) on one wallet and SHORTS legacy finance + broad financial-beta (Blackstone/BX + SP500) on another — both trend-confirmed on absolute 4h/1h structure — so the P&L is the disruptor-vs-incumbent spread.",
       "belief_plain": "Buys the companies and tokens that are pulling finance on-chain (the crypto exchange, the stablecoin issuer, the BTC treasuries) and at the same time shorts the old-finance incumbents and the broad market, on two separate wallets. It only buys names that are actually trending up and only shorts names actually rolling over, and it bets bigger on its highest-conviction picks (HYPE and Circle).",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Money is migrating on-chain — stablecoins, crypto exchanges and BTC treasuries are eating legacy financial rails. You want to own the disruptors and short the incumbents so the return is the GAP between them, not the direction of the market. HONEST CAVEAT: the hedge is cross-sector and the short universe is thin (few pure legacy-finance names list on the venue yet), so the short leg leans on the broad index — it nets down market beta rather than perfectly isolating the pair, and the long book is the strong, high-conviction side.",
       "tags": [
         "on-chain-finance",
@@ -3261,7 +3518,7 @@
       "emoji": "🐂",
       "tagline": "A vol-balanced all-weather LONG basket across asset classes (crypto majors + equity indices + metals + energy + FX), each sleeve sized by inverse realized volatility so no single class dominates risk — plus a defensive ballast book that scales up when the tape turns risk-off.",
       "belief_plain": "Holds a steady, always-invested basket spread across crypto, stock indices, gold, oil and currencies, and quietly puts more weight on the calm assets and less on the wild ones so nothing can blow up the whole book. A second smaller book buys defensives (gold, yen) and doubles up when markets get nervous.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "You want a low-drama core holding to sit under your more aggressive bets — always invested, diversified across asset classes, and risk-balanced by volatility rather than a directional view. Not a market-timing bet; a steady, all-weather core with a built-in defensive cushion.",
       "tags": [
         "risk_parity",
@@ -3322,7 +3579,7 @@
       "emoji": "🦏",
       "tagline": "Carries cheap convexity across two books: an always-on small LONG carry in the crisis-beneficiary complex (gold / oil / dollar / yen), plus a dormant, stress-gated leveraged add that goes LONG the spiking crisis assets and SHORT the cratering risk assets the moment a shared cross-asset stress detector confirms a shock — then banks the spike.",
       "belief_plain": "Built to lose a little in calm and win big in a crisis. One book quietly holds gold/oil/dollar/yen as standing insurance whenever they're trending up. The other sits in cash until a shock hits — oil spiking, stocks breaking down, Bitcoin rolling over — then piles into the crisis winners and shorts the risky stuff, and takes profit fast because crises reverse hard.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "You want the part of the portfolio that's green on the days everything else is red. Not a fixed war bet you switch on, and not a macro trend-follower — Rhino is always-on insurance that self-activates a leveraged convex leg on a measured stress signal, with no view required.",
       "tags": [
         "tail-risk",
@@ -3386,7 +3643,7 @@
       "emoji": "🦂",
       "tagline": "Hunts trend-following entries across a curated crypto + XYZ basket (BTC/ETH/majors, mid-caps, plus crude oil, Brent, gold and the S&P): enters only when smart money is concentrated in a direction AND 4h price agrees, scores SM dominance + multi-timeframe momentum, and rides maker-optimized exits with a let-winners-run trailing ladder.",
       "belief_plain": "Trades a hand-picked set of coins and commodities/indices. It only acts when the best traders are crowded on one side and the 4-hour price is already moving that way, then trails a profit-locking stop and pays cheaper maker fees on the way out.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "The strongest, lowest-noise trends show up where smart-money concentration and 4h price direction agree — across BOTH crypto and the XYZ commodities/indices that most agents ignore. Score that agreement, gate hard on it, and let the DSL ride the winners while maker-preferred exits claw back the fee drag that kills high-turnover active traders.",
       "tags": [
         "momentum",
@@ -3455,7 +3712,7 @@
       "emoji": "🕷️",
       "tagline": "An AI/Tech momentum long book plus a macro/majors mean-reversion book — two legs, two wallets, one package.",
       "belief_plain": "AI/tech equities and crypto majors trend over days, while majors and energy snap back from short-term extremes — run both books side by side.",
-      "version": "6.0.3",
+      "version": "6.1.0",
       "thesis": null,
       "tags": [
         "ai",
@@ -3520,7 +3777,7 @@
       "emoji": "🎯",
       "tagline": "One wallet expresses a macro view as a long/short basket — but it only presses a name when the market is confirming that direction (4h/1h trend + 24h momentum aligned), and the DSL + drawdown gate de-risk when the thesis stops working. Default preset: risk_off (long gold/silver, short SP500/XYZ100/BTC). Swap the basket inputs to express recovery, war_escalation/war_recovery, hype_vs_market, gold_over_btc/btc_over_gold.",
       "belief_plain": "You pick what you think will happen — say, a risk-off shock — and the fund holds the basket that expresses it: long the assets that win, short the ones that lose. But it doesn't blindly hold: it only buys a name while the market is actually moving its way, and trails a stop to cut names that stop working.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "You bring the market VIEW; the fund expresses it with discipline. Instead of picking a trading style, you pick what you believe will happen — and one wallet trades the long/short basket that expresses it, pressing each name only when the tape confirms the thesis direction rather than fighting it.",
       "tags": [
         "macro",
@@ -3579,7 +3836,7 @@
       "emoji": "🦅",
       "tagline": "Scans a whitelist of ~25 small/mid-cap Hyperliquid perps that no other agent covers (majors and XYZ are banned), and enters when smart-money concentration aligns with a fresh 4h trend, the 1h confirms it isn't a false breakout, and 15m velocity is accelerating — then sizes leverage to conviction (5x, 7x apex), cuts losers fast and rides the right-tail winners for days on a trailing stop.",
       "belief_plain": "Hunts the small coins the rest of the fleet ignores. It only buys (or shorts) one when the best traders are crowding in, the 4-hour trend agrees, the 1-hour isn't already rolling over, and short-term momentum is building — then goes in harder on the strongest setups and trails a stop. Most trades are tiny losses cut fast; the occasional big winner pays for everything.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "The biggest blind spot on Hyperliquid is the small/mid-cap long tail — every other agent is locked to the majors or a single asset, so nobody is reading smart-money flow on HEMI, WLD, XPL, AIXBT and the rest. Small caps have a thicker trader-count signal-to-noise ratio than the majors: when smart-money concentration on one aligns with a fresh 4h trend and accelerating 15m velocity, that's a momentum entry with a long right tail. A low win rate is fine when the winners are several times the size of the losers.",
       "tags": [
         "small-cap",
@@ -3652,7 +3909,7 @@
       "emoji": "🐺",
       "tagline": "Two books on two wallets that read one shared cross-asset regime (equities, oil, gold, BTC, the dollar). The RISK-ON book longs beaten-down beta in a confirmed risk-on regime; the RISK-OFF book longs defensives and shorts risk in a confirmed risk-off regime — capital rotates to whichever the macro favors.",
       "belief_plain": "Watches the whole macro complex — stocks, oil, gold, BTC, the dollar — and waits for them to agree on which way the wind is blowing. When it's risk-on it buys the beaten-down risk assets that are turning up; when it's risk-off it buys safe havens and shorts risk. No single asset can flip it; the whole complex has to lean one way.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "You think the edge is in trading the macro TURN, not a fixed view and not per-asset trend. You want a fund that detects which way the regime is shifting across the whole cross-asset complex and rotates its two books to that side, standing down entirely when nothing agrees.",
       "tags": [
         "regime",
@@ -3714,7 +3971,7 @@
       "emoji": "🐺",
       "tagline": "A single-asset BTC bet driven by a macro-regime read: each tick it measures BTC's 7-day trend strength and annualized realized volatility (plus cross-asset dispersion for context) and classifies the market into TREND_UP, TREND_DOWN or CHOP — going long BTC in a calm uptrend, short BTC in a high-vol crash, and staying out otherwise, then letting a balanced DSL ride the regime.",
       "belief_plain": "Coyote first asks 'what kind of market are we in?' It looks at how far Bitcoin has moved over the last week and how violent that move has been. A steady 5%+ climb with calm volatility means uptrend — it goes long BTC. A sharp 5%+ drop with a volatility spike means a panic crash — it goes short BTC. Anything in between is chop, so it stays out. Real regimes last days, so it trades rarely and lets the trend run.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Most agents re-implement their own 'should I be active right now?' check; Coyote makes the macro regime a first-class decision. BTC's 7-day move sets the direction and realized vol confirms the character — demanding HIGH vol for a short distinguishes a panic crash worth fading-with from an orderly grind-down that's really just chop. Because regimes are persistent, the right behavior is a slow cadence, a 6h cooldown and a max of 2 entries/day so it never churns on noise, then a wide DSL trail so a real regime move runs for days.",
       "tags": [
         "btc",
@@ -3762,7 +4019,7 @@
       "emoji": "🦎",
       "tagline": "A relative-value pairs trader on correlated crypto majors: for each pair (ETH/BTC, SOL/ETH, SOL/BTC) it z-scores the latest price ratio vs its 48-bar (1h) mean, and when the ratio stretches >=2 sigma AND starts reverting, it takes a directional bet on the high-beta leg in the snap-back direction — sizing one slot and letting a tight mean-reversion DSL bank the reversion.",
       "belief_plain": "Trades the spread between two coins, not the market. When ETH gets expensive relative to BTC (or SOL vs ETH), the ratio stretches far from its usual level — and ratios snap back more reliably than outright prices. Chameleon measures how stretched a pair is, waits until the ratio starts turning back, then bets on the high-beta coin (ETH or SOL) in the direction that profits from the snap-back, and trails a tight stop to bank the reversion.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Correlated majors trade as a pack, but their ratios oscillate around a mean. A 3-sigma ETH/BTC extension is a cleaner edge than guessing ETH's absolute direction — the pair's correlation does the work. The Senpi runtime is single-position, so instead of a two-leg market-neutral spread Chameleon takes a directional bet on the high-beta leg; it captures most of the reversion edge without spread-level position management, and the move is bounded, so a tight ladder banks the snap-back rather than holding for a trend.",
       "tags": [
         "eth",
@@ -3813,7 +4070,7 @@
       "emoji": "🦫",
       "tagline": "An onboarding-tier BTC specialist: enters only when the 4h candle structure is trending AND Senpi's Smart-Money leaderboard agrees with that direction — then takes one flat-5x position and lets a wide DSL ladder ride the trend.",
       "belief_plain": "Trades only BTC. It asks two questions — is BTC trending on the 4-hour chart, and does smart money agree? If both are yes it opens one position and trails a stop instead of guessing the exit. Built for first-time users.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "New users want one clean answer, not a scattergun across the market. BTC is the most liquid, most legible asset on Hyperliquid; 'is it trending and does smart money agree?' is the simplest honest edge — and a wide trailing stop lets a real trend run multi-day without micromanagement.",
       "tags": [
         "btc",
@@ -3859,7 +4116,7 @@
       "emoji": "🐈",
       "tagline": "A big-tech equity-perp trend follower on Hyperliquid XYZ (NVDA/TSLA/AAPL/META/MSFT/GOOGL/AMZN/AMD/MU/INTC/TSM/ORCL): enters the single strongest name when its 4h trend is non-neutral AND smart-money leans the same way (tilt >= 55%), sizes a flat 20% margin at 5x, and lets a wide DSL ratchet ride the move — with a 48h cap so positions don't camp through the weekend pricing gap.",
       "belief_plain": "Trades the big tech stocks you already know — NVDA, TSLA, AAPL and nine more — as perps on Hyperliquid XYZ, 23/5. It only enters when a stock's 4-hour trend and the best traders are pointing the same way, holds the single strongest setup, and trails a stop so a real move can run — but caps each hold at 48 hours so it never sits through the Friday-to-Sunday gap when these names have no external price.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Big tech is the most-traded equity sector, and Hyperliquid XYZ surfaces these names as leveraged perps with 23/5 hours. A clean trend + smart-money confluence on the highest-liquidity XYZ equities catches directional moves without the small-cap noise of a broad scanner. The 48h hard_timeout is intentional: equity perps reconcile against an internal oracle over the weekend gap, where drift accumulates without external price discovery — so winners are let to run on the 4h timescale but never held through the full Fri-Sun window.",
       "tags": [
         "big-tech",
@@ -3920,7 +4177,7 @@
       "emoji": "🦡",
       "tagline": "A single-asset Brent crude (xyz:BRENTOIL) specialist: enters only when 5m/15m/1h/4h trend all agree AND smart-money (mark/oracle premium) leans the same way, then stacks OI velocity, volume spikes and price cleanliness into a conviction score — sizing leverage to conviction (3/5/7/10x) and letting the DSL ride the news move.",
       "belief_plain": "Trades only Brent crude oil. It waits until every timeframe from 5 minutes to 4 hours is pointing the same way and order flow agrees, then goes in harder when more signals line up — and trails a stop instead of guessing the exit. Oil trades around the clock, weekends included.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Oil moves on discrete news — OPEC decisions, geopolitics, inventory releases — with sharp 2-5% directional bursts and violent reversals after overshoot. An agent that watches only Brent can read its 4-timeframe structure, order-flow premium, OI and volume far more tightly than a broad scanner, catch the clean move early, and lock profit before the snap-back.",
       "tags": [
         "oil",
@@ -3968,7 +4225,7 @@
       "emoji": "🦎",
       "tagline": "Point it at any liquid coin you name and it trades just that one: it scores trend structure, momentum and funding into a single confluence read on that name, goes long or short when enough signals line up — sizing conviction to the strength of the setup — and trails a stop instead of guessing the exit.",
       "belief_plain": "You pick the coin; Gecko trades only that coin. It waits until the 1-hour and 4-hour trend, momentum and funding all point the same way, then goes in — harder when more of them agree — and never guesses the exit: a trailing stop does all the closing. One coin, one position, done well.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Most people don't want a scattergun across the whole market — they want their coin traded properly. Gecko is bison's validated confluence scorer pointed at a single user-named asset: trend structure (1h/4h), momentum, RSI and funding are summed into one conviction score, direction resolves from the timeframe waterfall, and leverage/margin scale to the score. One asset, one high-conviction slot; the DSL owns every exit and the drawdown_halt is the backstop. It fills the long tail of 'make me a strategy for <my coin>' without a bespoke build each time.",
       "tags": [
         "configurable",
@@ -4015,7 +4272,7 @@
       "emoji": "🐻",
       "tagline": "A single-asset BTC specialist: enters only when 4h and 1h trend structure agree, 15m momentum confirms, smart money leans the same way, and a macro V-recovery gate proves the move isn't a fade right off the 24h extreme — then sizes leverage to conviction (7/10/10x) and lets the DSL ride the winner.",
       "belief_plain": "Trades only BTC. It waits for the 4-hour and 1-hour trend to agree, momentum to confirm, and the best traders to be leaning the same way — and it refuses to short right off a 24h low (or long right off a 24h high) because those fades whipsaw. It goes in harder when more factors line up, and trails a stop instead of guessing the exit.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "BTC has the deepest liquidity on Hyperliquid and the cleanest trend structure. An agent that watches only BTC can read its multi-timeframe structure, smart-money flow, and funding far more tightly than a broad scanner — and BTC's 4h structure metric lags V-recoveries, so a distance-from-24h-extreme gate stops it from fading a reversal that the candle structure hasn't caught up to yet.",
       "tags": [
         "btc",
@@ -4061,7 +4318,7 @@
       "emoji": "🐦",
       "tagline": "An onboarding-tier single-asset ETH trend follower: enters only when the 4h candle structure is trending AND Senpi's Smart-Money leaderboard agrees with that direction — then holds one position at a fixed 5x and lets a wide DSL ladder ride the trend for multi-day moves.",
       "belief_plain": "Trades only ETH. It asks two simple questions — is ETH trending on the 4-hour chart, and do the best traders agree with that direction? If both say yes it opens one position and trails a stop instead of guessing the exit. Built for first-time users.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "New users want one clean question answered well, not a scattergun across the market. ETH has the liquidity and the smart-money depth, and a simple agent that watches only ETH — checking 4h structure and the leaderboard's net lean — gives a beginner a clear directional position without funding-rate math or multi-asset tuning.",
       "tags": [
         "eth",
@@ -4106,7 +4363,7 @@
       "emoji": "🪶",
       "tagline": "An onboarding-tier single-asset HYPE specialist: enters only when the 4h trend structure is directional AND Senpi's Smart-Money leaderboard agrees with that direction (tilt >= 60%) — then holds one flat-5x position and lets a wide DSL ladder ride the trend.",
       "belief_plain": "Trades only HYPE. It asks two simple questions — is HYPE trending on the 4-hour chart, and do the best traders agree with that direction? If both are yes, it opens one position and trails a wide stop instead of guessing the exit, so winning trends can run for days.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "New users want one clean decision, not a scattergun across the market. HYPE has the liquidity and the moves, and a one-asset, one-direction strategy with a Smart-Money confirmation gate is the simplest honest answer to 'I'm new to Senpi, where do I start?'",
       "tags": [
         "hype",
@@ -4151,7 +4408,7 @@
       "emoji": "🦎",
       "tagline": "A broad-index trend-follower on the XYZ equity indices (xyz:SP500 + xyz:XYZ100): each tick measures the 4-day move of each index, picks the stronger one past the trend floor, and rides it in that direction — no stock-picking, no commodities. The closest thing to an index fund, but 24/7 on Hyperliquid.",
       "belief_plain": "Trades only the two broad stock-market indices (S&P 500 and the XYZ 100). Every few minutes it checks which index has the bigger 4-day move; if that move is large enough it goes that way (up = long, down = short), bets bigger when the move is strong and volume is rising, and then trails a stop. The simplest stock-market exposure on Hyperliquid — no individual stocks.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "You want broad stock-market exposure on Hyperliquid without picking individual stocks, commodities, or pre-IPO names. Two liquid index instruments, one decision per tick: trend-follow whichever index has the clearer 4-day direction. The edge is in the slow index drift, so a wide DSL rides it for days and a 48h hard-timeout caps the XYZ weekend pricing-gap risk.",
       "tags": [
         "sp500",
@@ -4201,7 +4458,7 @@
       "emoji": "🐨",
       "tagline": "The simplest agent in the catalog: pick one asset (default BTC), fire LONG once on deploy, then hold with an ultra-wide DSL trail (max_loss 30%, retrace, 90-day timeout). No scoring, no scheduling — the choice to deploy Koala IS the bet.",
       "belief_plain": "Trades only the one coin you pick (BTC by default). It buys once when you turn it on, then just holds — never adding, never trading around it — with a very wide safety stop that only releases on a catastrophic reversal or after three months. The whole idea is to own the coin and have a net under it.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Some users do not want a market-reading agent at all — they just want to own one asset and have a safety net. Koala is that answer in code: one asset, one entry, one stop. Fire-once by default (a true buy-and-forget), with an optional re-entry cycle for operators who want 'buy / DSL-exits / buy again' on a long cooldown.",
       "tags": [
         "btc",
@@ -4248,7 +4505,7 @@
       "emoji": "🐻",
       "tagline": "A single-asset SOL specialist: enters only when 4h and 1h trend structure agree, 15m momentum confirms, and smart-money lean, funding, and BTC all line up — then sizes leverage to conviction (5/6/7x) and lets the DSL ride the winner.",
       "belief_plain": "Trades only SOL. It waits for the 4-hour and 1-hour trend to agree, momentum to confirm, and the best traders to be leaning the same way — then goes in harder when more of those line up, and trails a stop instead of guessing the exit.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "You want one coin done really well, not a scattergun across the market. SOL has the liquidity and the moves, and an agent that watches only SOL can read its structure, smart-money flow, and funding far more tightly than a broad universe scanner ever could.",
       "tags": [
         "sol",
@@ -4293,7 +4550,7 @@
       "emoji": "🐟",
       "tagline": "Top-down structure trading on FX pairs (EUR / GBP / JPY), the way it's taught: the Daily, 4-hour and 1-hour charts must all agree on trend direction, the 4-hour marks the area price is expected to retest, and the 15-minute times the entry off a break of structure inside that zone. If the timeframes disagree, or price isn't at the level, or there's no 15-minute trigger, it does nothing. Long & short, low leverage scaled to how small FX moves are.",
       "belief_plain": "This is how structure traders actually read a chart: start wide, then zoom in. First it checks that the Daily, 4-hour and 1-hour charts are all pointing the same way — if they disagree, there's no trade. Then on the 4-hour it marks the zone price is likely to pull back to. Then it waits, on the 15-minute chart, for price to actually reach that zone AND break in the trend direction before entering. Three things have to line up: direction, location, and timing. Miss any one and it stands aside. It trades the major currency pairs, which move in small percentages, so it uses the leverage that matches.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Multi-timeframe / ICT-style structure trading is one of the largest retail methodologies and the catalog had no expression of it — nor any FX template at all, despite Hyperliquid listing EUR, GBP and JPY. Manta encodes the top-down cascade faithfully: each timeframe answers exactly one question (higher frames = bias, 4h = location, 15m = timing) and is not allowed to answer another, which is the discipline the method is really about. The confluence is mandatory, not additive — a signal requires all three, because a 15m break outside the zone is noise and a zone touch with no break is a falling knife. Thresholds are FX-scaled throughout: a 0.5% daily move is a big FX day, so a crypto-sized structure filter would call every currency chart neutral forever.",
       "tags": [
         "fx",
@@ -4348,7 +4605,7 @@
       "emoji": "🧊",
       "tagline": "A single-asset ETH specialist: smart-money concentration picks the side first, then 4h and 1h trend structure must agree, 15m momentum confirms, and funding, open interest, BTC and RSI all add conviction — then sizes leverage to score (5/7/10x) and lets the DSL ride the winner.",
       "belief_plain": "Trades only ETH. It first looks at which way the best traders are leaning hard, then only takes it if the 4-hour and 1-hour trend agree and momentum confirms — going in harder when more factors line up, and trailing a stop instead of guessing the exit.",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "thesis": "You want one coin done really well, not a scattergun across the market. ETH has the liquidity and smart-money depth, and a hybrid agent that watches only ETH can read the leaderboard's net lean, candle structure, funding and open interest far more tightly than a broad universe scanner ever could.",
       "tags": [
         "eth",
@@ -4394,7 +4651,7 @@
       "emoji": "🐏",
       "tagline": "A single-asset gold (xyz:GOLD) specialist: goes long when gold's trend lines up across the 1h and 4h and momentum agrees — and leans in harder when the market turns risk-off and money is looking for a safe haven — and can short a clean downtrend. Holds one position at a time and trails a stop instead of guessing the exit.",
       "belief_plain": "Trades only gold. It buys when gold is trending up and, especially, when the market gets defensive and flows into safe havens; it can short a clear downtrend. It never picks a top or bottom by hand — a trailing stop does all the exiting. Gold trades around the clock, weekends included.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Gold is the market's safe-haven anchor: it trends on real-rate and risk-regime shifts and gets bid hardest when risk assets wobble. An agent that watches only gold can read its 1h/4h trend structure, momentum and RSI far more tightly than a broad scanner, and add a safe-haven tilt when a risk-off funding regime shows up — catching the defensive bid early and locking profit as the move matures. Concentration by conviction on one asset, with the DSL owning every exit.",
       "tags": [
         "gold",
@@ -4440,7 +4697,7 @@
       "emoji": "🦌",
       "tagline": "Watches a small whitelist of large-cap crypto for a real parabolic setup — established uptrend, a 7-day move of 25%+ on surging volume that's still accelerating, with smart money piled long — then goes long and hands the trade to the widest stop in the catalog so it can ride the whole run through the violent intraday pullbacks.",
       "belief_plain": "Only buys when a coin is genuinely going parabolic, not just trending. It waits for a big multi-week move that's still speeding up on heavy volume with the best traders leaning long, then uses a very loose trailing stop so the position survives the 5-8% dips that would shake out a normal trend trade.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "The hard part of a parabolic run isn't entering — it's not getting chopped out. A standard trend trail makes local-volatility decisions and exits on the first 5-8% pullback, missing the rest of a +60% move. Stag pairs a strict entry filter (so it only fires on a real parabolic) with the deliberately wide parabolic_runner DSL (so the trade survives the gyrations). The trade-off is honest: it bleeds in chop, which is exactly why the filter is strict.",
       "tags": [
         "parabolic",
@@ -4490,7 +4747,7 @@
       "emoji": "🐢",
       "tagline": "The Turtle breakout, rebuilt with our DSL. It enters when price breaks its 20-day high (long) or low (short) and MACD agrees, then ADDS units as the move extends — a second at +½N, a third at +1N, a fourth at +1½N (N = 20-day ATR). Each unit is its own wallet with its own trailing stop, calibrated to its rung: the base breathes widest and carries the trend, the tip locks tightest and peels off first, so the pyramid unwinds top-down instead of all at once. One asset (BTC by default), long or short, four units.",
       "belief_plain": "This is the classic Turtle trading system with a modern exit. It waits for a real breakout — price pushing past its highest level in 20 days — and only takes it if momentum (MACD) agrees, which filters out the false breaks that trap breakout buyers. Then, the Turtle move: as the trend keeps running in your favor, it adds more size in steps, building a bigger position into a winner. The twist is how it gets out. The original Turtles dumped the whole stack at one stop; Terrapin gives each added chunk its own trailing stop — the first, safest chunk rides the longest, while the chunks added late (which have the least cushion) protect their profit fastest and exit first if it turns. You fund it once and it splits across four sub-wallets, one per chunk.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "The Turtle breakout is one of the most documented trend-following systems in existence, and the catalog had no expression of it — because a faithful pyramid needs to ADD to a winning position, and Hyperliquid nets positions per coin per wallet, so a single-wallet build can only ever hold the first unit. Terrapin solves that structurally: four units, four wallets, each arming off the same statelessly-computed frozen breakout anchor so the ½N ladder is consistent without any cross-wallet coordination. The deliberate modernization is the exit. Turtle's unified 2N / 10-day-low stop becomes four independent DSL ladders, progressively tighter up the pyramid — which is not just faithful-enough but arguably better: the position unwinds from the top on a reversal, banking the exposed upper units while the base rides, instead of giving the whole stack back at one level. The MACD filter is the user's requested addition ('turtle con MACD') and does real work — it vetoes the momentum-less breakout that is the system's classic whipsaw.",
       "tags": [
         "turtle",
@@ -4543,7 +4800,7 @@
       "emoji": "🦡",
       "tagline": "A single-asset HYPE specialist: six-gate trend entry (4h structure, 1h non-opposition, 15m momentum, base-tech floor, 4h magnitude) layered with a market-wide funding-regime + funding-persistence macro gate and a smart-money HARD BLOCK — then sizes leverage to conviction (3/5x) and lets the DSL ride the winner.",
       "belief_plain": "Trades only HYPE. It waits for the 4-hour trend to be strong, the 1-hour to not be fighting it, and short-term momentum to confirm — then checks the broader funding 'crowding' regime and refuses to trade when the best traders are leaning the other way. It goes in harder when more factors line up, and trails a stop instead of guessing the exit.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "HYPE is one of the highest-volatility majors on Hyperliquid. A specialist that watches only HYPE can read its trend structure, smart-money flow, funding regime and persistence far more tightly than a broad scanner — and the macro funding-regime gate keeps it out of crowded, liquidation-prone setups that single-asset momentum alone would walk into.",
       "tags": [
         "hype",
@@ -4590,7 +4847,7 @@
       "emoji": "🐉",
       "tagline": "A long-term conviction book on ONE major (the thesis coin: ETH/SOL/HYPE), ridden through volatility on a catastrophic-only stop, plus a tactical dip-buyer that presses the pullbacks — cushioned by a diversified short of OTHER assets that are actually breaking down, so the hedge protects market risk without ever betting against your thesis.",
       "belief_plain": "Holds one major you believe in for the long haul and adds on its dips, while shorting a basket of other coins/indices whenever they roll over — so a market selloff that would hurt your coin is offset by profits on the short side, and you never short the coin you're bullish on.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "You have a high-conviction long-term view on one major and want to ride it through normal volatility instead of being stopped out — but you still want a real cushion in a broad selloff. So you hold the thesis on a wide disaster-only stop, press its dips, and hedge by shorting OTHER assets that are confirmed breaking down (vol-parity sized, sized up when your own coin is breaking too). Long the conviction, short the carnage elsewhere.",
       "tags": [
         "conviction",
@@ -4649,7 +4906,7 @@
       "emoji": "🐆",
       "tagline": "A patient universe sniper: scans the top-100 smart-money markets every tick and refuses to fire unless smart-money consensus, velocity, acceleration, dual-price confirmation, volume, quality-trader alignment, and rank-climb all line up — then takes ONE position, sized 3-8x by conviction, and lets the DSL ride the winner.",
       "belief_plain": "Watches where the best traders are crowding across the whole market, but waits for everything to agree at once — the smart money, the price, the volume, the speed of the move — before taking a single, high-conviction bet. Most of the time it does nothing; that patience is the point.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Any one signal is noise. Real edge shows up only when smart-money consensus, momentum, acceleration, price, volume, and proven-trader alignment all confirm the same direction on the same coin at the same moment. That confluence is rare, so the right move is to sit on one slot, wait for it, strike once at conviction-scaled leverage, and let a ratcheting trailing stop — not a fixed target — decide the exit so the rare big trend pays for the quiet weeks.",
       "tags": [
         "smart-money",
@@ -4693,7 +4950,7 @@
       "emoji": "🐦",
       "tagline": "Auto-discovers the platform's top-performing strategies, then trades the asset + direction they agree on most — performance-weighted, so a stronger strategy gets more say (capped so one outlier can't dominate).",
       "belief_plain": "Lets the best strategies on the platform do the work. Every few minutes it finds the top performers, looks at what they're holding right now, and copies whatever the most (and best) of them are piling into together — going long what they're long and short what they're short.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Following one trader or one leaderboard is one layer; Cuckoo is a layer above it. The strategies it follows are themselves copy/algo/trader-following strategies, so it captures the consensus of the consensus. When the best strategies independently pile into the same asset+direction, that agreement is a strong, self-cleaning signal — underperformers fall out of the top-N automatically, so the pool refreshes toward whatever is working.",
       "tags": [
         "copy-trading",
@@ -4737,7 +4994,7 @@
       "emoji": "🐕",
       "tagline": "A patient contrarian on BTC/ETH/SOL/HYPE: waits for a major to move 3%+ in 4h while smart money piles in heavily, then fades the crowded, exhausted side — but only when the funding regime confirms the unwind and the move is still fresh. Conservative 7-10x leverage, wide DSL to let the reversal develop.",
       "belief_plain": "When a big coin runs hard and the best traders are all crowded onto the same side, the crowd is maximum exposed and the unwind is the trade. Dog bets against that exhausted consensus on BTC, ETH, SOL and HYPE — but only when the move has genuinely overextended, the crowding is still building, and market-wide funding shows the crowd really is one-sided. Most of the time it waits.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Hyperliquid is dominated by leverage traders chasing momentum. When a major moves 3%+ in four hours and smart-money consensus piles in 15%+, the late entrants are maximally exposed and funding pressure plus mean reversion force the unwind. Dog's edge is being on the unwind side before capitulation accelerates — so it scores the smart-money direction, hard-gates on exhaustion (>=3% 4h move), freshness (15m contribution still rising), trader depth (>=30), and a funding regime that confirms the crowd is one-sided, then emits the OPPOSITE direction at conservative leverage and lets a wide ratcheting stop ride the reversal rather than banking too early.",
       "tags": [
         "smart-money",
@@ -4792,7 +5049,7 @@
       "emoji": "🐦",
       "tagline": "Fades an exhausted crowd: when 70%+ of top traders are piled onto one side of BTC/ETH/SOL/HYPE but price refuses to follow (it stalls or rolls over against the crowd), the crowded side is out of fuel — Egret takes the other side, sized flat at 15% / <=5x, and banks the bounded snapback with a tight ratchet.",
       "belief_plain": "When almost everyone good is leaning the same way on a coin but the price won't move with them, the trade is crowded and out of buyers (or sellers). Egret bets on the snap-back the other way, and because that bounce is small and quick, it locks in profit fast instead of holding for a big trend.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Smart-money concentration is usually a confirmation signal — but at an extreme, with price refusing to confirm, it flips contrarian: a maximally-crowded side with no one left to push has only one way to resolve, the unwind. The edge is the bounded snapback, so the right design is the inverse of a momentum holder: maker-only non-urgent entry, a tight ratchet that banks the bounce, and time-cuts that exit a fade that didn't resolve quickly.",
       "tags": [
         "btc",
@@ -4847,7 +5104,7 @@
       "emoji": "🐺",
       "tagline": "A short-only crypto defense sleeve on majors (BTC/ETH/SOL/HYPE) plus crypto-proxy equities (xyz:MSTR/COIN/CRCL): shorts the block ONLY when risk-off confirms — the market-wide funding regime is LONG_CROWDED (crowded longs = squeeze fuel), smart money is rotating OUT of the name, and the 4h trend is breaking down. Conservative 4x, tight short-side DSL, 30h cap because squeezes resolve fast. CAVEAT: this is a hedge that pairs with long crypto exposure — it idles and emits nothing whenever risk-off conditions are not met.",
       "belief_plain": "Most of the time the safe trade on crypto is no trade. But when the best traders are all crowded long, smart money starts rotating out, and price begins rolling over together, that crowded long is fuel for a squeeze to the downside. Hyena bets against that exhausted crowd — short only — on Bitcoin, Ether, Solana, HYPE, and the crypto-proxy stocks MicroStrategy, Coinbase and Circle. It is a defense sleeve you run alongside your long crypto bets to cushion a downturn; when the risk-off picture is not there, it does nothing and waits.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "The fleet has no dedicated short-biased crypto agent — every directional engine is long-or-long/short, so there is no clean defensive sleeve for a risk-off turn. Hyena fills that gap. It treats the market-wide funding regime as a master gate: it only opens new shorts when funding shows the crowd is one-sided LONG (LONG_CROWDED), because a crowded long is the squeeze that a short monetizes. On top of that gate it requires, per name, that smart money is net-SHORT (rotating out) AND that the 4h structure is making lower highs (price confirming the unwind). All three must agree, so it sits idle in normal markets and only acts on genuine risk-off confluence. It is short_only by design — a hedge meant to be paired with long crypto exposure, sized conservatively (15% margin, 4x) with a tight short-side DSL and a 30h hold cap because short squeezes resolve fast.",
       "tags": [
         "short-only",
@@ -4911,7 +5168,7 @@
       "emoji": "🐟",
       "tagline": "Reads the L2 order book on BTC/ETH/SOL/HYPE — when resting depth is lopsided (bids far heavier than asks, or the reverse) that's directional pressure, but it only fires when 15m momentum and smart money agree, then hands the position to a wide DSL and lets the move run (it does not scalp).",
       "belief_plain": "Looks at how much resting buy vs sell interest is stacked in the order book of the big, liquid coins. A heavily one-sided book signals pressure in that direction — but a lopsided book alone is noise, so it only acts when short-term price momentum and the best traders are pointing the same way. Then it holds the trade with a wide trailing stop instead of flipping in and out.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "Order-book imbalance is a genuine microstructure edge, but trading it as a per-tick scalp just bleeds fees. Marlin uses the imbalance differently — as the entry-timing signal on a momentum thesis: the book says which side has pressure right now, momentum and smart money confirm the move is real, and then you hold it with a wide ratchet and let it work. Restricting the universe to four liquid majors keeps the imbalance reading reliable (thin books give garbage ratios), and a 24h hard timeout caps the short-horizon thesis without choking a real run.",
       "tags": [
         "btc",
@@ -4964,7 +5221,7 @@
       "emoji": "🐦",
       "tagline": "Maintains a daily-refreshed pool of the most consistent (ELITE/RELIABLE) Hyperliquid traders, reads each one's open book, and mirrors ONLY their single highest-conviction bet — and only when that one position dominates their whole book (e.g. ~98% of capital in one 3x position). Leans hardest when several elite traders independently pile into the same concentrated trade.",
       "belief_plain": "Looks past the leaderboard noise and keeps a shortlist of the steadiest, most-proven traders on Hyperliquid. Instead of copying everything they do, Oxpecker copies only the trade they're betting their whole book on — the one position that makes up most of their capital. When more than one of those proven traders is all-in on the same trade in the same direction, it bets harder, then trails a wide stop so the conviction can run.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "A proven trader's signal is loudest exactly when they concentrate. Cohort copiers average a pool and whale mirrors ride a fixed name list; Oxpecker does neither — it screens for the highest consistency tier (ELITE/RELIABLE) and then, within that elite set, only acts on positions that represent real conviction: where one bet is the overwhelming majority of the trader's book. A reliable trader with ~98% of their capital in one short is telling you something an opaque cohort average buries. Quality-tier x position-concentration is the whole edge — consensus across multiple elite traders on the same concentrated trade is the strongest signal there is, and the wide let-winners-run DSL respects that conviction rather than scalping it.",
       "tags": [
         "copy-trading",
@@ -5011,7 +5268,7 @@
       "emoji": "🦅",
       "tagline": "Hunts ELITE/RELIABLE traders who are winning big this week, reads the single bet driving their streak, confirms the smart-money crowd agrees and the asset hasn't already run away from the whale's entry, then piggybacks the same trade — sizing leverage to conviction (7/8/10x).",
       "belief_plain": "Finds the traders who are crushing it right now AND have a proven track record, figures out which position is making them the money, checks the smart-money crowd is leaning the same way, and copies that trade — but skips it if the price already ran too far past where the whale got in.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "A trader who is both proven (ELITE/RELIABLE) and hot right now is the best signal you can ride. Don't average a cohort and don't chase one-week wonders — find the quality account on a live streak, isolate the conviction bet driving it, confirm the smart-money crowd and recent price action agree, and follow only if you can still get in near the whale's entry.",
       "tags": [
         "smart-money",
@@ -5054,7 +5311,7 @@
       "emoji": "🐟",
       "tagline": "Autonomous smart-money whale mirror — auto-builds a top-trader cohort and mirrors their highest-conviction positions; optionally mirror specific whales you name via inputs.whales. Like a remora fish riding a shark, it leans hardest when several whales pile into the same trade (consensus) or when a whale is ELITE/RELIABLE tier.",
       "belief_plain": "Out of the box, Remora finds the most proven traders on Hyperliquid, watches their open positions, and copies the strongest bets — betting bigger when several of them are in the same trade and one has an elite track record. Prefer to ride specific traders you trust? Name them and Remora mirrors exactly those instead. Either way it trails a wide stop so the trade can run.",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "thesis": "Riding the highest-conviction position of proven traders keeps your exposure tracking real smart money, and the consensus multiplier means it leans hardest exactly when those traders independently agree — one whale can be wrong, three agreeing is a much stronger signal. By default Remora is autonomous: it auto-builds a top-trader cohort (all-time realized PnL, refreshed daily) so it always has whales to mirror — no config required. Name your own whales to make it ride exactly the traders you choose. Whales hold winners, so the exit lets the mirror run and only caps staleness.",
       "tags": [
         "whale",
@@ -5100,7 +5357,7 @@
       "emoji": "🪳",
       "tagline": "A patient striker: watches the top-50 smart-money leaderboard and fires only on violent FIRST_JUMP / IMMEDIATE_MOVER rank explosions confirmed by 4h trend, 1h price, fresh 15m velocity, and a 1.5x volume spike — then sizes one bet and lets a tight ratchet ride it. Long silences are expected and correct.",
       "belief_plain": "Cockroaches survive by not moving when there's nothing to chase. Roach watches which coins the best traders are suddenly piling into — a coin violently jumping up the leaderboard — and only buys when that rank-jump is backed by the 4-hour trend, the last hour's price, fresh momentum, and a real volume spike all agreeing. Most of the time it does nothing; the patience is the edge.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Most leaderboard movement is noise. Real edge is a violent, fresh rank-jump — a coin exploding from #25+ into the top of the smart-money board in a single scan — but only when it's confirmed by trend, price, fresh velocity, and volume at the same instant. Those explosions are rare, so the right move is to ban equities, demand a high composite score with multiple confirmations, take the few that qualify at fixed 7x sizing, and let a ratcheting DSL stop bank the move. Stalker-style accumulation entries were removed — fewer, higher-quality strikes beat more, mixed ones.",
       "tags": [
         "smart-money",
@@ -5146,7 +5403,7 @@
       "emoji": "🕶️",
       "tagline": "Watches a handful of vetted Hyperliquid traders and mirrors only the positions they NEWLY open — never inheriting a stale book mid-move — with a hard entry-slippage guard so you never chase a fill that already ran, plus budget-relative sizing with a min-notional floor.",
       "belief_plain": "Instead of copying one trader's whole account — and inheriting trades already deep in profit or loss at a worse price than they got — Shadow watches two or three proven traders and only acts when one of them OPENS a brand-new position. It checks how far price has already moved from their entry and skips the trade if it is too late to get a comparable fill. It sizes each mirror to your budget with a floor so a position is never too small to matter, and it manages its own exit.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "The failure mode of naive mirroring is entry drift: you inherit a book at a 1-5% worse price than the trader got, so the same trade is a loss for you. Shadow fires ONLY on fresh opens (a snapshot-diff against a seeded book, so nothing pre-existing is ever inherited), rejects any entry whose price has already run past a slippage cap, and can require multi-trader confirmation before committing size. You follow proven money at their price, not yesterday's book at yours. Leverage is capped, so a trader's 40x book becomes something survivable.",
       "tags": [
         "copy-trading",
@@ -5190,7 +5447,7 @@
       "emoji": "🐠",
       "tagline": "Reads the entire smart-money board every tick, ranks every asset by net smart-money conviction (tilt x notional x breadth), then rides the rotation — LONG the assets the best traders are crowding into and SHORT the ones they're fleeing, gated by price so it never fights a hard trend. Captures days like 'long semis/indices, short the crypto block'.",
       "belief_plain": "Most copy-trading bots ask 'are the best traders long this one coin?'. Stingray instead looks at the whole market at once and asks 'what are the best traders rotating INTO, and what are they rotating OUT OF?'. It buys the crowd's new favorites and sells the ones they're abandoning — but only when the price chart isn't already screaming the other way — then trails a wide stop so a real rotation can run for days.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Smart money doesn't just pick coins, it rotates capital across the whole board — out of one asset class and into another. Per-asset copy-traders miss this because they evaluate each market in isolation; they can't see that the SAME flow leaving crypto is funding the bid in indices. Stingray ranks the entire board by net tilt (long_ratio - 50) weighted by notional and trader breadth, so a strong, deep, widely-held lean outranks a thin spike, then takes BOTH sides at once — long the inflows, short the outflows — for a market-neutral-ish rotation book. A price-confirmation gate (no longs into a hard 4h downtrend, no shorts into a hard uptrend) keeps it from fighting price, and a DSL ratchet lets the winning legs run while cutting the losers.",
       "tags": [
         "smart-money",
@@ -5239,7 +5496,7 @@
       "emoji": "🐋",
       "tagline": "Buckets Hyperliquid traders by lifetime realized PnL into a smart-money cohort and a crowd, then positions WITH the smartest money — and against the crowd — wherever the smart cohort is heavily net-directional and adding to it daily.",
       "belief_plain": "Looks at where the most profitable traders on Hyperliquid are putting their money as a group, and copies that lean — going long what they're loading up on and short what they're dumping, especially when the average crowd is on the other side.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "You trust the aggregate of proven winners over any single guru or your own read. When the >$1M-realized crowd is piling into a coin day after day while the small accounts fade it, that divergence is the edge — so follow the smart cohort, not one whale, and hedge the book with a separate short sleeve.",
       "tags": [
         "smart-money",
@@ -5284,7 +5541,7 @@
       "emoji": "🦅",
       "tagline": "When BTC moves hard, crypto-correlated equities on Hyperliquid XYZ (Coinbase, MicroStrategy) follow late: Osprey self-computes each proxy's catch-up gap (leader move x its beta minus the move it has actually made), and when a proxy still owes a gap in the leader's direction it enters the proxy that way and lets a wide DSL ride the catch-up.",
       "belief_plain": "When Bitcoin makes a big move, the crypto-flavored stocks on the XYZ exchange (Coinbase, MicroStrategy) usually move the same way — but a beat late, because they are priced on a different venue. Osprey works out how far behind each one is and bets it catches up, then trails a wide stop so the catch-up can run for a day or two.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "A crypto-correlated equity has a known beta to BTC (COIN ~1.8x, MSTR ~2.5x), so a BTC move implies an expected proxy move. But XYZ pricing trails spot crypto around its reference windows, so the proxy's actual move lags — a measurable, tradeable gap. Trading the lag (not the leader) means entering in the leader's confirmed direction only when the proxy still owes catch-up, which sidesteps the chase-the-leader failure mode and lets the structural pricing lag, not a directional guess, be the edge.",
       "tags": [
         "xyz",
@@ -5333,7 +5590,7 @@
       "emoji": "🦝",
       "tagline": "Trades only the weekend, only on tokenized stocks & commodities (XYZ): while the underlying markets are closed and XYZ runs on an internal oracle, Raccoon positions in the direction sentiment has been pushing the price — and captures the snap-back when real external pricing resumes Monday open. Sizes 15% / 3x and rides a tight DSL with a 48h Monday-exit cap.",
       "belief_plain": "From Friday evening to Sunday evening the real stock and commodity markets are closed, so tokenized versions on XYZ drift on an internal estimate instead of a live price. When trading resumes Monday, that estimate snaps to the true market price. Raccoon bets in the direction the weekend drift (plus the best traders) is leaning, and exits into that Monday snap — and only ever runs on the weekend.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "thesis": "Fri 17:00 ET -> Sun 18:00 ET, trade.xyz has no external price feed for equities/commodities and runs a 30-min EWMA internal oracle that drifts on impact-price activity. Accumulated weekend sentiment (>= 2% move + volume + smart-money agreement) shows up as directional oracle drift; when external pricing resumes Sunday evening the implied price reconciles to the real value. Positioning into that gap and exiting at the Monday-open snap is the edge — and confining all activity to the weekend window avoids weekday false signals and Lemur's 24/7 IPOP territory.",
       "tags": [
         "xyz",


### PR DESCRIPTION
#553 shipped the five templates and corrected `senpi-strategy-author/references/dsl-presets.yaml`, but did neither of the things that make those changes actually **reach an agent**:

1. **`catalog.json` was never regenerated** — discovery could not surface the new templates at all.
2. **Neither skill's version was bumped.** `senpi-*` skills auto-upgrade on a MINOR, so without it every deployed agent keeps the **old presets** — the ones that still carry the ratchet-into-a-loss. Fixing the source file only helps if the source ships.

## Changes

- Regenerated `catalog.json` to **both locations** via `gen_catalog.py --branch main` (107 strategies; the 2 warnings on caribou/hydra are pre-existing).
- **`senpi-strategy-discover` 2.17.0 → 2.18.0** — glossary + catalog now carry the five.
- **`senpi-strategy-author` 3.0.3 → 3.1.0** — the corrected DSL preset library.

## Verified an agent can actually find them

```
discover.py --theme "scalping fast intraday"
  swift  theme_score 12  hits: fast, intraday, scalping   <- #1
  oryx   theme_score  6  hits: intraday                   <- #2
```

`time_horizon: scalp` is derived correctly for both from their 60s cadence.

## Correction to the #553 analysis

Fast-horizon supply was **5** (barracuda, jackal, scorpion at `scalp`; jaguar, kestrel at `intraday`), **not 2**. `time_horizon` is **derived** by `gen_catalog` from `tick_seconds`, so reading it out of `strategy.yaml` — where it is usually unauthored — undercounted. The demand gap was **~10:1, not 24:1**. Still the largest in the catalog, and swift/oryx still rank #1–2 on the query, but the number I gave was wrong.

## CI

Vendor parity OK · golden OK (107 templates) · **493 passed / 1 skipped**.