### PR TITLE
fix(catalog): never emit a null optional signal key — 5 scanners discard every candidate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,5 +27,9 @@ jobs:
 
       # pytest collects every test regardless of a __main__ runner — bare `python3 <file>` exits 0
       # without running anything on a runner-less file (test_default_catalog.py), a silent green.
-      - name: full suites (ops + discover + trading-runtime)
-        run: python3 -m pytest senpi-strategy-ops/tests senpi-strategy-discover/tests senpi-trading-runtime/tests senpi-trader-research/tests senpi-market-pulse/tests senpi-portfolio/tests -q
+      # `strategies/tests` holds catalog-wide contract guards (no null optional signal keys).
+      # Named explicitly rather than `strategies`: a module-level sys.exit() in
+      # strategies/chimp/tests/test_package_shape.py aborts collection for that whole tree
+      # (pre-existing, unrelated).
+      - name: full suites (ops + discover + trading-runtime + catalog guards)
+        run: python3 -m pytest senpi-strategy-ops/tests senpi-strategy-discover/tests senpi-trading-runtime/tests senpi-trader-research/tests senpi-market-pulse/tests senpi-portfolio/tests strategies/tests -q

--- a/senpi-strategy-discover/catalog.json
+++ b/senpi-strategy-discover/catalog.json
@@ -1,6 +1,6 @@
 {
   "_version": "2.1",
-  "_updated": "2026-09-03",
+  "_updated": "2026-09-04",
   "_generated": true,
   "_instructions": "GENERATED from each strategy package's strategy.yaml — do not hand-edit; run senpi-trading-runtime/scripts/gen_catalog.py. Agents read this via senpi-strategy-discover (scripts/discover.py). DECLARED fields (archetype, sub_style, asset_classes, asset_scope, risk_level, tier, belief_plain, direction) are author-set in strategy.yaml `catalog:`; DERIVED fields (assets, leverage_max, funding_split, instance_count, cadence_seconds, time_horizon, max_slots) are computed from instances/params. Labels/glosses come from senpi-strategy-discover/references/glossary.yaml. 'min_budget' is the machine-COMPUTED minimum total budget at which the design functions (min_budget.py) — the smallest budget where every wallet funds and its smallest slot clears the $12 bumped notional; 'wallet_count' + 'min_budget_binding_wallet' explain it. It is NOT authored — deleting an authored min_budget is a no-op; use min_budget_floor to RAISE it. Positions scale with budget above the min. A strategy is a deployable package; install via senpi-strategy-ops.",
   "skills": [
@@ -283,7 +283,7 @@
       "emoji": "🦉",
       "tagline": "Scans every liquid Hyperliquid crypto perp (OI > $3M) for one-sided crowding — extreme funding + lopsided smart money + concentrated OI — then waits for that crowding to persist 1h+ AND for exhaustion to fire (volume fading, price stalling, RSI divergence) before fading the crowd. Conviction-scaled leverage (7/8/10) at 25% margin, with a macro gate that stands down when BTC's 4h move is extreme.",
       "belief_plain": "The crowd is wrong at the extremes. When everyone piles onto one side of a coin — paying punishing funding, the best traders all leaning the same way, open interest stacking up — and the price then stops following through, the unwind is violent and predictable. Owl waits for both the crowded state AND the exhaustion trigger, then takes the other side. Most days it does nothing, because most days one or both is missing.",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "thesis": "Crowded trades unwind violently. Owl's edge is timing the unwind: it never fades on crowding alone (which can persist and grind), it waits for crowding to PERSIST 1h+ and for distinct exhaustion signals (declining volume under extreme funding, price stalling against the crowd, capitulation wicks, 4h RSI divergence) to confirm the move is dying. Mean reversion fails in trending macro, so a hard gate blocks all fades when |BTC 4h| > 3%. XYZ banned — the funding/smart-money scoring is calibrated on crypto data shape.",
       "tags": [
         "contrarian",
@@ -3836,7 +3836,7 @@
       "emoji": "🦅",
       "tagline": "Scans a whitelist of ~25 small/mid-cap Hyperliquid perps that no other agent covers (majors and XYZ are banned), and enters when smart-money concentration aligns with a fresh 4h trend, the 1h confirms it isn't a false breakout, and 15m velocity is accelerating — then sizes leverage to conviction (5x, 7x apex), cuts losers fast and rides the right-tail winners for days on a trailing stop.",
       "belief_plain": "Hunts the small coins the rest of the fleet ignores. It only buys (or shorts) one when the best traders are crowding in, the 4-hour trend agrees, the 1-hour isn't already rolling over, and short-term momentum is building — then goes in harder on the strongest setups and trails a stop. Most trades are tiny losses cut fast; the occasional big winner pays for everything.",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "thesis": "The biggest blind spot on Hyperliquid is the small/mid-cap long tail — every other agent is locked to the majors or a single asset, so nobody is reading smart-money flow on HEMI, WLD, XPL, AIXBT and the rest. Small caps have a thicker trader-count signal-to-noise ratio than the majors: when smart-money concentration on one aligns with a fresh 4h trend and accelerating 15m velocity, that's a momentum entry with a long right tail. A low win rate is fine when the winners are several times the size of the losers.",
       "tags": [
         "small-cap",
@@ -4272,7 +4272,7 @@
       "emoji": "🐻",
       "tagline": "A single-asset BTC specialist: enters only when 4h and 1h trend structure agree, 15m momentum confirms, smart money leans the same way, and a macro V-recovery gate proves the move isn't a fade right off the 24h extreme — then sizes leverage to conviction (7/10/10x) and lets the DSL ride the winner.",
       "belief_plain": "Trades only BTC. It waits for the 4-hour and 1-hour trend to agree, momentum to confirm, and the best traders to be leaning the same way — and it refuses to short right off a 24h low (or long right off a 24h high) because those fades whipsaw. It goes in harder when more factors line up, and trails a stop instead of guessing the exit.",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "thesis": "BTC has the deepest liquidity on Hyperliquid and the cleanest trend structure. An agent that watches only BTC can read its multi-timeframe structure, smart-money flow, and funding far more tightly than a broad scanner — and BTC's 4h structure metric lags V-recoveries, so a distance-from-24h-extreme gate stops it from fading a reversal that the candle structure hasn't caught up to yet.",
       "tags": [
         "btc",
@@ -4800,7 +4800,7 @@
       "emoji": "🦡",
       "tagline": "A single-asset HYPE specialist: six-gate trend entry (4h structure, 1h non-opposition, 15m momentum, base-tech floor, 4h magnitude) layered with a market-wide funding-regime + funding-persistence macro gate and a smart-money HARD BLOCK — then sizes leverage to conviction (3/5x) and lets the DSL ride the winner.",
       "belief_plain": "Trades only HYPE. It waits for the 4-hour trend to be strong, the 1-hour to not be fighting it, and short-term momentum to confirm — then checks the broader funding 'crowding' regime and refuses to trade when the best traders are leaning the other way. It goes in harder when more factors line up, and trails a stop instead of guessing the exit.",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "thesis": "HYPE is one of the highest-volatility majors on Hyperliquid. A specialist that watches only HYPE can read its trend structure, smart-money flow, funding regime and persistence far more tightly than a broad scanner — and the macro funding-regime gate keeps it out of crowded, liquidation-prone setups that single-asset momentum alone would walk into.",
       "tags": [
         "hype",
@@ -4994,7 +4994,7 @@
       "emoji": "🐕",
       "tagline": "A patient contrarian on BTC/ETH/SOL/HYPE: waits for a major to move 3%+ in 4h while smart money piles in heavily, then fades the crowded, exhausted side — but only when the funding regime confirms the unwind and the move is still fresh. Conservative 7-10x leverage, wide DSL to let the reversal develop.",
       "belief_plain": "When a big coin runs hard and the best traders are all crowded onto the same side, the crowd is maximum exposed and the unwind is the trade. Dog bets against that exhausted consensus on BTC, ETH, SOL and HYPE — but only when the move has genuinely overextended, the crowding is still building, and market-wide funding shows the crowd really is one-sided. Most of the time it waits.",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "thesis": "Hyperliquid is dominated by leverage traders chasing momentum. When a major moves 3%+ in four hours and smart-money consensus piles in 15%+, the late entrants are maximally exposed and funding pressure plus mean reversion force the unwind. Dog's edge is being on the unwind side before capitulation accelerates — so it scores the smart-money direction, hard-gates on exhaustion (>=3% 4h move), freshness (15m contribution still rising), trader depth (>=30), and a funding regime that confirms the crowd is one-sided, then emits the OPPOSITE direction at conservative leverage and lets a wide ratcheting stop ride the reversal rather than banking too early.",
       "tags": [
         "smart-money",

--- a/strategies/catalog.json
+++ b/strategies/catalog.json
@@ -1,6 +1,6 @@
 {
   "_version": "2.1",
-  "_updated": "2026-09-03",
+  "_updated": "2026-09-04",
   "_generated": true,
   "_instructions": "GENERATED from each strategy package's strategy.yaml — do not hand-edit; run senpi-trading-runtime/scripts/gen_catalog.py. Agents read this via senpi-strategy-discover (scripts/discover.py). DECLARED fields (archetype, sub_style, asset_classes, asset_scope, risk_level, tier, belief_plain, direction) are author-set in strategy.yaml `catalog:`; DERIVED fields (assets, leverage_max, funding_split, instance_count, cadence_seconds, time_horizon, max_slots) are computed from instances/params. Labels/glosses come from senpi-strategy-discover/references/glossary.yaml. 'min_budget' is the machine-COMPUTED minimum total budget at which the design functions (min_budget.py) — the smallest budget where every wallet funds and its smallest slot clears the $12 bumped notional; 'wallet_count' + 'min_budget_binding_wallet' explain it. It is NOT authored — deleting an authored min_budget is a no-op; use min_budget_floor to RAISE it. Positions scale with budget above the min. A strategy is a deployable package; install via senpi-strategy-ops.",
   "skills": [
@@ -283,7 +283,7 @@
       "emoji": "🦉",
       "tagline": "Scans every liquid Hyperliquid crypto perp (OI > $3M) for one-sided crowding — extreme funding + lopsided smart money + concentrated OI — then waits for that crowding to persist 1h+ AND for exhaustion to fire (volume fading, price stalling, RSI divergence) before fading the crowd. Conviction-scaled leverage (7/8/10) at 25% margin, with a macro gate that stands down when BTC's 4h move is extreme.",
       "belief_plain": "The crowd is wrong at the extremes. When everyone piles onto one side of a coin — paying punishing funding, the best traders all leaning the same way, open interest stacking up — and the price then stops following through, the unwind is violent and predictable. Owl waits for both the crowded state AND the exhaustion trigger, then takes the other side. Most days it does nothing, because most days one or both is missing.",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "thesis": "Crowded trades unwind violently. Owl's edge is timing the unwind: it never fades on crowding alone (which can persist and grind), it waits for crowding to PERSIST 1h+ and for distinct exhaustion signals (declining volume under extreme funding, price stalling against the crowd, capitulation wicks, 4h RSI divergence) to confirm the move is dying. Mean reversion fails in trending macro, so a hard gate blocks all fades when |BTC 4h| > 3%. XYZ banned — the funding/smart-money scoring is calibrated on crypto data shape.",
       "tags": [
         "contrarian",
@@ -3836,7 +3836,7 @@
       "emoji": "🦅",
       "tagline": "Scans a whitelist of ~25 small/mid-cap Hyperliquid perps that no other agent covers (majors and XYZ are banned), and enters when smart-money concentration aligns with a fresh 4h trend, the 1h confirms it isn't a false breakout, and 15m velocity is accelerating — then sizes leverage to conviction (5x, 7x apex), cuts losers fast and rides the right-tail winners for days on a trailing stop.",
       "belief_plain": "Hunts the small coins the rest of the fleet ignores. It only buys (or shorts) one when the best traders are crowding in, the 4-hour trend agrees, the 1-hour isn't already rolling over, and short-term momentum is building — then goes in harder on the strongest setups and trails a stop. Most trades are tiny losses cut fast; the occasional big winner pays for everything.",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "thesis": "The biggest blind spot on Hyperliquid is the small/mid-cap long tail — every other agent is locked to the majors or a single asset, so nobody is reading smart-money flow on HEMI, WLD, XPL, AIXBT and the rest. Small caps have a thicker trader-count signal-to-noise ratio than the majors: when smart-money concentration on one aligns with a fresh 4h trend and accelerating 15m velocity, that's a momentum entry with a long right tail. A low win rate is fine when the winners are several times the size of the losers.",
       "tags": [
         "small-cap",
@@ -4272,7 +4272,7 @@
       "emoji": "🐻",
       "tagline": "A single-asset BTC specialist: enters only when 4h and 1h trend structure agree, 15m momentum confirms, smart money leans the same way, and a macro V-recovery gate proves the move isn't a fade right off the 24h extreme — then sizes leverage to conviction (7/10/10x) and lets the DSL ride the winner.",
       "belief_plain": "Trades only BTC. It waits for the 4-hour and 1-hour trend to agree, momentum to confirm, and the best traders to be leaning the same way — and it refuses to short right off a 24h low (or long right off a 24h high) because those fades whipsaw. It goes in harder when more factors line up, and trails a stop instead of guessing the exit.",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "thesis": "BTC has the deepest liquidity on Hyperliquid and the cleanest trend structure. An agent that watches only BTC can read its multi-timeframe structure, smart-money flow, and funding far more tightly than a broad scanner — and BTC's 4h structure metric lags V-recoveries, so a distance-from-24h-extreme gate stops it from fading a reversal that the candle structure hasn't caught up to yet.",
       "tags": [
         "btc",
@@ -4800,7 +4800,7 @@
       "emoji": "🦡",
       "tagline": "A single-asset HYPE specialist: six-gate trend entry (4h structure, 1h non-opposition, 15m momentum, base-tech floor, 4h magnitude) layered with a market-wide funding-regime + funding-persistence macro gate and a smart-money HARD BLOCK — then sizes leverage to conviction (3/5x) and lets the DSL ride the winner.",
       "belief_plain": "Trades only HYPE. It waits for the 4-hour trend to be strong, the 1-hour to not be fighting it, and short-term momentum to confirm — then checks the broader funding 'crowding' regime and refuses to trade when the best traders are leaning the other way. It goes in harder when more factors line up, and trails a stop instead of guessing the exit.",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "thesis": "HYPE is one of the highest-volatility majors on Hyperliquid. A specialist that watches only HYPE can read its trend structure, smart-money flow, funding regime and persistence far more tightly than a broad scanner — and the macro funding-regime gate keeps it out of crowded, liquidation-prone setups that single-asset momentum alone would walk into.",
       "tags": [
         "hype",
@@ -4994,7 +4994,7 @@
       "emoji": "🐕",
       "tagline": "A patient contrarian on BTC/ETH/SOL/HYPE: waits for a major to move 3%+ in 4h while smart money piles in heavily, then fades the crowded, exhausted side — but only when the funding regime confirms the unwind and the move is still fresh. Conservative 7-10x leverage, wide DSL to let the reversal develop.",
       "belief_plain": "When a big coin runs hard and the best traders are all crowded onto the same side, the crowd is maximum exposed and the unwind is the trade. Dog bets against that exhausted consensus on BTC, ETH, SOL and HYPE — but only when the move has genuinely overextended, the crowding is still building, and market-wide funding shows the crowd really is one-sided. Most of the time it waits.",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "thesis": "Hyperliquid is dominated by leverage traders chasing momentum. When a major moves 3%+ in four hours and smart-money consensus piles in 15%+, the late entrants are maximally exposed and funding pressure plus mean reversion force the unwind. Dog's edge is being on the unwind side before capitulation accelerates — so it scores the smart-money direction, hard-gates on exhaustion (>=3% 4h move), freshness (15m contribution still rising), trader depth (>=30), and a funding regime that confirms the crowd is one-sided, then emits the OPPOSITE direction at conservative leverage and lets a wide ratcheting stop ride the reversal rather than banking too early.",
       "tags": [
         "smart-money",

--- a/strategies/dog/main/scanners/scan.py
+++ b/strategies/dog/main/scanners/scan.py
@@ -264,7 +264,10 @@ def scan(inputs, ctx):
             "direction": c["direction"],          # the FADE direction (post contrarian flip)
             "marginPct": margin_pct,              # FLAT PERCENT (0,100] — runtime sizes the dollars
             "leverage": c["leverage"],            # conviction-tiered 7/10x; runtime applies + clamps
-            "data": {
+            # `required: false` in signal_data_schema permits an ABSENT key, never a present-and-null:
+            # the intake discards the WHOLE candidate on a null optional. Drop them here rather than
+            # coercing to 0/"" — a coerced value would assert a measurement that was never taken.
+            "data": {k: v for k, v in {
                 "score": c["score"],
                 "smDirection": c["sm_direction"],
                 "leverage": c["leverage"],
@@ -281,7 +284,7 @@ def scan(inputs, ctx):
                 "crowdingTrend": c["crowding_trend"],
                 "assetFunding": float(c["asset_funding"]),
                 "heldAssets": sorted(held_set),
-            },
+            }.items() if v is not None},
         })
         emitted.append({"asset": c["asset"], "direction": c["direction"],
                         "score": c["score"], "leverage": c["leverage"]})

--- a/strategies/dog/strategy.yaml
+++ b/strategies/dog/strategy.yaml
@@ -7,7 +7,7 @@
 schema_version: 1
 
 id: dog
-version: "1.1.0"
+version: "1.1.1"
 
 catalog:
   name: "Dog — Contrarian Pup (SM Exhaustion Fader)"

--- a/strategies/grizzly/main/scanners/scan.py
+++ b/strategies/grizzly/main/scanners/scan.py
@@ -246,7 +246,10 @@ def scan(inputs, ctx):
                 "direction": th["direction"],
                 "marginPct": margin_pct,          # SIZING INTENT — runtime sizes the dollars
                 "leverage": leverage,             # conviction-tiered (7/10/10); runtime applies it
-                "data": {
+                # `required: false` in signal_data_schema permits an ABSENT key, never a present-and-null:
+                # the intake discards the WHOLE candidate on a null optional. Drop them here rather than
+                # coercing to 0/"" — a coerced value would assert a measurement that was never taken.
+                "data": {k: v for k, v in {
                     "score": th["score"], "tier": tier_label, "leverage": leverage,
                     "direction": th["direction"],
                     "trend4h": th["trend_4h"], "trendStrength4h": th["trend_strength_4h"],
@@ -258,7 +261,7 @@ def scan(inputs, ctx):
                     "priceChange5m": th["mom_5m"], "priceChange15m": th["mom_15m"],
                     "priceChange1h": th["mom_1h"], "priceChange4h": th["mom_4h"],
                     "reasons": th["reasons"],
-                },
+                }.items() if v is not None},
             }]
 
     # ── persist dedup map + this tick's result EVERY tick; self-trims at

--- a/strategies/grizzly/strategy.yaml
+++ b/strategies/grizzly/strategy.yaml
@@ -7,7 +7,7 @@
 schema_version: 1
 
 id: grizzly
-version: "1.1.0"
+version: "1.1.1"
 catalog:
   name: "Grizzly — BTC Alpha Hunter"
   emoji: "🐻"

--- a/strategies/owl/main/scanners/scan.py
+++ b/strategies/owl/main/scanners/scan.py
@@ -469,7 +469,10 @@ def scan(inputs, ctx):
         "direction": best["fade_direction"],            # OPPOSITE of the crowd — Owl is contrarian
         "marginPct": margin_pct,                         # SIZING INTENT — PERCENT (0,100]; runtime sizes USD
         "leverage": leverage,                            # conviction-scaled 7/8/10 (10x cap); runtime clamps
-        "data": {
+        # `required: false` in signal_data_schema permits an ABSENT key, never a present-and-null:
+        # the intake discards the WHOLE candidate on a null optional. Drop them here rather than
+        # coercing to 0/"" — a coerced value would assert a measurement that was never taken.
+        "data": {k: v for k, v in {
             "score": best["combined_score"],
             "leverage": leverage,
             "crowdDirection": best["crowd_direction"],
@@ -485,5 +488,5 @@ def scan(inputs, ctx):
             "peakCrowdingScore": best["peak_crowding_score"],
             "exhaustionSignals": " | ".join(best.get("exhaustion_signals", [])),
             "reasons": best["reasons"],
-        },
+        }.items() if v is not None},
     }]

--- a/strategies/owl/strategy.yaml
+++ b/strategies/owl/strategy.yaml
@@ -7,7 +7,7 @@
 schema_version: 1
 
 id: owl
-version: "1.2.0"
+version: "1.2.1"
 
 catalog:
   name: "Owl — Contrarian Crowding-Unwind Hunter"

--- a/strategies/tests/test_no_null_optional_signal_keys.py
+++ b/strategies/tests/test_no_null_optional_signal_keys.py
@@ -23,11 +23,15 @@ import re
 import sys
 
 import pytest
+import yaml
 
 _ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
-# Optional keys observed to arrive as None from an upstream read that has no row for the asset.
-# Any scanner emitting one of these must drop it when it is None rather than emit a null.
+# REGISTRY, not a detector. These are optional keys OBSERVED to arrive as None from an upstream
+# read with no row for the asset. Whether a key can be null is a property of its upstream, which no
+# static check can know — the fleet declares 310 distinct `required: false` keys and almost none of
+# them ever go null. So this list grows when a new nullable key is found in the wild; it does not
+# pretend to enumerate them in advance. `test_registry_keys_are_really_optional` keeps it honest.
 _NULLABLE_OPTIONAL_KEYS = (
     "persistenceHours",
     "fundingPersistenceHours",
@@ -152,13 +156,33 @@ def _scanners_emitting_nullable_keys():
 
 @pytest.mark.parametrize("rel", _scanners_emitting_nullable_keys())
 def test_every_scanner_emitting_a_nullable_optional_key_drops_nulls(rel):
-    """Fleet guard: any scanner that emits one of the known-nullable optional keys must
-    filter None out of the emitted `data` map. Catches the next package to hit this."""
+    """Fleet guard: a scanner emitting a known-nullable optional key must filter None out of
+    EVERY `data` map it emits.
+
+    Counted per emission site, not once per file: a file-wide substring search passes a scanner
+    that filters one site and forgets a second one added later, which is the regression shape to
+    expect here. Today every one of these scanners has exactly one site — this keeps that true.
+    """
     src = open(os.path.join(os.path.dirname(_ROOT), rel), encoding="utf-8").read()
-    assert re.search(r"if v is not None", src), (
-        f"{rel} emits a nullable optional key but never drops None from `data` — "
-        "the intake will discard every such candidate"
+    sites = len(re.findall(r'"data":\s*\{', src))
+    filtered = len(re.findall(r"\}\.items\(\) if v is not None\}", src))
+    assert sites and filtered == sites, (
+        f"{rel} emits a nullable optional key from {sites} `data` site(s) but only {filtered} "
+        f"drop None — the intake discards every candidate carrying a null optional"
     )
+
+
+def test_registry_keys_are_really_optional_somewhere_in_the_catalog():
+    """A typo in _NULLABLE_OPTIONAL_KEYS would silently select nothing and pass everything. Each
+    registry key must actually be declared `required: false` by some instance."""
+    declared = set()
+    for path in glob.glob(os.path.join(_ROOT, "*", "*", "runtime.yaml")):
+        for sc in (yaml.safe_load(open(path, encoding="utf-8")) or {}).get("scanners") or []:
+            for k, v in (sc.get("signal_data_schema") or {}).items():
+                if isinstance(v, dict) and v.get("required") is False:
+                    declared.add(k)
+    unknown = sorted(set(_NULLABLE_OPTIONAL_KEYS) - declared)
+    assert not unknown, f"registry keys not declared optional anywhere: {unknown} (typo?)"
 
 
 if __name__ == "__main__":

--- a/strategies/tests/test_no_null_optional_signal_keys.py
+++ b/strategies/tests/test_no_null_optional_signal_keys.py
@@ -1,0 +1,165 @@
+"""Catalog-wide guard: a scanner must never emit an optional `data` key whose value is None.
+
+WHY THIS EXISTS (2026-09-04). `signal_data_schema` marks a key `required: false`, which permits
+the key to be **ABSENT** — not present-and-null. The intake validates the emitted envelope and
+discards the WHOLE candidate on a null:
+
+    delivery_candidate_invalid: data key 'persistenceHours' has wrong type
+                                (expected number, got NoneType)
+
+The scanner logs a normal `candidate_rejected` tick, so every error-keyed health check passes while
+the strategy never trades. Measured cost on 2026-09-04: M409673's catalog `dog` discarded **151**
+candidates over 7 days and had not traded in 15 days ($70 ACTIVE); `vulture` users lost 71 + 43 + 11
+more, `grizzly` 1. Three catalog packages emit a nullable optional key when the upstream
+funding-persistence read has no row for the asset — the common real-world case.
+
+Run:
+  python3 -m pytest strategies/tests -q
+  python3 strategies/tests/test_no_null_optional_signal_keys.py
+"""
+import glob
+import os
+import re
+import sys
+
+import pytest
+
+_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+# Optional keys observed to arrive as None from an upstream read that has no row for the asset.
+# Any scanner emitting one of these must drop it when it is None rather than emit a null.
+_NULLABLE_OPTIONAL_KEYS = (
+    "persistenceHours",
+    "fundingPersistenceHours",
+    "crowdingTrend",
+)
+
+
+def _load(pkg, instance="main"):
+    """Import a package's scanner modules with its own scanners/ dir first on sys.path."""
+    d = os.path.join(_ROOT, pkg, instance, "scanners")
+    sys.path.insert(0, d)
+    try:
+        for mod in ("scoring", "scan"):
+            sys.modules.pop(mod, None)
+        import scoring  # noqa: F401
+        import scan
+        return scan
+    finally:
+        sys.path.remove(d)
+
+
+class _FakeState:
+    def __init__(self):
+        self.rows = []
+
+    def append(self, row):
+        self.rows.append(row)
+
+    def last(self):
+        return self.rows[-1] if self.rows else None
+
+    def recent(self, n):
+        return self.rows[-n:]
+
+
+class _FakeMcp:
+    """Canned MCP reads. `market_get_funding_history` returns a row WITHOUT
+    `persistence_hours` — exactly what the live API returns for an asset it has no
+    funding-persistence history for, and the trigger for the null emission."""
+
+    def __init__(self, responses):
+        self.responses = responses
+        self.calls = []
+
+    def call_tool(self, name, args):
+        self.calls.append((name, args))
+        if name not in self.responses:
+            raise AssertionError(f"unexpected tool call {name!r}")
+        return self.responses[name]
+
+
+class _FakeCtx:
+    def __init__(self, responses, wallet="0x" + "ab" * 20):
+        self.senpi_mcp = _FakeMcp(responses)
+        self.wallet = wallet
+        self.state = _FakeState()
+
+
+def _dog_ctx():
+    """One BTC market that clears dog's hard gates (30+ traders, 4h exhaustion >= 3%
+    aligned with SM direction, 15m velocity > 0), with NO funding-persistence row."""
+    market = {
+        "token": "BTC",
+        "dex": "",
+        "direction": "LONG",
+        "pct_of_top_traders_gain": 20.0,
+        "trader_count": 120,
+        "token_price_change_pct_4h": 5.0,
+        "token_price_change_pct_1h": 0.5,
+        "contribution_pct_change_15m": 1.0,
+        "contribution_pct_change_1h": 0.5,
+        "contribution_pct_change_4h": 0.5,
+    }
+    return _FakeCtx({
+        "strategy_get_clearinghouse_state": {
+            "data": {"main": {"marginSummary": {"accountValue": "1000"}, "assetPositions": []}}
+        },
+        "leaderboard_get_markets": {"data": {"markets": [market]}},
+        "market_get_funding_regime": {"data": {"regime": "LONG_CROWDED"}},
+        # row present, persistence_hours ABSENT -> scoring resolves it to None
+        "market_get_funding_history": {"data": {"data": [{"asset": "BTC"}]}},
+        "market_get_asset_data": {"data": {"asset_context": {"funding": 0.001}}},
+    })
+
+
+def test_dog_emits_no_null_data_values_when_funding_persistence_is_missing():
+    """The M409673 defect, end to end: scan() must emit a candidate whose `data` carries
+    no None. Before the fix `persistenceHours` and `crowdingTrend` are both None and the
+    intake discards the candidate."""
+    scan = _load("dog")
+    signals = scan.scan({"minScore": 0}, _dog_ctx())
+
+    assert signals, "fixture must produce at least one emitted signal"
+    for sig in signals:
+        nulls = sorted(k for k, v in sig["data"].items() if v is None)
+        assert not nulls, f"emitted null optional keys {nulls} — intake discards this candidate"
+
+
+def test_dog_keeps_the_optional_key_when_the_value_is_real():
+    """The fix must drop only nulls; a genuine persistence reading still ships."""
+    scan = _load("dog")
+    ctx = _dog_ctx()
+    ctx.senpi_mcp.responses["market_get_funding_history"] = {
+        "data": {"data": [{"asset": "BTC", "persistence_hours": 18, "funding_trend": "DECAYING"}]}
+    }
+    signals = scan.scan({"minScore": 0}, ctx)
+
+    assert signals
+    data = signals[0]["data"]
+    assert data["persistenceHours"] == 18.0
+    assert data["crowdingTrend"] == "DECREASING"
+
+
+def _scanners_emitting_nullable_keys():
+    out = []
+    for path in sorted(glob.glob(os.path.join(_ROOT, "*", "*", "scanners", "scan.py"))):
+        src = open(path, encoding="utf-8").read()
+        if any(f'"{k}"' in src for k in _NULLABLE_OPTIONAL_KEYS):
+            out.append(os.path.relpath(path, os.path.dirname(_ROOT)))
+    return out
+
+
+@pytest.mark.parametrize("rel", _scanners_emitting_nullable_keys())
+def test_every_scanner_emitting_a_nullable_optional_key_drops_nulls(rel):
+    """Fleet guard: any scanner that emits one of the known-nullable optional keys must
+    filter None out of the emitted `data` map. Catches the next package to hit this."""
+    src = open(os.path.join(os.path.dirname(_ROOT), rel), encoding="utf-8").read()
+    assert re.search(r"if v is not None", src), (
+        f"{rel} emits a nullable optional key but never drops None from `data` — "
+        "the intake will discard every such candidate"
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/strategies/vulture/main/scanners/scan.py
+++ b/strategies/vulture/main/scanners/scan.py
@@ -204,7 +204,10 @@ def scan(inputs, ctx):
             "direction": c["direction"],
             "marginPct": margin_pct,          # SIZING INTENT (PERCENT) — runtime sizes the dollars
             "leverage": c["leverage"],        # conviction-tiered (5/7); runtime applies it
-            "data": {
+            # `required: false` in signal_data_schema permits an ABSENT key, never a present-and-null:
+            # the intake discards the WHOLE candidate on a null optional. Drop them here rather than
+            # coercing to 0/"" — a coerced value would assert a measurement that was never taken.
+            "data": {k: v for k, v in {
                 "score": c["score"],
                 "tier": c["tier_label"],
                 "leverage": c["leverage"],
@@ -220,7 +223,7 @@ def scan(inputs, ctx):
                 "contribChange4h": c["c4h"],
                 "fundingRegime": c["regime"],
                 "persistenceHours": c["persistence_hours"],
-            },
+            }.items() if v is not None},
         })
         recent[cu] = now
 

--- a/strategies/vulture/strategy.yaml
+++ b/strategies/vulture/strategy.yaml
@@ -7,7 +7,7 @@
 schema_version: 1
 
 id: vulture                  # == package dir name; == the instance runtime.yaml `group`
-version: "1.2.0"             # single source for catalog + MCP attribution (skillName/skillVersion)
+version: "1.2.1"             # single source for catalog + MCP attribution (skillName/skillVersion)
 
 catalog:                     # discovery surface. `group` here is the discovery TAXONOMY bucket.
   name: "Vulture — Small-Cap Momentum Rider"

--- a/strategies/wolverine/main/scanners/scan.py
+++ b/strategies/wolverine/main/scanners/scan.py
@@ -281,7 +281,10 @@ def scan(inputs, ctx):
                 "direction": th["direction"],
                 "marginPct": margin_pct,          # SIZING INTENT — runtime sizes the dollars
                 "leverage": leverage,             # conviction-tiered (3/5); runtime applies it
-                "data": {
+                # `required: false` in signal_data_schema permits an ABSENT key, never a present-and-null:
+                # the intake discards the WHOLE candidate on a null optional. Drop them here rather than
+                # coercing to 0/"" — a coerced value would assert a measurement that was never taken.
+                "data": {k: v for k, v in {
                     "score": th["score"], "tier": tier_label, "leverage": leverage,
                     "direction": th["direction"],
                     "trend4h": th["trend_4h"], "trendStrength4h": th["trend_strength_4h"],
@@ -296,7 +299,7 @@ def scan(inputs, ctx):
                     "smPct": th["sm_pct"], "smTraders": th["sm_traders"], "smCc15m": th["sm_cc_15m"],
                     "smAligned": th["sm_aligned"],
                     "reasons": th["reasons"],
-                },
+                }.items() if v is not None},
             }]
 
     if ctx.state is not None:

--- a/strategies/wolverine/strategy.yaml
+++ b/strategies/wolverine/strategy.yaml
@@ -7,7 +7,7 @@
 schema_version: 1
 
 id: wolverine
-version: "1.1.0"
+version: "1.1.1"
 catalog:
   name: "Wolverine — HYPE Alpha Hunter"
   emoji: "🦡"


### PR DESCRIPTION
## The bug

`signal_data_schema`'s `required: false` permits a key to be **ABSENT** — not present-and-null. The intake validates the emitted envelope and discards the **whole candidate** on a null optional:

```
delivery_candidate_invalid: data key 'persistenceHours' has wrong type (expected number, got NoneType)
```

The scanner logs an ordinary `candidate_rejected` tick, so every error-keyed health check passes while the strategy silently never trades. Five catalog packages emit a nullable optional key whenever the upstream funding-persistence read has no row for the asset — the common real-world case:

| package | key(s) emitted as null |
|---|---|
| `dog` | `persistenceHours`, `crowdingTrend` |
| `vulture` | `persistenceHours` |
| `grizzly` | `fundingPersistenceHours` |
| `wolverine` | `fundingPersistenceHours` |
| `owl` | `persistenceHours` |

## Measured cost

Telemetry, 7 days to 2026-09-04:

| user | package | candidates discarded | state |
|---|---|---|---|
| M409673 | `dog` | **151** | $70 ACTIVE, **no trade in 15 days** |
| M416826 | `vulture` | 71 | wallets since closed |
| M416733 | `vulture` | 43 | wallets since closed |
| M417390 | `vulture` | 11 | wallets since closed |
| M416809 | `grizzly` | 1 | — |

This is the fourth consecutive daily funnel report to carry it as a live leak, and the sixth distinct user of the flavour.

## The fix

Drop `None`-valued keys from the emitted `data` map at each of the five emission sites.

Deliberately **not** coercing to `0` / `""`: a coerced value asserts a measurement that was never taken, which is worse than an absent optional. A genuine reading still ships unchanged.

## The guard

New `strategies/tests/test_no_null_optional_signal_keys.py`:

1. **Behavioural** — drives `dog.scan()` against a fake ctx whose `market_get_funding_history` row has no `persistence_hours`, the exact M409673 shape. Before this fix it fails with `emitted null optional keys ['crowdingTrend', 'persistenceHours']`.
2. **Companion** — proves the fix drops only nulls: a real 18 h reading still ships as `persistenceHours: 18.0`, `crowdingTrend: "DECREASING"`.
3. **Fleet lint** — parametrised over every `strategies/*/*/scanners/scan.py` that emits one of the known-nullable optional keys, so the next package to hit this fails CI. **The lint is what found `owl` and `wolverine`; a hand-picked list had missed both.**

Wired into `.github/workflows/tests.yml`. Named as an explicit path rather than `strategies`, because a module-level `sys.exit()` in `strategies/chimp/tests/test_package_shape.py` aborts pytest collection for that whole tree — pre-existing, untouched here.

## Verification

```
python3 -m pytest <the workflow's six suites> strategies/tests -q
→ 509 passed, 1 skipped, 45 subtests passed
```

- Red-green re-proven by stashing only the five scanner patches: **6 failed / 1 passed**, then **7 passed** restored.
- Both standalone CI checks pass (min_budget vendor parity, min_budget golden).
- Every existing `strategies/*/tests` suite run individually: unchanged.
- PATCH bump on the five packages; `catalog.json` regenerated via `gen_catalog.py` into both locations (diff is exactly 10 version lines + 2 `_updated`).
- `validate_strategy.py` clean on all five.

**Pre-existing, not touched:** the `chimp` collection abort, and `strategies/starling/tests` 1 failure (`test_ratchet_locks_gains_only_and_never_a_loss` — fails identically on clean `main`).

## Follow-up, not in this PR

- **The intake should also treat `null` as absent** for a `required: false` key. That is the belt-and-braces half; this PR fixes the emitters we own.
- `owl` reads `round(best["persistence_hours"], 2)`, which would raise `TypeError` before reaching the emit if the value were ever `None` — a separate latent path, left alone.
- M409673's box still runs the pre-fix file. Once this merges the deployed copy needs refreshing (`curl -o` the raw catalog file + restart the scanner) before that user trades again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
