### PR TITLE
ops: an empty runtime inventory is an answer, not a failed read

### DIFF
--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -22,7 +22,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "3.7.0"
+  version: "3.6.24"
   platform: senpi
   exchange: hyperliquid
   requires:

--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -22,7 +22,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "3.6.23"
+  version: "3.7.0"
   platform: senpi
   exchange: hyperliquid
   requires:

--- a/senpi-strategy-ops/scripts/_cli.py
+++ b/senpi-strategy-ops/scripts/_cli.py
@@ -207,13 +207,19 @@ def _parse_runtime_list(out):
         if not line:
             continue
         low = line.lower()
+        # The empty-inventory line is tested BEFORE the header gate. A box with no runtimes prints
+        # "No runtimes installed." and NO header row, so looking for it only after a header is seen
+        # means it is never seen at all: the `continue` below skips it. The (rows=[], valid=False)
+        # that falls out is read as "inventory unreadable" by `list_runtimes_or_none`, inverting the
+        # very contract this parser exists to hold — and it does so precisely on the boxes whose
+        # honest answer is "nothing is running", which is the broken-deploy case `verify` is for.
+        if "no runtimes" in low:
+            empty_marker = True
+            break
         if not seen_header:
             if low.startswith("id") and "status" in low and "wallet" in low:
                 seen_header = True
             continue
-        if "no runtimes" in low:
-            empty_marker = True
-            break
         parts = [p for p in re.split(r"\s{2,}|\t+", line) if p]
         if len(parts) >= 2:
             rows.append({"name": parts[0], "wallet": parts[1],

--- a/senpi-strategy-ops/scripts/_cli.py
+++ b/senpi-strategy-ops/scripts/_cli.py
@@ -213,7 +213,16 @@ def _parse_runtime_list(out):
         # that falls out is read as "inventory unreadable" by `list_runtimes_or_none`, inverting the
         # very contract this parser exists to hold — and it does so precisely on the boxes whose
         # honest answer is "nothing is running", which is the broken-deploy case `verify` is for.
-        if "no runtimes" in low:
+        #
+        # ANCHORED, because this now runs before the header gate and so sees every stdout line: an
+        # unanchored substring would let any future line merely CONTAINING the phrase short-circuit
+        # to a confident "empty", which is the fail-OPEN direction this parser exists to prevent.
+        # The only stdout emission today is `console.log("No runtimes installed.")`
+        # (senpi-trading-runtime `src/cli/senpi-commands.ts`); the near-miss
+        # "…No runtimes were read." is an UNREADABLE state, but it goes to stderr with rc!=0, which
+        # `list_runtimes_or_none` rejects before parsing. Anchoring keeps it excluded a third time,
+        # and errs toward None (fail-closed) if the wording ever drifts.
+        if low.startswith("no runtimes"):
             empty_marker = True
             break
         if not seen_header:

--- a/senpi-strategy-ops/tests/test_cli_reads.py
+++ b/senpi-strategy-ops/tests/test_cli_reads.py
@@ -412,6 +412,14 @@ class ParseRuntimeListEmptyVsUnreadable(unittest.TestCase):
         with mock.patch.object(_cli, "run_cli", return_value=(0, "garbled\n", "")):
             self.assertIsNone(_cli.list_runtimes_or_none())
 
+    def test_the_marker_is_anchored_not_a_loose_substring(self):
+        # The marker test runs before the header gate, so it sees every line. A line that merely
+        # MENTIONS the phrase must not be promoted to a confident empty inventory — that is the
+        # fail-open direction. No header, no rows, no anchored marker => unreadable.
+        rows, valid = _cli._parse_runtime_list("warning: there are no runtimes to report here\n")
+        self.assertEqual(rows, [])
+        self.assertFalse(valid)
+
     def test_a_failed_read_is_still_unreadable(self):
         with mock.patch.object(_cli, "run_cli", return_value=(1, self.EMPTY, "boom")):
             self.assertIsNone(_cli.list_runtimes_or_none())

--- a/senpi-strategy-ops/tests/test_cli_reads.py
+++ b/senpi-strategy-ops/tests/test_cli_reads.py
@@ -8,6 +8,9 @@ Two contracts live here, both of them about not answering a question the surface
     fail-closed pair (`find_list_or_none` / `list_strategies_or_none`) keeps the two apart.
   * **a requested amount is never a funded one.** `strategy_funded` reports the backend's own
     figure or nothing at all.
+  * **…and empty != unreadable, the same contract inverted.** `_parse_runtime_list` must call a box
+    with no runtimes EMPTY, not unreadable — otherwise `verify` cannot answer on exactly the boxes
+    where the answer is "nothing is running".
 
 Run:  python3 senpi-strategy-ops/tests/test_cli_reads.py
 """
@@ -15,6 +18,7 @@ Run:  python3 senpi-strategy-ops/tests/test_cli_reads.py
 import json
 import sys
 import unittest
+from unittest import mock
 from pathlib import Path
 
 SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
@@ -366,6 +370,51 @@ class RunCliSpawnFailures(unittest.TestCase):
         self.assertEqual((rc, out), (-1, ""))
         self.assertFalse(err.startswith(_cli.SPAWN_FAILED_PREFIX))
         self.assertIn("timed out", err)
+
+
+class ParseRuntimeListEmptyVsUnreadable(unittest.TestCase):
+    """`_parse_runtime_list` -> (rows, valid). `valid` is what `list_runtimes_or_none` turns into the
+    []-vs-None distinction, so it decides whether a caller is told "no runtimes" or "I could not read
+    the inventory". A box with NO runtimes prints "No runtimes installed." and no header row, and that
+    has to come back valid: `deploy.py verify` raises ReadFailed ("COULD NOT CHECK") on None, which
+    made it structurally unable to answer for a strategy whose runtime was never installed."""
+
+    EMPTY = ("[senpi-core][redact-pii] [info] PII redaction ready\n"
+             "No runtimes installed.\n")
+
+    POPULATED = ("[senpi-core][redact-pii] [info] PII redaction ready\n"
+                 "id\t\twallet\t\tsource\t\tstatus\n"
+                 "badger-main\t\t0x74b4...5a41\t\t(inline)\t\trunning\n"
+                 "otter-main\t\t0x56fc...0ea2\t\t(inline)\t\trunning\n")
+
+    def test_an_empty_inventory_is_readable_and_empty(self):
+        rows, valid = _cli._parse_runtime_list(self.EMPTY)
+        self.assertEqual(rows, [])
+        self.assertTrue(valid, "a box with no runtimes is an ANSWER, not a failed read")
+
+    def test_an_empty_inventory_reaches_the_or_none_caller_as_a_list(self):
+        # The regression that mattered: None here is "unreadable", and `verify` refuses to answer.
+        with mock.patch.object(_cli, "run_cli", return_value=(0, self.EMPTY, "")):
+            self.assertEqual(_cli.list_runtimes_or_none(), [])
+
+    def test_a_populated_inventory_still_parses_every_row(self):
+        rows, valid = _cli._parse_runtime_list(self.POPULATED)
+        self.assertTrue(valid)
+        self.assertEqual([r["name"] for r in rows], ["badger-main", "otter-main"])
+        self.assertEqual(rows[0]["status"], "running")
+
+    def test_a_banner_only_read_is_still_unreadable(self):
+        # The guard the parser was built for must survive: no header, no rows, no empty-marker line
+        # is a garbled read, and it must stay None rather than becoming a confident "no runtimes".
+        rows, valid = _cli._parse_runtime_list("some unrelated banner\nand another line\n")
+        self.assertEqual(rows, [])
+        self.assertFalse(valid)
+        with mock.patch.object(_cli, "run_cli", return_value=(0, "garbled\n", "")):
+            self.assertIsNone(_cli.list_runtimes_or_none())
+
+    def test_a_failed_read_is_still_unreadable(self):
+        with mock.patch.object(_cli, "run_cli", return_value=(1, self.EMPTY, "boom")):
+            self.assertIsNone(_cli.list_runtimes_or_none())
 
 
 if __name__ == "__main__":

--- a/senpi-strategy-ops/tests/test_close.py
+++ b/senpi-strategy-ops/tests/test_close.py
@@ -99,6 +99,66 @@ class CloseRuntimeDeleteConfirm(unittest.TestCase):
         self.assertIn("(already closed)", rec["plan"])
 
 
+class CloseLastRuntimeOnTheBox(unittest.TestCase):
+    """The teardown money path, driven through the REAL `runtime list` parser rather than a stubbed
+    `list_runtimes_or_none`, because that parser is what decides empty-vs-unreadable here.
+
+    Deleting the LAST runtime on a box leaves an inventory that prints "No runtimes installed." and
+    NO header row. While `_parse_runtime_list` only looked for that line after seeing a header it
+    returned (rows=[], valid=False) -> None -> `_runtime_gone` False (fail-closed, correctly), so
+    `close_one` retried the delete and then reported `status: "failed"` — "still in (or unreadable
+    from) `runtime list` after delete" — on a teardown that had actually succeeded. The strategy_close
+    was still fired for the operator to retry, but the record lied about the outcome."""
+
+    def setUp(self):
+        self._orig = (_cli.run_cli, close.MCPClient)
+        self.deletes, self.closed = [], []
+        outer = self
+
+        def fake_run_cli(args, timeout=60):
+            if "list" in args:
+                # what the CLI really prints on a box with nothing installed: banner, no header row
+                return (0, "[senpi-core][redact-pii] [info] PII redaction ready\n"
+                           "No runtimes installed.\n", "")
+            outer.deletes.append(args)
+            return (1, "", "[⚡HyperDX] banner…")     # delete rc is unreliable, as the class above pins
+        _cli.run_cli = fake_run_cli
+
+        class _FakeMCP:
+            def mcp_call(self, name, timeout=None, **kw):
+                if name == "strategy_close":
+                    outer.closed.append(kw.get("strategyId"))
+                return {"success": True}
+        close.MCPClient = _FakeMCP
+
+    def tearDown(self):
+        _cli.run_cli, close.MCPClient = self._orig
+
+    _STRAT = {"strategyId": "s1", "strategyWalletAddress": "0xabc", "status": "ACTIVE"}
+    _RUNTIMES = [{"name": "pkg-main", "wallet": "0xabc"}]
+
+    def test_the_empty_inventory_left_behind_reads_as_gone(self):
+        self.assertEqual(_cli.list_runtimes_or_none(), [])
+        self.assertTrue(close._runtime_gone("pkg-main"))
+
+    def test_tearing_down_the_last_runtime_reports_success_not_failure(self):
+        rec = close.close_one("main", self._STRAT, self._RUNTIMES, False, lambda m: None)
+        self.assertEqual(rec["status"], "closing")     # was "failed" on a delete that worked
+        self.assertEqual(rec["runtime"], "stopped")
+        self.assertEqual(self.closed, ["s1"])
+        self.assertEqual(len(self.deletes), 1)         # gone on the first read => no redundant retry
+
+    def test_an_unreadable_inventory_on_the_same_path_still_fails_closed(self):
+        # The guard must survive: a garbled read is NOT an empty box.
+        _cli.run_cli = lambda args, timeout=60: (
+            (0, "garbled banner only\n", "") if "list" in args
+            else (self.deletes.append(args) or (1, "", "")))
+        rec = close.close_one("main", self._STRAT, self._RUNTIMES, False, lambda m: None)
+        self.assertEqual(rec["status"], "failed")
+        self.assertEqual(self.closed, [])
+        self.assertEqual(len(self.deletes), 2)
+
+
 class SelectDirectTarget(unittest.TestCase):
     """`--strategy-id`/`--address` address ONE specific strategy directly — unlike `--all`/`<package>`,
     which answer a SET question ("what's open for X"), where an empty result is a legitimate true


### PR DESCRIPTION
## The bug

`_parse_runtime_list` tested for the `"No runtimes installed."` line **only after** it had seen the table header. A box with no runtimes prints that line and **no header at all**, so the `continue` in the not-yet-seen-header branch skipped straight past it. Neither `empty_marker` nor `seen_header` was ever set, and the parser returned `(rows=[], valid=False)`.

`list_runtimes_or_none` turns `valid=False` into `None`, whose documented meaning is *"the inventory is unreadable"*. Its own docstring is explicit about why that distinction matters:

> `or_none` is the whole point: `[]` means "no runtimes", `None` means "the inventory is unreadable", and a check that reads the second as the first reports every strategy on the box as runtime-less.

The bug is that same confusion, inverted. On a box with zero runtimes the read came back as a **failure** rather than as an empty list.

## Blast radius: two call sites, both wrong on an empty box

**1. `deploy.py verify` could not answer at all.** The check whose entire job is *"is this strategy live?"* raised `ReadFailed`:

```
? stingray: COULD NOT CHECK — a read this check needs failed, so NOTHING about
  stingray is verified here (this says nothing about whether it is live):
    - `openclaw senpi runtime list` could not be read — the runtime inventory
      is not visible from here
```

while `openclaw senpi runtime list`, run directly on the same box seconds later, answered fine with `No runtimes installed.` So `verify` was structurally unable to answer **precisely on the boxes whose honest answer is "nothing is running"** — which is the broken-deploy case it exists for.

Found on a live box (M416163) where a funded `ACTIVE` strategy had no runtime installed. `verify` could not say so, and the deploy was reported to the user as successful.

**2. `close.py`'s teardown money path reported failure on a successful delete.** `_runtime_gone` reads the same helper. Measured with `run_cli` stubbed to the real empty-box output:

| | `list_runtimes_or_none()` | `_runtime_gone("pkg-main")` |
|---|---|---|
| `origin/main` | `None` | `False` |
| this branch | `[]` | `True` |

So deleting the **last** runtime on a box left an inventory that read back as unreadable: `close_one` retried the delete, then recorded `status: "failed"` — *"still in (or unreadable from) `runtime list` after delete"* — on a teardown that had actually succeeded. The new `True` does not weaken the fail-closed rule, because the inventory genuinely **was** read and `[]` genuinely means the runtime is absent.

## The fix

Hoist the empty-inventory test above the header gate, **anchored** with `low.startswith("no runtimes")`.

Anchoring matters because running before the header gate means the test now sees every stdout line, and an unanchored substring would let any future line merely *containing* the phrase short-circuit to a confident "empty" — the fail-**open** direction this parser exists to prevent. The only stdout emission today is `console.log("No runtimes installed.")`; the near-miss `"…No runtimes were read."` is an unreadable state on stderr with `rc != 0`, which `list_runtimes_or_none` already rejects before parsing. Anchoring excludes it a third time and errs toward `None` if the wording ever drifts.

The guard the parser was built for is untouched: a banner-only or garbled read still has no header, no rows and no marker, so it stays `valid=False` → `None`.

## Tests

**`test_cli_reads.py`** — new `ParseRuntimeListEmptyVsUnreadable`, alongside the sibling *"unreadable != empty"* contract that already lives there (module docstring extended to name this direction too). Empty inventory parses and reaches the `_or_none` caller as `[]`; a populated table still parses every row; banner-only, `rc != 0`, and a line that merely mentions the phrase all stay `None`.

**`test_close.py`** — new `CloseLastRuntimeOnTheBox`, driven through the **real** parser via `run_cli` rather than a stubbed `list_runtimes_or_none`, because the existing `CloseRuntimeDeleteConfirm` stubs that helper and so cannot see this. Covers: the empty inventory reads as gone, the teardown reports `closing` with exactly one delete (no redundant retry), and a garbled read on the same path still fails closed.

**Verified both directions.** 4 tests across the two files fail on `origin/main`'s `_cli.py` and pass with the fix. The two fail-closed guards pass on both, which is the point of them.

```
python3 -m pytest senpi-strategy-ops/tests -q
362 passed, 1 skipped, 45 subtests passed
```

Also green: `test_min_budget_vendor_parity.py` (VENDOR PARITY OK) and `test_min_budget_golden.py` (GOLDEN OK — 107 templates).

One unrelated pre-existing failure across the wider CI selection, `senpi-portfolio/tests/test_portfolio.py::test_all_step_is_byte_identical_to_run`, confirmed failing identically on clean `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)