### PR TITLE
fix(stingray): stop upper-casing the leaderboard token at ingest (kPEPE)

### DIFF
--- a/senpi-strategy-discover/catalog.json
+++ b/senpi-strategy-discover/catalog.json
@@ -5447,7 +5447,7 @@
       "emoji": "🐠",
       "tagline": "Reads the entire smart-money board every tick, ranks every asset by net smart-money conviction (tilt x notional x breadth), then rides the rotation — LONG the assets the best traders are crowding into and SHORT the ones they're fleeing, gated by price so it never fights a hard trend. Captures days like 'long semis/indices, short the crypto block'.",
       "belief_plain": "Most copy-trading bots ask 'are the best traders long this one coin?'. Stingray instead looks at the whole market at once and asks 'what are the best traders rotating INTO, and what are they rotating OUT OF?'. It buys the crowd's new favorites and sells the ones they're abandoning — but only when the price chart isn't already screaming the other way — then trails a wide stop so a real rotation can run for days.",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "thesis": "Smart money doesn't just pick coins, it rotates capital across the whole board — out of one asset class and into another. Per-asset copy-traders miss this because they evaluate each market in isolation; they can't see that the SAME flow leaving crypto is funding the bid in indices. Stingray ranks the entire board by net tilt (long_ratio - 50) weighted by notional and trader breadth, so a strong, deep, widely-held lean outranks a thin spike, then takes BOTH sides at once — long the inflows, short the outflows — for a market-neutral-ish rotation book. A price-confirmation gate (no longs into a hard 4h downtrend, no shorts into a hard uptrend) keeps it from fighting price, and a DSL ratchet lets the winning legs run while cutting the losers.",
       "tags": [
         "smart-money",

--- a/strategies/catalog.json
+++ b/strategies/catalog.json
@@ -5447,7 +5447,7 @@
       "emoji": "🐠",
       "tagline": "Reads the entire smart-money board every tick, ranks every asset by net smart-money conviction (tilt x notional x breadth), then rides the rotation — LONG the assets the best traders are crowding into and SHORT the ones they're fleeing, gated by price so it never fights a hard trend. Captures days like 'long semis/indices, short the crypto block'.",
       "belief_plain": "Most copy-trading bots ask 'are the best traders long this one coin?'. Stingray instead looks at the whole market at once and asks 'what are the best traders rotating INTO, and what are they rotating OUT OF?'. It buys the crowd's new favorites and sells the ones they're abandoning — but only when the price chart isn't already screaming the other way — then trails a wide stop so a real rotation can run for days.",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "thesis": "Smart money doesn't just pick coins, it rotates capital across the whole board — out of one asset class and into another. Per-asset copy-traders miss this because they evaluate each market in isolation; they can't see that the SAME flow leaving crypto is funding the bid in indices. Stingray ranks the entire board by net tilt (long_ratio - 50) weighted by notional and trader breadth, so a strong, deep, widely-held lean outranks a thin spike, then takes BOTH sides at once — long the inflows, short the outflows — for a market-neutral-ish rotation book. A price-confirmation gate (no longs into a hard 4h downtrend, no shorts into a hard uptrend) keeps it from fighting price, and a DSL ratchet lets the winning legs run while cutting the losers.",
       "tags": [
         "smart-money",

--- a/strategies/stingray/main/scanners/scan.py
+++ b/strategies/stingray/main/scanners/scan.py
@@ -174,7 +174,12 @@ def _board(ctx, limit, xyz_banned):
     for m in markets:
         if not isinstance(m, dict):
             continue
-        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        # RAW case — Hyperliquid asset names are CASE-SENSITIVE (kPEPE, kBONK, kSHIB). Upper-casing
+        # here corrupted the name at ingest, so every downstream use got "KPEPE": the venue rejects
+        # it, `openclaw senpi validate` fails the package, and a name that slips past validate is a
+        # silent no-trade. _venue_asset (from #548) preserves case but cannot help if it is handed an
+        # already-corrupted token. Group case-insensitively (below) but CARRY the raw name.
+        token = str(m.get("token", m.get("coin", m.get("asset", ""))))
         if not token:
             continue
         dex = str(m.get("dex", "")).lower()
@@ -186,7 +191,7 @@ def _board(ctx, limit, xyz_banned):
         vol = scoring.safe_float(m.get("volume", m.get("avg_volume_6h", m.get("avgVolume", 0))))
         traders = scoring.safe_float(m.get("trader_count", m.get("traders", 0)))
 
-        key = (token, dex)
+        key = (token.upper(), dex)              # case-insensitive GROUPING only — row carries raw case
         row = by_asset.setdefault(key, {
             "token": token, "dex": dex,
             "long_pct": 0.0, "short_pct": 0.0,

--- a/strategies/stingray/strategy.yaml
+++ b/strategies/stingray/strategy.yaml
@@ -8,7 +8,7 @@
 schema_version: 1
 
 id: stingray
-version: "1.2.1"
+version: "1.2.2"
 
 catalog:
   name: "Stingray — Cross-Asset Smart-Money Rotation"


### PR DESCRIPTION
Hyperliquid asset names are **case-sensitive**. `_board` upper-cased the token the moment it read the leaderboard, so `kPEPE` → `KPEPE`, and every downstream use got the corrupted name — including the venue read and the emit.

**Found live tonight:** a fresh v1.2.1 deploy failed `openclaw senpi validate` with *"KPEPE is an invalid ticker"*.

Validate catching it is the **good** case — it only fires when `kPEPE` happens to be ranked at validate time. When it isn't, the package deploys clean and the bug becomes a **silent no-trade** the first time a k-prefixed name reaches the top of the board.

[#548](https://github.com/Senpi-ai/senpi-skills/pull/548)'s `_venue_asset` preserves case correctly, but it can't help — it was being handed a token already destroyed at ingest, three hundred lines upstream.

## The fix

The `.upper()` was load-bearing: `key = (token, dex)` groups the leaderboard's separate long and short rows for one asset, and that grouping must be case-insensitive. So keep **both** forms rather than dropping it:

```python
key = (token.upper(), dex)     # case-insensitive GROUPING
"token": token                 # RAW case for the venue read + emit
```

Verified on a synthetic board — `kPEPE` split across long/short rows, `NVDA` on xyz, `BTC` on main:

```
row token    dex     -> venue asset    long%  short%
BTC          (main)  BTC                  55       0
NVDA         xyz     xyz:NVDA             70       0
kPEPE        (main)  kPEPE                60      40
```

case preserved ✓ · long/short rows still merge ✓ · `xyz:` prefix still applies ✓

## Fleet scope — deliberately not swept

Three other instances share this exact shape: **bald-eagle**, **cheetah**, **orca**. Not fixed here on purpose — each `.upper()` protects something different (bald-eagle's feeds a `token not in allowed_set` whitelist check; the others have no grouping key), so a blind sweep would break bald-eagle. They need individual reads.

The broader grep finds ~80 `.upper()` calls on token/coin/asset across the fleet, but most are dedup or comparison sets where upper-casing is safe. Separating those from the ones that reach a venue call is a real audit, not a regex.

stingray **1.2.1 → 1.2.2**. Catalog regenerated. Package tests 3/3 · CI 502 passed / 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)