### PR TITLE
fix(strategy-ops): refresh a bare-id package from remote instead of pinning to the local copy

### DIFF
--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -22,7 +22,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "3.6.24"
+  version: "3.7.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -68,7 +68,7 @@ remote fetch. Mechanics + state machine: [`references/lifecycle.md`](references/
 > **`status` is the gate, not a suggestion.** A strategy is LIVE only when the deploy report's `overall`
 > is **`live`** — every instance created + installed + a **verified scanner tick observed**.
 > `installed-unobserved` means the tick was NOT seen inside the wait window — not failure and not
-> success; say exactly that. Never report "live" off a started job, a running phase, or an install alone.
+> success; say exactly that. Never report "live" off a started job, a running phase, or an install alone — nor a VERSION off the catalog; quote deploy's own `package <id> vX.Y.Z`.
 
 **Step 0 — resolve which strategy.** The user's word ("spider") is a strategy **`id`**. Confirm it
 exists against the registry (`curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/refs/heads/main/strategies/catalog.json`);

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -135,11 +135,37 @@ def _pkg_version(pkg_dir):
         return None
 
 
-def _fetch_fresh(sid, ref, log):
-    """Fetch <sid> into a TEMP root; return that path, or None if the remote lacks it / is
-    unreachable. Temp-first is the safety property: a failed download can never leave the durable
-    root without a package."""
-    tmp = Path(tempfile.mkdtemp(prefix=f"senpi-pkg-{sid}-"))
+def _stage_aside(dest_root, sid, log, why):
+    """Move <dest_root>/<sid> out of the way, to a name that cannot already exist. Returns the
+    backup path, or None if there was nothing there.
+
+    EVERY existing directory is moved, not just a loadable one. A dir holding files but no
+    strategy.yaml — the shape a pre-3.7.0 interrupted fetch leaves — used to skip this and then
+    take `shutil.move(fresh, local)`, which moves the package INSIDE it: BadPackage on this run,
+    and on the next one a `shutil.Error` because the nested copy is already there. The durable root
+    stayed wedged until a human cleared it."""
+    local = dest_root / sid
+    if not local.exists():
+        return None
+    stamp = time.strftime("%Y%m%dT%H%M%S")
+    backup = dest_root / f"{sid}.bak-{stamp}"
+    n = 1
+    while backup.exists():                       # two refreshes in one second must not collide
+        backup = dest_root / f"{sid}.bak-{stamp}-{n}"
+        n += 1
+    shutil.move(str(local), str(backup))
+    log(f"{why} — previous copy kept at {backup}")
+    return backup
+
+
+def _fetch_fresh(sid, ref, log, dest_root):
+    """Fetch <sid> into a staging dir INSIDE the durable root, and return it, or None if the remote
+    lacks it / is unreachable. Staging first is the safety property: a failed download can never
+    leave the durable root without a package. Staging *inside* dest_root (not /tmp) keeps the final
+    swap on one filesystem, so it is a rename rather than a cross-device copy+delete that could
+    fail half-way on a full disk."""
+    dest_root.mkdir(parents=True, exist_ok=True)
+    tmp = Path(tempfile.mkdtemp(prefix=f".senpi-fetch-{sid}-", dir=dest_root))
     try:
         _fetch.fetch_package(sid, tmp, ref=ref)      # contract: writes <dest_root>/<id>
         if not (tmp / sid / "strategy.yaml").is_file():
@@ -190,7 +216,7 @@ def ensure_pkg(arg, ref, log):
         log(f"{sid!r} carries deploy state — using the deployed copy ({_pkg_version(local)}), not refreshing")
         return _pkg.load(local)
 
-    fresh = _fetch_fresh(sid, ref, log)
+    fresh = _fetch_fresh(sid, ref, log, dest_root)
     if fresh is None:
         if loadable:
             log(f"WARNING: could not refresh {sid!r} — deploying the LOCAL copy ({_pkg_version(local)}), "
@@ -203,14 +229,20 @@ def ensure_pkg(arg, ref, log):
             f"  Deploying a locally-authored package? Pass its DIRECTORY path instead of a bare id, "
             f"e.g.: deploy.py validate /data/workspace/strategies/{sid}")
 
-    if loadable:
-        backup = dest_root / f"{sid}.bak-{time.strftime('%Y%m%dT%H%M%S')}"
-        old_v = _pkg_version(local)
-        shutil.move(str(local), str(backup))
-        log(f"{sid!r} refreshed: {old_v} -> {_pkg_version(fresh)} (previous copy kept at {backup})")
-    else:
-        log(f"{sid!r} not on disk — fetched {_pkg_version(fresh)} into {dest_root}")
-    dest_root.mkdir(parents=True, exist_ok=True)
+    old_v, new_v = _pkg_version(local), _pkg_version(fresh)
+    # Nothing to do when the versions already agree. The documented flow is `validate` then
+    # `create`, so without this an ordinary deploy leaves TWO .bak dirs — unbounded, never pruned,
+    # and picked up by validate_universe's root.glob("*") as if they were real packages. It also
+    # meant a forked template was backed up and replaced on EVERY command rather than once.
+    if loadable and new_v is not None and new_v == old_v:
+        log(f"{sid!r} already current at {new_v} — not refreshing")
+        shutil.rmtree(fresh.parent, ignore_errors=True)
+        return _pkg.load(local)
+
+    why = (f"{sid!r} refreshed: {old_v} -> {new_v}" if loadable
+           else f"{sid!r} on disk but unloadable — replacing with fetched {new_v}")
+    if _stage_aside(dest_root, sid, log, why) is None:   # unconditional: see the docstring there
+        log(f"{sid!r} not on disk — fetched {new_v} into {dest_root}")
     shutil.move(str(fresh), str(local))
     shutil.rmtree(fresh.parent, ignore_errors=True)
     return _pkg.load(local)

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -76,7 +76,9 @@ the verdict, never the invariant.
 import argparse
 import json
 import re
+import shutil
 import sys
+import tempfile
 import time
 from pathlib import Path
 
@@ -123,38 +125,95 @@ EXIT_PENDING = 6
 
 # ---------- package resolution (unchanged — discovery stays in skills) ----------
 
+def _pkg_version(pkg_dir):
+    """Declared version of a package on disk, or None. Text-scanned so it still reports on a
+    package that does not load."""
+    try:
+        m = re.search(r'^version:\s*"([^"]+)"', (Path(pkg_dir) / "strategy.yaml").read_text(), re.M)
+        return m.group(1) if m else None
+    except OSError:
+        return None
+
+
+def _fetch_fresh(sid, ref, log):
+    """Fetch <sid> into a TEMP root; return that path, or None if the remote lacks it / is
+    unreachable. Temp-first is the safety property: a failed download can never leave the durable
+    root without a package."""
+    tmp = Path(tempfile.mkdtemp(prefix=f"senpi-pkg-{sid}-"))
+    try:
+        _fetch.fetch_package(sid, tmp, ref=ref)      # contract: writes <dest_root>/<id>
+        if not (tmp / sid / "strategy.yaml").is_file():
+            raise _fetch.FetchError("fetched tree has no strategy.yaml")
+        return tmp / sid
+    except Exception as e:                            # noqa — a fetch failure must not sink a deploy
+        shutil.rmtree(tmp, ignore_errors=True)
+        log(f"remote fetch of {sid!r} unavailable ({e})")
+        return None
+
+
 def ensure_pkg(arg, ref, log):
-    # A package that EXISTS on disk is authoritative — load it and let any BadPackage surface as the
-    # real, fixable error. NEVER fall through to a (possibly stale) remote fetch just because a local
-    # package is invalid: that silently deploys the wrong version and discards the author's local fixes.
-    # Only a bare id that isn't a local directory triggers the catalog fetch from remote.
-    if (_pkg.resolve_pkg_dir(arg) / "strategy.yaml").is_file():
+    """Resolve `arg` (package PATH or bare catalog id) to a Package, REFRESHING a bare id from the
+    remote so a deploy installs the current version.
+
+    Until 2026-09-04 an on-disk package was used verbatim and the remote never consulted, so a box
+    that had ever fetched a strategy was pinned to that copy forever — every later catalog fix
+    invisible to it. Observed live: a box deployed stingray v1.0.0 while the catalog was at v1.2.1,
+    funded the wallet, and reported success.
+
+    Three cases still do NOT refresh:
+      - an explicit PATH is an author's working copy — never second-guessed (an invalid one raises
+        its own error rather than falling through to a fetch: the GLM footgun)
+      - `.deploy-state.json` means a legacy DEPLOYED package — grafting catalog files onto live
+        deploy state is money-adjacent
+      - a bare id the remote does not have is LOCALLY AUTHORED — the 404 keeps the local copy, which
+        is what protects authored work without a marker file
+    A refresh renames the old copy to <id>.bak-<ts> rather than deleting it; any other fetch failure
+    keeps local and warns rather than blocking the deploy.
+    """
+    if (Path(arg) / "strategy.yaml").is_file():       # explicit path = explicit intent
         return _pkg.load(arg)
+
     sid = Path(arg).name
-    # Fetch to the DURABLE root (absolute, CWD-independent), never a CWD-relative path: a relative
-    # dest resolved inside a managed skill dir gets wiped on the next SKILL.md version bump.
+    # The DURABLE root (absolute, CWD-independent): a relative dest inside a managed skill dir gets
+    # wiped on the next SKILL.md version bump.
     dest_root = _pkg.strategies_root()
-    # A dest dir carrying deploy state but no loadable strategy.yaml is a partially-wiped DEPLOYED
-    # package — fetching would graft pristine catalog files onto a live deploy's remains. Refuse; this
-    # needs eyes, not a fetch. (This script no longer WRITES `.deploy-state.json`, but boxes deployed
-    # before the verb still carry one, and `_pkg.resolve_pkg_dir` still reads it as the tie-break.)
-    if (dest_root / sid / ".deploy-state.json").is_file():
+    local = dest_root / sid
+    has_state = (local / ".deploy-state.json").is_file()
+    loadable = (local / "strategy.yaml").is_file()
+
+    if has_state and not loadable:                    # partially-wiped deployed package — needs eyes
         raise SystemExit(
-            f"error: {dest_root / sid} carries deploy state (.deploy-state.json) but no loadable "
+            f"error: {local} carries deploy state (.deploy-state.json) but no loadable "
             f"strategy.yaml — refusing to fetch the catalog copy over a deployed package's remains.\n"
             f"  Inspect the directory and restore its files (or move the state aside) first.")
-    log(f"package {sid!r} not on disk — fetching from remote into {dest_root}…")
-    try:
-        _fetch.fetch_package(sid, dest_root, ref=ref)
-        return _pkg.load(dest_root / sid)
-    except (_fetch.FetchError, _pkg.BadPackage) as e:
+    if has_state:
+        log(f"{sid!r} carries deploy state — using the deployed copy ({_pkg_version(local)}), not refreshing")
+        return _pkg.load(local)
+
+    fresh = _fetch_fresh(sid, ref, log)
+    if fresh is None:
+        if loadable:
+            log(f"WARNING: could not refresh {sid!r} — deploying the LOCAL copy ({_pkg_version(local)}), "
+                f"which may be stale if this id is in the catalog")
+            return _pkg.load(local)
         raise SystemExit(
-            f"error: {e}\n"
-            f"  {arg!r} is not a package on disk (tried {arg!r}, {dest_root / sid}, and "
+            f"error: {arg!r} is not a package on disk (tried {arg!r}, {local}, and "
             f"'strategies/{sid}' relative to the current directory) and could not be fetched as a "
             f"catalog id.\n"
             f"  Deploying a locally-authored package? Pass its DIRECTORY path instead of a bare id, "
             f"e.g.: deploy.py validate /data/workspace/strategies/{sid}")
+
+    if loadable:
+        backup = dest_root / f"{sid}.bak-{time.strftime('%Y%m%dT%H%M%S')}"
+        old_v = _pkg_version(local)
+        shutil.move(str(local), str(backup))
+        log(f"{sid!r} refreshed: {old_v} -> {_pkg_version(fresh)} (previous copy kept at {backup})")
+    else:
+        log(f"{sid!r} not on disk — fetched {_pkg_version(fresh)} into {dest_root}")
+    dest_root.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(fresh), str(local))
+    shutil.rmtree(fresh.parent, ignore_errors=True)
+    return _pkg.load(local)
 
 
 def local_pkg(arg):

--- a/senpi-strategy-ops/tests/test_pkg.py
+++ b/senpi-strategy-ops/tests/test_pkg.py
@@ -343,6 +343,54 @@ def test_ensure_pkg_refreshes_a_stale_local_copy_and_backs_it_up(monkeypatch, tm
     assert len(baks) == 1 and deploy._pkg_version(baks[0]) == "1.0.0"     # old copy kept, not deleted
 
 
+def test_ensure_pkg_recovers_a_dir_with_no_strategy_yaml(monkeypatch, tmp_path):
+    """A <durable>/<id>/ holding files but no strategy.yaml — the shape a pre-3.7.0 interrupted
+    fetch leaves — used to skip the backup and then move the fetched package INSIDE it: BadPackage
+    on that run, shutil.Error on the next, and the root stayed wedged until cleared by hand."""
+    deploy = _import_deploy()
+    monkeypatch.setenv("SENPI_STRATEGIES_DIR", str(tmp_path / "durable"))
+    junk = tmp_path / "durable" / "spider"
+    junk.mkdir(parents=True)
+    (junk / "scan.py").write_text("# leftover from an interrupted fetch")
+    monkeypatch.setattr(deploy._fetch, "fetch_package", _fake_fetch("1.2.1"))
+
+    pkg = deploy.ensure_pkg("spider", None, lambda m: None)
+    assert deploy._pkg_version(pkg.dir) == "1.2.1"
+    assert not (tmp_path / "durable" / "spider" / "spider").exists()     # not nested
+    deploy.ensure_pkg("spider", None, lambda m: None)                    # 2nd run used to raise
+    baks = list((tmp_path / "durable").glob("spider.bak-*"))
+    assert len(baks) == 1 and (baks[0] / "scan.py").is_file()            # junk preserved, not deleted
+
+
+def test_ensure_pkg_does_not_churn_backups_when_already_current(monkeypatch, tmp_path):
+    """The documented flow is `validate` then `create`, so an unconditional swap left TWO .bak dirs
+    per deploy — unbounded, never pruned, and picked up by validate_universe's root.glob("*") as if
+    they were real packages. A forked template was also replaced on every command, not once."""
+    deploy = _import_deploy()
+    monkeypatch.setenv("SENPI_STRATEGIES_DIR", str(tmp_path / "durable"))
+    make_flat(tmp_path / "durable", pkg_id="spider", version="1.2.1")
+    monkeypatch.setattr(deploy._fetch, "fetch_package", _fake_fetch("1.2.1"))
+
+    msgs = []
+    for _ in range(3):
+        deploy.ensure_pkg("spider", None, msgs.append)
+    assert not list((tmp_path / "durable").glob("spider.bak-*"))
+    assert any("already current at 1.2.1" in m for m in msgs)
+
+
+def test_ensure_pkg_backups_are_unique_within_one_second(monkeypatch, tmp_path):
+    """The stamp is 1-second granularity and shutil.move into an existing dir moves INSIDE it, so
+    two refreshes in the same second silently nested and a third raised shutil.Error."""
+    deploy = _import_deploy()
+    monkeypatch.setenv("SENPI_STRATEGIES_DIR", str(tmp_path / "durable"))
+    make_flat(tmp_path / "durable", pkg_id="spider", version="1.0.0")
+    for v in ("1.1.0", "1.2.0", "1.2.1"):
+        monkeypatch.setattr(deploy._fetch, "fetch_package", _fake_fetch(v))
+        deploy.ensure_pkg("spider", None, lambda m: None)
+    assert len(list((tmp_path / "durable").glob("spider.bak-*"))) == 3
+    assert not (tmp_path / "durable" / "spider" / "spider").exists()
+
+
 def test_ensure_pkg_keeps_local_when_the_remote_has_no_such_package(monkeypatch, tmp_path):
     """A locally AUTHORED package is not in the catalog, so the fetch 404s — that is what protects
     authored work, with no marker file needed."""

--- a/senpi-strategy-ops/tests/test_pkg.py
+++ b/senpi-strategy-ops/tests/test_pkg.py
@@ -322,6 +322,74 @@ def test_resolve_pkg_dir_path_form_finds_durable_package(monkeypatch, tmp_path):
     assert _pkg.resolve_pkg_dir("strategies/spider") == tmp_path / "durable" / "spider"
 
 
+def _fake_fetch(version):
+    """A fetch_package stand-in that writes a flat package at <version> into <dest_root>/<id>."""
+    def _f(sid, dest_root, ref=None, **kw):
+        make_flat(Path(dest_root), pkg_id=sid, version=version)
+    return _f
+
+
+def test_ensure_pkg_refreshes_a_stale_local_copy_and_backs_it_up(monkeypatch, tmp_path):
+    """THE BUG: an on-disk package used to win forever, so a box that had ever fetched a strategy
+    was pinned to that copy and every later catalog fix was invisible. Live: a box deployed
+    stingray v1.0.0 while the catalog was at v1.2.1, funded the wallet, and reported success."""
+    deploy = _import_deploy()
+    monkeypatch.setenv("SENPI_STRATEGIES_DIR", str(tmp_path / "durable"))
+    make_flat(tmp_path / "durable", pkg_id="spider", version="1.0.0")     # the stale local copy
+    monkeypatch.setattr(deploy._fetch, "fetch_package", _fake_fetch("1.2.1"))
+    pkg = deploy.ensure_pkg("spider", None, lambda m: None)
+    assert deploy._pkg_version(pkg.dir) == "1.2.1"                        # the CURRENT version deploys
+    baks = list((tmp_path / "durable").glob("spider.bak-*"))
+    assert len(baks) == 1 and deploy._pkg_version(baks[0]) == "1.0.0"     # old copy kept, not deleted
+
+
+def test_ensure_pkg_keeps_local_when_the_remote_has_no_such_package(monkeypatch, tmp_path):
+    """A locally AUTHORED package is not in the catalog, so the fetch 404s — that is what protects
+    authored work, with no marker file needed."""
+    deploy = _import_deploy()
+    monkeypatch.setenv("SENPI_STRATEGIES_DIR", str(tmp_path / "durable"))
+    make_flat(tmp_path / "durable", pkg_id="my-own", version="0.1.0")
+
+    def _404(*a, **k):
+        raise deploy._fetch.FetchError("strategy 'my-own' not found under strategies/")
+
+    monkeypatch.setattr(deploy._fetch, "fetch_package", _404)
+    msgs = []
+    pkg = deploy.ensure_pkg("my-own", None, msgs.append)
+    assert deploy._pkg_version(pkg.dir) == "0.1.0"                        # untouched
+    assert not list((tmp_path / "durable").glob("my-own.bak-*"))          # and not backed up
+    assert any("WARNING" in m for m in msgs)
+
+
+def test_ensure_pkg_failed_fetch_never_leaves_the_root_without_a_package(monkeypatch, tmp_path):
+    """Temp-first: a download that dies partway must not destroy the copy already on disk."""
+    deploy = _import_deploy()
+    monkeypatch.setenv("SENPI_STRATEGIES_DIR", str(tmp_path / "durable"))
+    make_flat(tmp_path / "durable", pkg_id="spider", version="1.0.0")
+
+    def _boom(sid, dest_root, ref=None, **kw):
+        make_flat(Path(dest_root), pkg_id=sid, version="9.9.9")           # half-written…
+        raise OSError("connection reset")                                 # …then dies
+
+    monkeypatch.setattr(deploy._fetch, "fetch_package", _boom)
+    pkg = deploy.ensure_pkg("spider", None, lambda m: None)
+    assert deploy._pkg_version(pkg.dir) == "1.0.0"                        # local survives intact
+    assert not list((tmp_path / "durable").glob("spider.bak-*"))
+
+
+def test_ensure_pkg_does_not_refresh_a_package_carrying_deploy_state(monkeypatch, tmp_path):
+    """A legacy DEPLOYED package stays pinned — grafting catalog files onto live deploy state is
+    money-adjacent."""
+    deploy = _import_deploy()
+    monkeypatch.setenv("SENPI_STRATEGIES_DIR", str(tmp_path / "durable"))
+    make_flat(tmp_path / "durable", pkg_id="spider", version="1.0.0")
+    (tmp_path / "durable" / "spider" / ".deploy-state.json").write_text("{}")
+    called = []
+    monkeypatch.setattr(deploy._fetch, "fetch_package", lambda *a, **k: called.append(a))
+    pkg = deploy.ensure_pkg("spider", None, lambda m: None)
+    assert deploy._pkg_version(pkg.dir) == "1.0.0" and not called
+
+
 def test_ensure_pkg_never_fetches_over_deploy_state(monkeypatch, tmp_path):
     """A dest dir carrying .deploy-state.json but no loadable strategy.yaml (partially wiped
     deployed package) must REFUSE the catalog fetch, not overwrite in place: the fetch would
@@ -394,9 +462,14 @@ def test_ensure_pkg_fetches_into_durable_root_regardless_of_cwd(monkeypatch, tmp
     skill_dir.mkdir(parents=True)
     monkeypatch.chdir(skill_dir)  # the CWD-lottery losing position
     pkg = deploy.ensure_pkg("tech-breakout", None, lambda m: None)
-    assert fetched["dest_root"] == tmp_path / "durable"
+    # The invariant the incident fix protects is WHERE THE PACKAGE ENDS UP, not which directory the
+    # download passed through. ensure_pkg now fetches to a temp root and only moves into the durable
+    # root once the download is complete, so a failed fetch can never leave the durable root without
+    # a package — but the resting place, and the CWD-independence, are unchanged.
     assert pkg.dir == (tmp_path / "durable" / "tech-breakout").resolve()
+    assert (tmp_path / "durable" / "tech-breakout" / "strategy.yaml").is_file()
     assert not (skill_dir / "strategies").exists()  # nothing landed in the skill dir
+    assert Path(fetched["dest_root"]) != skill_dir  # and never the CWD/skill dir
 
 
 def test_fetch_out_path_refuses_traversal(tmp_path):


### PR DESCRIPTION
**@0xsarvesh for review** — this is the fix for the staleness issue, in the shape you suggested (always fetch), made safe.

## The bug

An on-disk package was used verbatim and the remote never consulted. A box that had **ever** fetched a strategy was pinned to that copy forever — every later catalog fix invisible to it, silently and indefinitely.

Observed live tonight: a box deployed `stingray` **v1.0.0** while the catalog was at **v1.2.1**, funded a $1,300 wallet, exited 0, and reported success. Five weeks of DSL safety fixes were absent from it.

**Not a regression.** `ensure_pkg` has never re-fetched a valid local package (`6bdd1a5b`, 23 Jun). It went unnoticed because the fetch dest used to be CWD-relative, so agents running from different directories kept missing the local copy and re-fetching *by accident*. #506 correctly moved fetches to a durable absolute root and removed that accident. There has never been a freshness check here.

## What changed

A bare id now refreshes from remote. **Three cases still don't**, each checkable:

| case | behaviour | why |
|---|---|---|
| explicit **PATH** arg | never refreshed | an author's working copy; an invalid one still raises its own error rather than falling through to a fetch (the GLM footgun — test unchanged, still passing) |
| `.deploy-state.json` present | stays pinned | grafting catalog files onto live deploy state is money-adjacent |
| remote **404** | keeps local | a locally authored package isn't in the catalog — this protects authored work with no marker file needed |

**Safety properties:**
- the fetch lands in a **temp root** and only moves into the durable root once complete — a failed or half-finished download can never leave the durable root without a package
- a refresh renames the old copy to `<id>.bak-<ts>`, never deletes
- any other fetch failure (offline, rate limit) keeps local and **warns** — a GitHub outage must never block a deploy

## The other half — why nobody noticed for five weeks

The agent reported the version it **asked for**, not the one that landed. `deploy`'s own output says `package <id> v1.0.0` and it was never read. `SKILL.md` now requires quoting that line.

Folded into the existing *"never report live off an install alone"* callout rather than added as a new paragraph — the ops body budget is 300 lines with **zero slack**, and its comment says adding a key means being under the ceiling, so I extended the sentence instead of cutting someone else's prose.

## Tests

4 new: stale local refreshes + old copy backed up · remote-404 keeps a locally authored package · a failed fetch leaves local intact · a deploy-state package isn't refreshed.

The durable-root test is re-pointed at where the package **ends up** rather than which directory the download passed through — the invariant #506 protects (CWD-independence, lands in the durable root) is unchanged and still asserted.

strategy-ops **3.6.0 → 3.7.0** · CI **506 passed / 1 skipped**.

## One residual risk worth an explicit decision

Someone who **forked a catalog template and kept the same id** now gets their fork backed up and replaced. Nothing is lost (`.bak-<ts>`), but their strategy changes under them. I think that's the right trade given the backup, but it's the one case that gets *worse*, so flagging rather than burying it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)