### PR TITLE
dsl: weak_peak_cut is a CHOP tool — off on all 73 longer-hold instances

### DIFF
--- a/strategies/albatross/main/runtime.yaml
+++ b/strategies/albatross/main/runtime.yaml
@@ -108,7 +108,11 @@ exit:
       enabled: true
       interval_in_minutes: 5760             # v2: 96h (4d) cap
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 90               # v2 weak_peak_cut
       min_value: 3.0
     dead_weight_cut:

--- a/strategies/ant/main/runtime.yaml
+++ b/strategies/ant/main/runtime.yaml
@@ -106,7 +106,11 @@ exit:
       enabled: true
       interval_in_minutes: 1440        # 24h — the daily rotation / funding-decay drop-off
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 720         # 12h — cut a stalled short that isn't paying its way
       min_value: 2.0
     phase1:

--- a/strategies/armadillo/main/runtime.yaml
+++ b/strategies/armadillo/main/runtime.yaml
@@ -102,7 +102,11 @@ exit:
     execution_timeout_seconds: 60
   dsl_preset:
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 1440            # 24h — a stalled name frees its slot
       min_value: 2.0
     phase1:

--- a/strategies/bald-eagle/main/runtime.yaml
+++ b/strategies/bald-eagle/main/runtime.yaml
@@ -96,7 +96,11 @@ exit:
       enabled: true
       interval_in_minutes: 480
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 240
       min_value: 3.0
     dead_weight_cut:

--- a/strategies/barnacle/main/runtime.yaml
+++ b/strategies/barnacle/main/runtime.yaml
@@ -130,7 +130,11 @@ exit:
       enabled: true                        # 48h cap — equity/index perps have a weekend pricing gap
       interval_in_minutes: 2880
     weak_peak_cut:
-      enabled: true                        # self-limiting: cut if the accumulation pop never appears
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 90
       min_value: 3.0
     dead_weight_cut:

--- a/strategies/bison/main/runtime.yaml
+++ b/strategies/bison/main/runtime.yaml
@@ -106,7 +106,11 @@ exit:
       enabled: false                       # v2.1: DISABLED — conviction holds run until DSL retrace
       interval_in_minutes: 120
     weak_peak_cut:
-      enabled: true                        # v2.1: KEPT — self-limiting
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 60
       min_value: 3.0
     dead_weight_cut:

--- a/strategies/bloodhound/main/runtime.yaml
+++ b/strategies/bloodhound/main/runtime.yaml
@@ -113,7 +113,11 @@ exit:
       enabled: false
       interval_in_minutes: 480
     weak_peak_cut:
-      enabled: true                        # the break failed to follow through -> release it
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 90
       min_value: 2.0
     dead_weight_cut:

--- a/strategies/boar/long/runtime.yaml
+++ b/strategies/boar/long/runtime.yaml
@@ -98,7 +98,11 @@ exit:
       enabled: true
       interval_in_minutes: 10080          # 7d — the debasement trend persists; let winners run
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 480            # 8h — cut a winner that peaked then stalled
       min_value: 2.0
     dead_weight_cut:

--- a/strategies/boar/short/runtime.yaml
+++ b/strategies/boar/short/runtime.yaml
@@ -95,7 +95,11 @@ exit:
       enabled: true
       interval_in_minutes: 7200           # 5d — shorter than the long book
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 360            # 6h — cut a short that bottomed then stalled
       min_value: 2.0
     dead_weight_cut:

--- a/strategies/camel/harvest/runtime.yaml
+++ b/strategies/camel/harvest/runtime.yaml
@@ -91,7 +91,11 @@ exit:
       enabled: true
       interval_in_minutes: 4320           # 3d — funding regimes decay
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 240            # 4h
       min_value: 1.5
     dead_weight_cut:

--- a/strategies/camel/payout/runtime.yaml
+++ b/strategies/camel/payout/runtime.yaml
@@ -91,7 +91,11 @@ exit:
       enabled: true
       interval_in_minutes: 4320           # 3d — funding regimes decay
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 240            # 4h
       min_value: 1.5
     dead_weight_cut:

--- a/strategies/caracal/breakout/runtime.yaml
+++ b/strategies/caracal/breakout/runtime.yaml
@@ -95,7 +95,11 @@ exit:
       enabled: true
       interval_in_minutes: 2880            # 2d — vol events resolve fast
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 180             # 3h — a stalled breakout has failed
       min_value: 2.0
     dead_weight_cut:

--- a/strategies/caracal/catalyst/runtime.yaml
+++ b/strategies/caracal/catalyst/runtime.yaml
@@ -95,7 +95,11 @@ exit:
       enabled: true
       interval_in_minutes: 2880            # 2d
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 180             # 3h
       min_value: 2.0
     dead_weight_cut:

--- a/strategies/caribou/long/runtime.yaml
+++ b/strategies/caribou/long/runtime.yaml
@@ -110,7 +110,11 @@ exit:
       enabled: false
       interval_in_minutes: 20160
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 720             # self-limiting only — cut a position that's gone nowhere for a long time
       min_value: 2.0
     dead_weight_cut:

--- a/strategies/caribou/short/runtime.yaml
+++ b/strategies/caribou/short/runtime.yaml
@@ -110,7 +110,11 @@ exit:
       enabled: false
       interval_in_minutes: 20160
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 720             # self-limiting only — cut a position that's gone nowhere for a long time
       min_value: 2.0
     dead_weight_cut:

--- a/strategies/chameleon/main/runtime.yaml
+++ b/strategies/chameleon/main/runtime.yaml
@@ -112,7 +112,11 @@ exit:
       enabled: true                        # v2: ON — reversion resolves or the thesis failed
       interval_in_minutes: 2880            # 48h
     weak_peak_cut:
-      enabled: true                        # v2: ON
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 120
       min_value: 2.0
     dead_weight_cut:

--- a/strategies/chimp/main/runtime.yaml
+++ b/strategies/chimp/main/runtime.yaml
@@ -116,7 +116,11 @@ exit:
     execution_timeout_seconds: 60
   dsl_preset:
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 2880        # 48h — a stalled position frees its slot within ~2 days
       min_value: 2.5
     phase1:

--- a/strategies/cougar/long/runtime.yaml
+++ b/strategies/cougar/long/runtime.yaml
@@ -86,7 +86,11 @@ exit:
       enabled: true
       interval_in_minutes: 10080          # 7d — equities trend longer than crypto
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 480            # 8h — cut a leader that peaked then stalled
       min_value: 2.0
     dead_weight_cut:

--- a/strategies/cougar/short/runtime.yaml
+++ b/strategies/cougar/short/runtime.yaml
@@ -86,7 +86,11 @@ exit:
       enabled: true
       interval_in_minutes: 10080          # 7d — equities trend longer than crypto
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 480            # 8h — cut a laggard short that peaked then stalled
       min_value: 2.0
     dead_weight_cut:

--- a/strategies/coyote/main/runtime.yaml
+++ b/strategies/coyote/main/runtime.yaml
@@ -99,7 +99,11 @@ exit:
       enabled: true
       interval_in_minutes: 7200            # 5d
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 480             # 8h
       min_value: 3.0
     dead_weight_cut:

--- a/strategies/cub/long/runtime.yaml
+++ b/strategies/cub/long/runtime.yaml
@@ -98,7 +98,11 @@ exit:
       enabled: true
       interval_in_minutes: 10080          # 7d — the AI trend persists; let winners run
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 480            # 8h — cut a winner that peaked then stalled
       min_value: 2.0
     dead_weight_cut:

--- a/strategies/cub/preipo/runtime.yaml
+++ b/strategies/cub/preipo/runtime.yaml
@@ -108,7 +108,11 @@ exit:
       enabled: true
       interval_in_minutes: 7200           # 5d — ride the ramp, but pre-IPO theses are time-boxed to the listing
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 480            # 8h — cut a ramp that peaked then stalled
       min_value: 2.0
     dead_weight_cut:

--- a/strategies/cub/short/runtime.yaml
+++ b/strategies/cub/short/runtime.yaml
@@ -95,7 +95,11 @@ exit:
       enabled: true
       interval_in_minutes: 7200           # 5d — shorter than the long book
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 360            # 6h — cut a short that bottomed then stalled
       min_value: 2.0
     dead_weight_cut:

--- a/strategies/dragonfly/btc/runtime.yaml
+++ b/strategies/dragonfly/btc/runtime.yaml
@@ -112,7 +112,11 @@ exit:
     execution_timeout_seconds: 60
   dsl_preset:
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 480          # spec weak_peak_cut_minutes
       min_value: 3.0
     phase1:

--- a/strategies/dragonfly/hype/runtime.yaml
+++ b/strategies/dragonfly/hype/runtime.yaml
@@ -114,7 +114,11 @@ exit:
     execution_timeout_seconds: 60
   dsl_preset:
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 240          # spec weak_peak_cut_minutes
       min_value: 3.0
     phase1:

--- a/strategies/eel/long/runtime.yaml
+++ b/strategies/eel/long/runtime.yaml
@@ -98,7 +98,11 @@ exit:
       enabled: true
       interval_in_minutes: 10080          # 7d — energy/power trends persist; let winners run
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 480            # 8h — cut a name that peaked then stalled
       min_value: 2.0
     dead_weight_cut:

--- a/strategies/eel/short/runtime.yaml
+++ b/strategies/eel/short/runtime.yaml
@@ -93,7 +93,11 @@ exit:
       enabled: true
       interval_in_minutes: 7200           # 5d — shorter than the power book
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 360            # 6h — cut a short that bottomed then stalled
       min_value: 2.0
     dead_weight_cut:

--- a/strategies/egret/main/runtime.yaml
+++ b/strategies/egret/main/runtime.yaml
@@ -101,7 +101,11 @@ exit:
       enabled: true                        # v2: ENABLED — a fade resolves quickly or the thesis failed
       interval_in_minutes: 2880            # v2 48h outer bound
     weak_peak_cut:
-      enabled: true                        # v2: ENABLED — cut a stale fade
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 120             # v2 weak_peak_cut interval 120min
       min_value: 2.0                       # v2 weak_peak_cut min_value 2.0
     dead_weight_cut:

--- a/strategies/elephant/fade/runtime.yaml
+++ b/strategies/elephant/fade/runtime.yaml
@@ -89,7 +89,11 @@ exit:
       enabled: true
       interval_in_minutes: 2880             # 2d
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 240              # 4h
       min_value: 1.5
     dead_weight_cut:

--- a/strategies/gecko/main/runtime.yaml
+++ b/strategies/gecko/main/runtime.yaml
@@ -94,7 +94,11 @@ exit:
     execution_timeout_seconds: 60
   dsl_preset:
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 1440              # 24h — a stalled name frees the single slot
       min_value: 2.5
     phase1:

--- a/strategies/gibbon/main/runtime.yaml
+++ b/strategies/gibbon/main/runtime.yaml
@@ -112,7 +112,11 @@ exit:
     execution_timeout_seconds: 60
   dsl_preset:
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 2160        # 36h — a stalled rotation frees its slot inside ~1.5 days
       min_value: 2.5
     phase1:

--- a/strategies/gorilla/main/runtime.yaml
+++ b/strategies/gorilla/main/runtime.yaml
@@ -109,7 +109,11 @@ exit:
     execution_timeout_seconds: 60
   dsl_preset:
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 10080       # 7d — matches the weekly recalibration
       min_value: 2.5
     phase1:

--- a/strategies/hawk/main/runtime.yaml
+++ b/strategies/hawk/main/runtime.yaml
@@ -104,7 +104,11 @@ exit:
       enabled: true                         # v2: 24h cap — failed breakouts get cut
       interval_in_minutes: 1440
     weak_peak_cut:
-      enabled: true                         # v2: 60min/3% — stale breakouts cut (self-limiting)
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 60
       min_value: 3.0
     dead_weight_cut:

--- a/strategies/hen/main/runtime.yaml
+++ b/strategies/hen/main/runtime.yaml
@@ -108,7 +108,11 @@ exit:
       enabled: true                         # session thesis expires + never camp into the weekend gap
       interval_in_minutes: 480              # 8h: covers the open plus the ~6.5h cash session that follows
     weak_peak_cut:
-      enabled: true                         # the open came and went and nothing happened -> release it
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 90
       min_value: 1.5
     dead_weight_cut:

--- a/strategies/hydra/dip/runtime.yaml
+++ b/strategies/hydra/dip/runtime.yaml
@@ -85,7 +85,11 @@ exit:
       enabled: false
       interval_in_minutes: 10080
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 360
       min_value: 2.0
     dead_weight_cut:

--- a/strategies/hydra/hedge/runtime.yaml
+++ b/strategies/hydra/hedge/runtime.yaml
@@ -110,7 +110,11 @@ exit:
       enabled: false
       interval_in_minutes: 7200
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 360
       min_value: 2.0
     dead_weight_cut:

--- a/strategies/hyena/main/runtime.yaml
+++ b/strategies/hyena/main/runtime.yaml
@@ -108,7 +108,11 @@ exit:
       enabled: true                         # 30h cap — squeezes resolve fast; don't camp a stale short
       interval_in_minutes: 1800
     weak_peak_cut:
-      enabled: true                         # cut if peak ROE < 2.0 in 90m — failed short thesis
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 90
       min_value: 2.0
     dead_weight_cut:

--- a/strategies/ibis/main/runtime.yaml
+++ b/strategies/ibis/main/runtime.yaml
@@ -120,7 +120,11 @@ exit:
       enabled: false
       interval_in_minutes: 480
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 120             # 2h on a 4h timeframe — release a setup that never worked
       min_value: 2.0
     dead_weight_cut:

--- a/strategies/iguana/main/runtime.yaml
+++ b/strategies/iguana/main/runtime.yaml
@@ -98,7 +98,11 @@ exit:
       enabled: true
       interval_in_minutes: 2880           # 48h — XYZ weekend pricing-gap risk
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 480            # 8h
       min_value: 3.0
     dead_weight_cut:

--- a/strategies/kingfisher/main/runtime.yaml
+++ b/strategies/kingfisher/main/runtime.yaml
@@ -103,7 +103,11 @@ exit:
       enabled: false
       interval_in_minutes: 240
     weak_peak_cut:
-      enabled: true                        # self-limiting: fires only if peak ROE never clears 2.0 in 60m
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 60
       min_value: 2.0
     dead_weight_cut:

--- a/strategies/kite/main/runtime.yaml
+++ b/strategies/kite/main/runtime.yaml
@@ -88,7 +88,11 @@ exit:
     execution_timeout_seconds: 60
   dsl_preset:
     hard_timeout: { enabled: true, interval_in_minutes: 7200 }               # 5d backstop
-    weak_peak_cut: { enabled: true, interval_in_minutes: 2880, min_value: 2.0 }  # retire a dead setup ~2d
+    # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+    # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+    # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+    # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+    weak_peak_cut: { enabled: false, interval_in_minutes: 2880, min_value: 2.0 }  # retire a dead setup ~2d
     phase1:
       # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
       # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.

--- a/strategies/lemon/main/runtime.yaml
+++ b/strategies/lemon/main/runtime.yaml
@@ -106,7 +106,11 @@ exit:
       enabled: true
       interval_in_minutes: 480               # 8h — mean reversion can take hours (v2)
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 60
       min_value: 2.0                         # cut if peak ROE never breaks 2% in 60m (v2)
     dead_weight_cut:

--- a/strategies/lion/long/runtime.yaml
+++ b/strategies/lion/long/runtime.yaml
@@ -108,7 +108,11 @@ exit:
       enabled: true
       interval_in_minutes: 10080          # 7d — the AI trend persists; let winners run
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 480            # 8h — cut a winner that peaked then stalled
       min_value: 2.0
     dead_weight_cut:

--- a/strategies/lion/short/runtime.yaml
+++ b/strategies/lion/short/runtime.yaml
@@ -104,7 +104,11 @@ exit:
       enabled: true
       interval_in_minutes: 7200           # 5d — shorter than the long book
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 360            # 6h — cut a short that bottomed then stalled
       min_value: 2.0
     dead_weight_cut:

--- a/strategies/mandate/main/runtime.yaml
+++ b/strategies/mandate/main/runtime.yaml
@@ -87,7 +87,11 @@ exit:
     execution_timeout_seconds: 120
   dsl_preset:
     hard_timeout: { enabled: true, interval_in_minutes: 20160 }        # 14d staleness cap
-    weak_peak_cut: { enabled: true, interval_in_minutes: 5760, min_value: 2.0 }  # retire dead weight ~4d
+    # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+    # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+    # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+    # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+    weak_peak_cut: { enabled: false, interval_in_minutes: 5760, min_value: 2.0 }  # retire dead weight ~4d
     phase1:
       # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
       # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.

--- a/strategies/manta/main/runtime.yaml
+++ b/strategies/manta/main/runtime.yaml
@@ -107,7 +107,11 @@ exit:
       enabled: false
       interval_in_minutes: 480
     weak_peak_cut:
-      enabled: true                        # the break didn't follow through -> release it
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 90
       min_value: 1.5
     dead_weight_cut:

--- a/strategies/mongoose/long/runtime.yaml
+++ b/strategies/mongoose/long/runtime.yaml
@@ -101,7 +101,11 @@ exit:
       enabled: true
       interval_in_minutes: 10080          # 7d — the trend persists; let winners run
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 480            # 8h — cut a winner that peaked then stalled
       min_value: 2.0
     dead_weight_cut:

--- a/strategies/mongoose/short/runtime.yaml
+++ b/strategies/mongoose/short/runtime.yaml
@@ -96,7 +96,11 @@ exit:
       enabled: true
       interval_in_minutes: 7200           # 5d — shorter than the long book
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 360            # 6h — cut a short that bottomed then stalled
       min_value: 2.0
     dead_weight_cut:

--- a/strategies/octopus/long/runtime.yaml
+++ b/strategies/octopus/long/runtime.yaml
@@ -88,7 +88,11 @@ exit:
       enabled: true
       interval_in_minutes: 5760           # 4d staleness cap
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 360            # 6h — cut a leader that peaked then stalled
       min_value: 2.0
     dead_weight_cut:

--- a/strategies/octopus/short/runtime.yaml
+++ b/strategies/octopus/short/runtime.yaml
@@ -89,7 +89,11 @@ exit:
       enabled: true
       interval_in_minutes: 5760           # 4d staleness cap
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 360            # 6h — cut a laggard-short that peaked then stalled
       min_value: 2.0
     dead_weight_cut:

--- a/strategies/orangutan/main/runtime.yaml
+++ b/strategies/orangutan/main/runtime.yaml
@@ -107,7 +107,11 @@ exit:
     execution_timeout_seconds: 60
   dsl_preset:
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 10080       # 7d — matches the weekly recalibration
       min_value: 2.5
     phase1:

--- a/strategies/owl/main/runtime.yaml
+++ b/strategies/owl/main/runtime.yaml
@@ -102,7 +102,11 @@ exit:
       enabled: true
       interval_in_minutes: 480              # 8h max — contrarian thesis unwind window
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 120
       min_value: 2.0                        # peak ROE floor; below this in 2h = thesis failed
     dead_weight_cut:

--- a/strategies/ram/main/runtime.yaml
+++ b/strategies/ram/main/runtime.yaml
@@ -96,7 +96,11 @@ exit:
     execution_timeout_seconds: 60
   dsl_preset:
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 2880            # 48h — a stalled gold position frees its slot
       min_value: 2.5
     phase1:

--- a/strategies/raven/main/runtime.yaml
+++ b/strategies/raven/main/runtime.yaml
@@ -112,7 +112,11 @@ exit:
     execution_timeout_seconds: 60
   dsl_preset:
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 1440        # 24h — a stalled momentum name frees its slot
       min_value: 2.5
     phase1:

--- a/strategies/rhino/escalation/runtime.yaml
+++ b/strategies/rhino/escalation/runtime.yaml
@@ -96,7 +96,11 @@ exit:
       enabled: true
       interval_in_minutes: 2880           # 2d
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 180            # 3h
       min_value: 2.0
     dead_weight_cut:

--- a/strategies/rooster/main/runtime.yaml
+++ b/strategies/rooster/main/runtime.yaml
@@ -105,7 +105,11 @@ exit:
       enabled: true                        # the session thesis expires — see note above
       interval_in_minutes: 480             # 8h: covers the open plus the session that follows it
     weak_peak_cut:
-      enabled: true                        # the open came and went and nothing happened -> release it
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 90
       min_value: 1.5
     dead_weight_cut:

--- a/strategies/rotator/main/runtime.yaml
+++ b/strategies/rotator/main/runtime.yaml
@@ -90,7 +90,11 @@ exit:
     execution_timeout_seconds: 45
   dsl_preset:
     hard_timeout: { enabled: true, interval_in_minutes: 2880 }              # 48h — full turnover
-    weak_peak_cut: { enabled: true, interval_in_minutes: 1440, min_value: 2.5 }  # free a stalled slot in ~1d
+    # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+    # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+    # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+    # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+    weak_peak_cut: { enabled: false, interval_in_minutes: 1440, min_value: 2.5 }  # free a stalled slot in ~1d
     phase1:
       # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
       # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.

--- a/strategies/sailfish/main/runtime.yaml
+++ b/strategies/sailfish/main/runtime.yaml
@@ -95,7 +95,11 @@ exit:
       enabled: true
       interval_in_minutes: 5760            # 96h — leadership can extend
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 480             # 8h
       min_value: 3.0
     dead_weight_cut:

--- a/strategies/salamander/main/runtime.yaml
+++ b/strategies/salamander/main/runtime.yaml
@@ -109,7 +109,11 @@ exit:
       enabled: true                         # v2: 48h cap — failed pullbacks get cut
       interval_in_minutes: 2880
     weak_peak_cut:
-      enabled: true                         # v2: 90min/3% — stale pullbacks cut (self-limiting)
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 90
       min_value: 3.0
     dead_weight_cut:

--- a/strategies/salmon/main/runtime.yaml
+++ b/strategies/salmon/main/runtime.yaml
@@ -97,7 +97,11 @@ exit:
     execution_timeout_seconds: 60
   dsl_preset:
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 720          # 12h — a stalled reversion frees its slot
       min_value: 2.0
     phase1:

--- a/strategies/shadow/main/runtime.yaml
+++ b/strategies/shadow/main/runtime.yaml
@@ -84,7 +84,11 @@ exit:
     execution_timeout_seconds: 45
   dsl_preset:
     hard_timeout: { enabled: true, interval_in_minutes: 2880 }      # 48h cap
-    weak_peak_cut: { enabled: true, interval_in_minutes: 720, min_value: 2.0 }
+    # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+    # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+    # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+    # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+    weak_peak_cut: { enabled: false, interval_in_minutes: 720, min_value: 2.0 }
     phase1:
       # Trailing DISABLED: the phase-1 floor trails HIGH-WATER, so after a small favourable
       # move it can still sit BELOW entry and close a WINNER at a loss — churning fees.

--- a/strategies/sheep/main/runtime.yaml
+++ b/strategies/sheep/main/runtime.yaml
@@ -97,7 +97,11 @@ exit:
       enabled: true
       interval_in_minutes: 4320            # 72h — trends can develop over days
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 360             # 6h
       min_value: 3.0
     dead_weight_cut:

--- a/strategies/starling/main/runtime.yaml
+++ b/strategies/starling/main/runtime.yaml
@@ -108,7 +108,11 @@ exit:
       # follow must clear to prove it is still working. At 2.5 (= 0.5% of price at 5x) any wiggle reset
       # the clock and this fired ONCE in 179 closes. At 10 (= 2% of price at 5x) a position that never
       # gets 2% our way in two days is correctly declared dead and frees its slot.
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 2880        # 48h
       min_value: 10
     phase1:

--- a/strategies/stingray/main/runtime.yaml
+++ b/strategies/stingray/main/runtime.yaml
@@ -102,7 +102,11 @@ exit:
       enabled: true                         # 48h: cap a stalled rotation leg (mixed crypto+xyz, weekend gaps)
       interval_in_minutes: 2880             # 48 hours
     weak_peak_cut:
-      enabled: true                         # self-limiting: fires only if peak ROE never clears 3.0 in 60min
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 60
       min_value: 3.0
     dead_weight_cut:

--- a/strategies/terrapin/u1/runtime.yaml
+++ b/strategies/terrapin/u1/runtime.yaml
@@ -99,7 +99,11 @@ exit:
       enabled: false
       interval_in_minutes: 1440
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 240             # a daily breakout that does nothing for 4h was a fakeout
       min_value: 2.0
     dead_weight_cut:

--- a/strategies/terrapin/u2/runtime.yaml
+++ b/strategies/terrapin/u2/runtime.yaml
@@ -95,7 +95,11 @@ exit:
       enabled: false
       interval_in_minutes: 1440
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 240
       min_value: 2.0
     dead_weight_cut:

--- a/strategies/terrapin/u3/runtime.yaml
+++ b/strategies/terrapin/u3/runtime.yaml
@@ -95,7 +95,11 @@ exit:
       enabled: false
       interval_in_minutes: 1440
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 180
       min_value: 2.0
     dead_weight_cut:

--- a/strategies/terrapin/u4/runtime.yaml
+++ b/strategies/terrapin/u4/runtime.yaml
@@ -97,7 +97,11 @@ exit:
       enabled: false
       interval_in_minutes: 1440
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 120
       min_value: 2.0
     dead_weight_cut:

--- a/strategies/thesis-fund/main/runtime.yaml
+++ b/strategies/thesis-fund/main/runtime.yaml
@@ -96,7 +96,11 @@ exit:
       enabled: true
       interval_in_minutes: 7200           # 5d
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 480            # 8h — recycle a name that stops confirming
       min_value: 2.0
     dead_weight_cut:

--- a/strategies/viper/main/runtime.yaml
+++ b/strategies/viper/main/runtime.yaml
@@ -96,7 +96,11 @@ exit:
     execution_timeout_seconds: 60
   dsl_preset:
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 1440        # 24h — a stalled structure name frees its slot
       min_value: 2.5
     phase1:

--- a/strategies/vulture/main/runtime.yaml
+++ b/strategies/vulture/main/runtime.yaml
@@ -114,7 +114,11 @@ exit:
       enabled: true
       interval_in_minutes: 10080            # 7 days — small-cap winners hold for days
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 180              # 3h
       min_value: 2.0
     dead_weight_cut:

--- a/strategies/weaver/main/runtime.yaml
+++ b/strategies/weaver/main/runtime.yaml
@@ -108,7 +108,11 @@ exit:
       enabled: true
       interval_in_minutes: 2880       # 48h
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 120
       min_value: 2.0
     phase1:

--- a/strategies/wolf/risk_off/runtime.yaml
+++ b/strategies/wolf/risk_off/runtime.yaml
@@ -89,7 +89,11 @@ exit:
       enabled: true
       interval_in_minutes: 4320            # 3d (ported verbatim)
     weak_peak_cut:
-      enabled: true
+      # DISABLED - this cut closes at MARKET at whatever price is there, with no floor, so on a
+      # longer-hold book it realises a small LOSS on a position that simply hadn't moved yet
+      # (Ignas, M408027, xyz:PLTR on cougar). Same defect we removed from phase1. weak_peak is
+      # a CHOP tool only: it belongs where the strategy already intends to be out within hours.
+      enabled: false
       interval_in_minutes: 240             # 4h (ported verbatim)
       min_value: 1.5
     dead_weight_cut:


### PR DESCRIPTION
Ignas (M408027) had `xyz:PLTR` on **cougar** close for a small loss.

**The ratchet fix was not at fault.** cougar has `phase1.enabled: false`, `max_loss_pct: 8`, first profit lock at +18%. It was **`weak_peak_cut`** — which the fleet sweep never touched.

## The defect

```
fires when:  8h elapsed
         AND high-water beat entry at some point
         AND peak ROE never reached min_value
         AND currently below that peak
      ->   CLOSE AT MARKET, at whatever price is there.  No floor.
```

That is the **identical defect we removed from phase 1**, still live on 86 instances.

At cougar's 5× with `min_value: 2.0` it reads: *"PLTR must gain +0.4% of price within 8 hours or be closed at market."* That's noise on an equity perp.

The "small loss" is the **signature, not a coincidence** — weak_peak only fires on positions whose peak stayed under `min_value`, i.e. that never got far from entry, so a close there is by construction a small number. A stop-out would have been −8% ROE (−1.6% of price), which isn't small.

The same mechanism closed eel's two crude shorts at **−4.5%** and **−3.0%** earlier the same day. Flagged then, not fixed then. This fixes it.

## The rule

> **weak_peak belongs only where the strategy already intends to be out within hours.** A book designed to hold cannot use a cut that realises whatever price happens to be there.

**Kept — 13, all chop** (catalog horizon `scalp`/`intraday`, or `hard_timeout ≤ 6h`):
`barracuda` `dog` `hare` `jackal` `jaguar` `kestrel` `mantis` `orca` `otter` `raptor` `roach` `scorpion` `spider/scalp`

**Disabled — 73 instances / 57 strategies**: 37 position-horizon, 35 swing, 1 unclassified.

Set `enabled: false` with the reason inline rather than deleting the block — matching how phase 1 was handled, so the knob stays visible in a diff instead of vanishing.

## Verification

- 13 remain enabled and **every one is chop**; **0 long-hold leaks**
- `phase1` still disabled fleet-wide
- Diff contains **nothing but** those `enabled` flips and their comments — 73 files, 365 insertions (73 × 4 comment lines + 73 flags), 73 deletions
- Both YAML styles handled — 4 instances use the inline flow-mapping form
- Catalog regenerated and confirmed unchanged (`weak_peak` is not a catalog field), so it is not in this diff
- Vendor parity **OK** · golden **OK** (107) · CI **502 passed / 1 skipped**

## Worth a second look

Three keepers are labelled `scalp` but have long or no position cap: **barracuda** (`hard_timeout` unbounded), **jackal** (4320m = 3d), **scorpion** (720m). They keep weak_peak on the strength of their catalog label, but a "scalp" that can hold three days is worth questioning on its own terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)