### PR TITLE
feat(strategy-author): say what the exit does, in plain words, before building it

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,8 +28,11 @@ jobs:
       # pytest collects every test regardless of a __main__ runner — bare `python3 <file>` exits 0
       # without running anything on a runner-less file (test_default_catalog.py), a silent green.
       # `strategies/tests` holds catalog-wide contract guards (no null optional signal keys).
+      # `senpi-strategy-author/tests` was never listed here, so its suite had never run in CI —
+      # added 2026-09-08 along with the exit-preview guard that keeps SKILL.md's worked ladder
+      # arithmetically true to dsl-presets.yaml.
       # Named explicitly rather than `strategies`: a module-level sys.exit() in
       # strategies/chimp/tests/test_package_shape.py aborts collection for that whole tree
       # (pre-existing, unrelated).
-      - name: full suites (ops + discover + trading-runtime + catalog guards)
-        run: python3 -m pytest senpi-strategy-ops/tests senpi-strategy-discover/tests senpi-trading-runtime/tests senpi-trader-research/tests senpi-market-pulse/tests senpi-portfolio/tests strategies/tests -q
+      - name: full suites (ops + discover + author + trading-runtime + catalog guards)
+        run: python3 -m pytest senpi-strategy-ops/tests senpi-strategy-discover/tests senpi-strategy-author/tests senpi-trading-runtime/tests senpi-trader-research/tests senpi-market-pulse/tests senpi-portfolio/tests strategies/tests -q

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Every analytical skill follows the **hidden-engine pattern**: a vendored, stdlib
 | [`senpi-account-status`](senpi-account-status/) | 1.2.0 | Points, loyalty tier, fees, referrals |
 | **Run a strategy** | | |
 | [`senpi-strategy-discover`](senpi-strategy-discover/) | 2.17.0 | Conversational picker — rank the catalog against your worldview |
-| [`senpi-strategy-author`](senpi-strategy-author/) | 2.4.2 | Build/edit a DSL-protected strategy package, one decision at a time |
+| [`senpi-strategy-author`](senpi-strategy-author/) | 3.2.0 | Build/edit a DSL-protected strategy package, one decision at a time |
 | [`senpi-strategy-ops`](senpi-strategy-ops/) | 2.2.1 | Deploy / monitor / close a named strategy (`deploy.py`, `close.py`) |
 | [`senpi-trade`](senpi-trade/) | 1.0.0 | Direct trade or mirror a specific trader — manual positions + copy trading, one decision at a time |
 | [`senpi-trading-runtime`](senpi-trading-runtime/) | 3.2.1 | The runtime contract reference: `scan(inputs, ctx)`, `runtime.yaml`, DSL |

--- a/README.md
+++ b/README.md
@@ -64,14 +64,14 @@ Every analytical skill follows the **hidden-engine pattern**: a vendored, stdlib
 | [`senpi-market-pulse`](senpi-market-pulse/) | 1.2.0 | Daily cross-asset market read (crypto, equities, commodities, macro, funding regime) |
 | [`senpi-smart-money`](senpi-smart-money/) | 1.2.0 | Where the most-profitable wallets are positioned vs. the crowd |
 | [`senpi-trader-research`](senpi-trader-research/) | 1.4.0 | Rank + vet Hyperliquid traders before copying them (mirror-aware: copyability, min-budget, live book) |
-| [`senpi-improve-trades`](senpi-improve-trades/) | 1.1.1 | Retrospective review + health checks off the **telemetry event log**: exit quality, missed signals, leaks, crashes, "if I'd held" counterfactual |
+| [`senpi-improve-trades`](senpi-improve-trades/) | 1.8.0 | Retrospective review + health checks off the **telemetry event log**: exit quality, missed signals, leaks, crashes, "if I'd held" counterfactual |
 | [`senpi-account-status`](senpi-account-status/) | 1.2.0 | Points, loyalty tier, fees, referrals |
 | **Run a strategy** | | |
-| [`senpi-strategy-discover`](senpi-strategy-discover/) | 2.17.0 | Conversational picker — rank the catalog against your worldview |
+| [`senpi-strategy-discover`](senpi-strategy-discover/) | 2.19.0 | Conversational picker — rank the catalog against your worldview |
 | [`senpi-strategy-author`](senpi-strategy-author/) | 3.2.0 | Build/edit a DSL-protected strategy package, one decision at a time |
-| [`senpi-strategy-ops`](senpi-strategy-ops/) | 2.2.1 | Deploy / monitor / close a named strategy (`deploy.py`, `close.py`) |
+| [`senpi-strategy-ops`](senpi-strategy-ops/) | 3.7.0 | Deploy / monitor / close a named strategy (`deploy.py`, `close.py`) |
 | [`senpi-trade`](senpi-trade/) | 1.0.0 | Direct trade or mirror a specific trader — manual positions + copy trading, one decision at a time |
-| [`senpi-trading-runtime`](senpi-trading-runtime/) | 3.2.1 | The runtime contract reference: `scan(inputs, ctx)`, `runtime.yaml`, DSL |
+| [`senpi-trading-runtime`](senpi-trading-runtime/) | 4.0.0 | The runtime contract reference: `scan(inputs, ctx)`, `runtime.yaml`, DSL |
 | **Move money / positioning** | | |
 | [`senpi-deposit-withdraw-transfer`](senpi-deposit-withdraw-transfer/) | 1.1.0 | The money-movement rails (funds in via embedded wallet or in-app USDC purchase; out via the app) |
 | [`senpi-why`](senpi-why/) | 1.0.3 | "Why Senpi / vs. other tools" — the positioning answer |

--- a/senpi-strategy-author/SKILL.md
+++ b/senpi-strategy-author/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "3.1.0"
+  version: "3.2.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -184,6 +184,13 @@ For each: ask the question, offer the options as plain choices, then map the ans
    (`interval_seconds`). **Never hand-roll stops — copy a preset from
    `senpi-strategy-author/references/dsl-presets.yaml`** (full path — it lives in THIS skill, not the
    runtime package).
+   **Say what the exit DOES before you name a preset**, in plain words: *"Your stop starts below your
+   entry and only ever moves up. As the trade gains it follows behind, locking more of the gain in — so
+   if the price dips you keep most of what you made instead of giving it back. It never sells while the
+   trade is still going your way."* It is **a stop-loss that climbs, not profit-taking**: nothing is
+   sold on the way up and no rung ever closes a winner — a rung only raises the price at which a
+   REVERSAL closes you. Users hear "lock 30% at +20%" as *sell 30% at +20%*, and act on it.
+   Say it every time.
 
 ## After the 7 — build it in STAGES, narrating as you go
 
@@ -201,6 +208,18 @@ the catalog entry, then unit-test → lint → `senpi validate` → hand to ops.
 
 1. **Confirm the spec.** Replay name + thesis + all 7 + opening constraints → get a "yes." *("You said
    rotate the cohort every 3 days — that's in.")* Nothing is written before this yes.
+   **Part of that replay is an EXIT PREVIEW — the ladder as outcomes, never as YAML.** Nobody reads
+   `{trigger_pct: 50, lock_hw_pct: 60}`; everybody reads what it does to their money. Each rung is
+   **floor ROE = the best ROE the trade ever reached × `lock_hw_pct` ÷ 100**, at the highest tier whose
+   `trigger_pct` has been passed. Three or four rungs, the downside floor, and the preset's own time
+   cuts if it has any. Template + worked example + the wording for each mismatch:
+   [`references/explaining-the-exit.md`](references/explaining-the-exit.md).
+   **Sanity-check the ladder first and say so when it doesn't fit** — never silently build what the
+   user can't get, and always offer a concrete alternative rather than a warning: **first rung above
+   ~40% ROE** (most trades never reach it, so nothing is ever locked) · **`lock_hw_pct: 0`** (exits
+   flat, still pays fees) · **locks that shrink as triggers rise** (usually a typo) · **preset against
+   the thesis** (a fader on `let_winners_run`). If they keep their choice after you've explained it,
+   build what they asked for.
 2. **Scaffold.** Match the idea to an archetype row in `references/creating-a-strategy.md`, create the
    package dirs **under the durable strategies root** — `/data/workspace/strategies/<id>/`
    (`SENPI_STRATEGIES_DIR` overrides), **NEVER inside a managed skill directory** (skill updates

--- a/senpi-strategy-author/SKILL.md
+++ b/senpi-strategy-author/SKILL.md
@@ -184,13 +184,13 @@ For each: ask the question, offer the options as plain choices, then map the ans
    (`interval_seconds`). **Never hand-roll stops — copy a preset from
    `senpi-strategy-author/references/dsl-presets.yaml`** (full path — it lives in THIS skill, not the
    runtime package).
-   **Say what the exit DOES before you name a preset**, in plain words: *"Your stop starts below your
-   entry and only ever moves up. As the trade gains it follows behind, locking more of the gain in — so
-   if the price dips you keep most of what you made instead of giving it back. It never sells while the
-   trade is still going your way."* It is **a stop-loss that climbs, not profit-taking**: nothing is
-   sold on the way up and no rung ever closes a winner — a rung only raises the price at which a
-   REVERSAL closes you. Users hear "lock 30% at +20%" as *sell 30% at +20%*, and act on it.
-   Say it every time.
+   **Say what the exit DOES before you name a preset**, in plain words: *"Your Dynamic Stop Loss (DSL)
+   moves your stop loss up as the price moves in your favor (up for long, down for short). As the trade
+   gains it follows behind, locking more of the gain in — so if the price dips you keep most of what you
+   made instead of giving it back. It never sells while the trade is still going your way."* It is
+   **a stop-loss that follows, not profit-taking**: nothing is sold on the way up and no rung ever
+   closes a winner — a rung only raises the price at which a REVERSAL closes you. Users hear "lock 30%
+   at +20%" as *sell 30% at +20%*. Say it every time.
 
 ## After the 7 — build it in STAGES, narrating as you go
 
@@ -211,8 +211,8 @@ the catalog entry, then unit-test → lint → `senpi validate` → hand to ops.
    **Part of that replay is an EXIT PREVIEW — the ladder as outcomes, never as YAML.** Nobody reads
    `{trigger_pct: 50, lock_hw_pct: 60}`; everybody reads what it does to their money. Each rung is
    **floor ROE = the best ROE the trade ever reached × `lock_hw_pct` ÷ 100**, at the highest tier whose
-   `trigger_pct` has been passed. Three or four rungs, the downside floor, and the preset's own time
-   cuts if it has any. Template + worked example + the wording for each mismatch:
+   `trigger_pct` has been passed. Lead with the downside floor — where the trade is now — then climb,
+   and add the preset's own time cuts if it has any. Template + worked example + the wording for each mismatch:
    [`references/explaining-the-exit.md`](references/explaining-the-exit.md).
    **Sanity-check the ladder first and say so when it doesn't fit** — never silently build what the
    user can't get, and always offer a concrete alternative rather than a warning: **first rung above

--- a/senpi-strategy-author/SKILL.md
+++ b/senpi-strategy-author/SKILL.md
@@ -186,11 +186,10 @@ For each: ask the question, offer the options as plain choices, then map the ans
    runtime package).
    **Say what the exit DOES before you name a preset**, in plain words: *"Your Dynamic Stop Loss (DSL)
    moves your stop loss up as the price moves in your favor (up for long, down for short). As the trade
-   gains it follows behind, locking more of the gain in — so if the price dips you keep most of what you
-   made instead of giving it back. It never sells while the trade is still going your way."* It is
-   **a stop-loss that follows, not profit-taking**: nothing is sold on the way up and no rung ever
-   closes a winner — a rung only raises the price at which a REVERSAL closes you. Users hear "lock 30%
-   at +20%" as *sell 30% at +20%*. Say it every time.
+   gains it follows behind, locking more of the gain in. It never sells while the trade is still going
+   your way."* It is **a stop-loss that follows, not profit-taking**: nothing is sold on the way up and
+   no rung ever closes a winner — a rung only raises the price at which a REVERSAL closes you. Users
+   hear "lock 30% at +20%" as *sell 30% at +20%*. Say it every time.
 
 ## After the 7 — build it in STAGES, narrating as you go
 

--- a/senpi-strategy-author/references/explaining-the-exit.md
+++ b/senpi-strategy-author/references/explaining-the-exit.md
@@ -46,15 +46,15 @@ behaves, then the preset's own time cuts.
 > nothing is sold while the trade is still climbing.
 
 That worked example is `let_winners_run`, which carries **no time cuts**. Add a line for the ones the
-chosen preset actually has — read them out of `dsl-presets.yaml`, do not recall them:
+chosen preset actually has — each row names the cut and its real duration, checked against `dsl-presets.yaml` by the test:
 
 | preset | time cuts to mention |
 |---|---|
 | `let_winners_run` | none |
-| `balanced` | flat-and-fading for 6h → out · 72h → out |
-| `mean_reversion` | flat-and-fading for 6h → out · hard timeout |
-| `scalp` | dead weight after 8h → out · hard timeout |
-| `parabolic_runner` | hard timeout only (14d) |
+| `balanced` | flat-and-fading `weak_peak_cut 6h` · outer bound `hard_timeout 72h` |
+| `mean_reversion` | flat-and-fading `weak_peak_cut 2h` · outer bound `hard_timeout 48h` |
+| `scalp` | flat-since-entry `dead_weight_cut 45m` · outer bound `hard_timeout 90m` |
+| `parabolic_runner` | outer bound `hard_timeout 336h` |
 
 ## When the ladder doesn't fit — offer, don't just warn
 

--- a/senpi-strategy-author/references/explaining-the-exit.md
+++ b/senpi-strategy-author/references/explaining-the-exit.md
@@ -11,9 +11,8 @@ Say what the exit does, in their words, before you build it.
 ## The one sentence, every time
 
 > Your Dynamic Stop Loss (DSL) moves your stop loss up as the price moves in your favor (up for long,
-> down for short). As the trade gains it follows behind, locking more of the gain in — so if the price
-> dips you keep most of what you made instead of giving it back. It never sells while the trade is
-> still going your way.
+> down for short). As the trade gains it follows behind, locking more of the gain in. It never sells
+> while the trade is still going your way.
 
 The parenthetical is doing real work on a short book. The stop always climbs in **ROE** terms, but in
 **price** terms a short's floor sits above entry and falls as the trade wins — `roeToPriceFloor`

--- a/senpi-strategy-author/references/explaining-the-exit.md
+++ b/senpi-strategy-author/references/explaining-the-exit.md
@@ -1,0 +1,80 @@
+# Explaining the exit — the preview you show before you build
+
+The exit is the part users misread most, and the misreading costs them money. The classic shape:
+someone sets `lock 10% at +100%` believing it means *take 10% profit at +100%*. It actually means
+*once you are up 100%, put the stop at 10% of your best*. A trade that peaks at +93% never reaches
+that only rung, so nothing is ever locked and the entire gain round-trips to the stop. The config is
+valid, the strategy reports healthy, and the user finds out afterwards.
+
+Say what the exit does, in their words, before you build it.
+
+## The one sentence, every time
+
+> Your stop starts below your entry and only ever moves up. As the trade gains it follows behind,
+> locking more of the gain in — so if the price dips you keep most of what you made instead of
+> giving it back. It never sells while the trade is still going your way.
+
+**It is a stop-loss that climbs, not profit-taking.** Nothing is sold on the way up. No rung ever
+closes a winner. A rung only raises the price at which a *reversal* closes you. If the user says
+"take profit at X" anywhere in the conversation, correct the framing before you set a number.
+
+## The arithmetic (from the engine, not from memory)
+
+`src/dsl/engine/floors.ts` in senpi-trading-runtime:
+
+- `tierIndexFromPrice` — the active rung is the **highest** tier whose `trigger_pct` the ROE has
+  reached. Below the first trigger there is no rung at all.
+- `computeTierFloor` — `floorRoe = highWaterRoe × lock_hw_pct / 100`.
+
+Two consequences worth saying out loud, because both surprise people:
+
+1. The floor tracks the **high-water** ROE — the best the trade ever reached — not where it is now.
+2. Below the first `trigger_pct` nothing is locked; the only floor is `phase1.max_loss_pct`
+   (`phase1.enabled: false` fleet-wide, so the trailing floor does not apply).
+
+## The template
+
+Three or four rungs, the downside, how it behaves, then the preset's own time cuts.
+
+> **What your exit will actually do**
+> • Up 20% → your stop moves to **+5%**. From here the trade can't lose money.
+> • Up 50% → your stop moves to **+30%**.
+> • Up 100% → your stop moves to **+85%**.
+> • Below +20% → nothing is locked in yet; your only floor is the **−8% max loss**.
+>
+> The stop follows the **best** price the trade ever hit, not where it is now — peak at +50%, drift
+> back to +35%, and that +30% stop is still the one holding. It only moves up, never down, and
+> nothing is sold while the trade is still climbing.
+
+That worked example is `let_winners_run`, which carries **no time cuts**. Add a line for the ones the
+chosen preset actually has — read them out of `dsl-presets.yaml`, do not recall them:
+
+| preset | time cuts to mention |
+|---|---|
+| `let_winners_run` | none |
+| `balanced` | flat-and-fading for 6h → out · 72h → out |
+| `mean_reversion` | flat-and-fading for 6h → out · hard timeout |
+| `scalp` | dead weight after 8h → out · hard timeout |
+| `parabolic_runner` | hard timeout only (14d) |
+
+## When the ladder doesn't fit — offer, don't just warn
+
+Every one of these ends in a concrete alternative the user can say yes to.
+
+**First rung above ~40% ROE.** Most trades never get there, so the position runs its whole life with
+nothing locked in. No shipped preset trips this — it catches hand-rolled ladders.
+> "Your first lock is at +100%. A trade that peaks at +93% locks nothing and can ride all the way
+> back down to your stop. `balanced` starts locking at +10%. Want that instead?"
+
+**`lock_hw_pct: 0`.** Exits flat and still pays both sides of the fee, so a "scratch" is a loss.
+Never ship one; there is no reading of the user's intent that this serves.
+
+**Locks that shrink as triggers rise** (`50` then `30`). The ladder loosens as the trade wins, which
+is backwards. Almost always a typo for the reverse order — read it back and ask.
+
+**Preset against the thesis.** A fader on `let_winners_run`, a multi-day trend on `scalp`.
+> "You described fading spikes, and those resolve in hours — `mean_reversion` banks at +5% instead of
+> waiting for +20%."
+
+If the user keeps their choice after you have explained it, build what they asked for. The rule is
+that they choose knowingly, not that they choose what you would.

--- a/senpi-strategy-author/references/explaining-the-exit.md
+++ b/senpi-strategy-author/references/explaining-the-exit.md
@@ -1,27 +1,20 @@
 # Explaining the exit — the preview you show before you build
 
-The exit is the part users misread most, and the misreading costs them money. The classic shape:
-someone sets `lock 10% at +100%` believing it means *take 10% profit at +100%*. It actually means
-*once you are up 100%, put the stop at 10% of your best*. A trade that peaks at +93% never reaches
-that only rung, so nothing is ever locked and the entire gain round-trips to the stop. The config is
-valid, the strategy reports healthy, and the user finds out afterwards.
+`lock 10% at +100%` reads as *take 10% profit at +100%*. It means *once you are up 100%, put the
+stop at 10% of your best*. A trade peaking at +93% never reaches that only rung, so nothing is ever
+locked and the whole gain round-trips. The config is valid and reports healthy the entire way down.
 
-Say what the exit does, in their words, before you build it.
+## The sentence
 
-## The one sentence, every time
+Lives in SKILL.md decision 7 — one copy, said every time. Don't restate it here; two copies of a
+sentence is the exact drift this file exists to stop.
 
-> Your Dynamic Stop Loss (DSL) moves your stop loss up as the price moves in your favor (up for long,
-> down for short). As the trade gains it follows behind, locking more of the gain in. It never sells
-> while the trade is still going your way.
+The parenthetical ("up for long, down for short") is doing real work on a short book: the stop always
+climbs in **ROE** terms, but in **price** terms a short's floor sits above entry and falls as the
+trade wins (`roeToPriceFloor` branches on direction).
 
-The parenthetical is doing real work on a short book. The stop always climbs in **ROE** terms, but in
-**price** terms a short's floor sits above entry and falls as the trade wins — `roeToPriceFloor`
-branches on direction. Keep it; a short-seller told "your stop moves up as the price increases" will
-read it as backwards and lose confidence in the whole preview.
-
-**It is a stop-loss that climbs, not profit-taking.** Nothing is sold on the way up. No rung ever
-closes a winner. A rung only raises the price at which a *reversal* closes you. If the user says
-"take profit at X" anywhere in the conversation, correct the framing before you set a number.
+**It is a stop-loss that follows, not profit-taking.** Nothing is sold on the way up; no rung ever
+closes a winner. If the user says "take profit at X", correct the framing before you set a number.
 
 ## The arithmetic (from the engine, not from memory)
 

--- a/senpi-strategy-author/references/explaining-the-exit.md
+++ b/senpi-strategy-author/references/explaining-the-exit.md
@@ -10,9 +10,15 @@ Say what the exit does, in their words, before you build it.
 
 ## The one sentence, every time
 
-> Your stop starts below your entry and only ever moves up. As the trade gains it follows behind,
-> locking more of the gain in — so if the price dips you keep most of what you made instead of
-> giving it back. It never sells while the trade is still going your way.
+> Your Dynamic Stop Loss (DSL) moves your stop loss up as the price moves in your favor (up for long,
+> down for short). As the trade gains it follows behind, locking more of the gain in — so if the price
+> dips you keep most of what you made instead of giving it back. It never sells while the trade is
+> still going your way.
+
+The parenthetical is doing real work on a short book. The stop always climbs in **ROE** terms, but in
+**price** terms a short's floor sits above entry and falls as the trade wins — `roeToPriceFloor`
+branches on direction. Keep it; a short-seller told "your stop moves up as the price increases" will
+read it as backwards and lose confidence in the whole preview.
 
 **It is a stop-loss that climbs, not profit-taking.** Nothing is sold on the way up. No rung ever
 closes a winner. A rung only raises the price at which a *reversal* closes you. If the user says
@@ -34,13 +40,14 @@ Two consequences worth saying out loud, because both surprise people:
 
 ## The template
 
-Three or four rungs, the downside, how it behaves, then the preset's own time cuts.
+Lead with where the trade is now — the downside floor — then climb. Rungs, then how it
+behaves, then the preset's own time cuts.
 
-> **What your exit will actually do**
+> **Here's the DSL settings on this strategy**
+> • Below +20% → nothing is locked in yet; your only floor is the **−8% max loss**.
 > • Up 20% → your stop moves to **+5%**. From here the trade can't lose money.
 > • Up 50% → your stop moves to **+30%**.
 > • Up 100% → your stop moves to **+85%**.
-> • Below +20% → nothing is locked in yet; your only floor is the **−8% max loss**.
 >
 > The stop follows the **best** price the trade ever hit, not where it is now — peak at +50%, drift
 > back to +35%, and that +30% stop is still the one holding. It only moves up, never down, and

--- a/senpi-strategy-author/tests/test_exit_preview_matches_presets.py
+++ b/senpi-strategy-author/tests/test_exit_preview_matches_presets.py
@@ -1,19 +1,11 @@
-"""The exit preview in explaining-the-exit.md must stay arithmetically true to dsl-presets.yaml.
+"""Every number in references/explaining-the-exit.md must be derivable from dsl-presets.yaml.
 
-WHY THIS EXISTS (2026-09-08). `references/dsl-configuration.md` drifted away from
-`references/dsl-presets.yaml` in the same directory and spent weeks teaching ladders the presets
-had already banned (`phase1.enabled: true`, `lock_hw_pct: 0` rungs). A worked example in prose has
-no compiler, so it rots silently and the agent teaches the user numbers that are no longer real.
+references/dsl-configuration.md drifted from dsl-presets.yaml in the same directory and spent weeks
+teaching ladders the presets had already banned. Prose has no compiler; this is one.
 
-SKILL.md's confirm step now shows users a worked `let_winners_run` preview. These tests recompute
-that example from the preset file using the engine's own formula, so the day someone retunes a
-preset the doc fails instead of lying:
-
-    floor ROE = high-water ROE x lock_hw_pct / 100        (dsl/engine/floors.ts computeTierFloor)
-    active tier = highest tier whose trigger_pct is <= ROE (dsl/engine/floors.ts tierIndexFromPrice)
-
-Run:
-  python3 -m pytest senpi-strategy-author/tests/test_exit_preview_matches_presets.py -q
+Engine (senpi-trading-runtime src/dsl/engine/floors.ts):
+  active rung = highest tier whose trigger_pct <= ROE   (tierIndexFromPrice)
+  floor ROE   = high-water ROE x lock_hw_pct / 100      (computeTierFloor)
 """
 import pathlib
 import re
@@ -22,115 +14,52 @@ import pytest
 import yaml
 
 _REFS = pathlib.Path(__file__).resolve().parents[1] / "references"
-_GUIDE = _REFS / "explaining-the-exit.md"
-_PRESETS = _REFS / "dsl-presets.yaml"
-
-_PRESET_IN_PREVIEW = "let_winners_run"
-
-_GUIDE_TEXT = _GUIDE.read_text(encoding="utf-8")
-_PRESETS_DOC = yaml.safe_load(_PRESETS.read_text(encoding="utf-8"))["presets"]
+_GUIDE = (_REFS / "explaining-the-exit.md").read_text(encoding="utf-8")
+_PRESETS = yaml.safe_load((_REFS / "dsl-presets.yaml").read_text(encoding="utf-8"))["presets"]
+_WORKED = "let_winners_run"  # the preset the template is worked in
 
 
 def _tiers(name):
-    """[(trigger_pct, lock_hw_pct), ...] for one preset, in file order."""
-    return [
-        (t["trigger_pct"], t["lock_hw_pct"])
-        for t in _PRESETS_DOC[name]["dsl_preset"]["phase2"]["tiers"]
-    ]
+    return [(t["trigger_pct"], t["lock_hw_pct"])
+            for t in _PRESETS[name]["dsl_preset"]["phase2"]["tiers"]]
 
 
-def _floor_roe(name, roe):
-    """The engine's floor at `roe`, or None when no tier has been reached yet."""
-    active = None
-    for trigger, lock in _tiers(name):          # tierIndexFromPrice: LAST tier at or below roe
-        if roe >= trigger:
-            active = lock
-    if active is None:
-        return None
-    return roe * active / 100                   # computeTierFloor
+def test_every_number_in_the_template_comes_from_the_preset():
+    """The rungs, the 'nothing locked below N%' line, and the max-loss floor."""
+    rungs = [(int(a), int(b)) for a, b in
+             re.findall(r"Up (\d+)% . your stop moves to \*\*\+(\d+)%\*\*", _GUIDE)]
+    assert rungs, "no 'Up N% -> your stop moves to +M%' lines found — template gone or reworded"
 
-
-def _preview_rungs():
-    """[(up_pct, stop_pct), ...] as explaining-the-exit.md promises them to the user."""
-    return [
-        (int(a), int(b))
-        for a, b in re.findall(r"Up (\d+)% . your stop moves to \*\*\+(\d+)%\*\*", _GUIDE_TEXT)
-    ]
-
-
-def test_the_preview_is_still_in_the_skill():
-    """Guard the guard: a preview that got deleted or reworded must not pass vacuously."""
-    assert _preview_rungs(), "no 'Up N% -> your stop moves to +M%' lines found in explaining-the-exit.md"
-
-
-@pytest.mark.parametrize("up,promised", _preview_rungs())
-def test_each_rung_matches_the_engine_arithmetic(up, promised):
-    """Every number shown to a user must be what the DSL engine would actually do."""
-    expected = _floor_roe(_PRESET_IN_PREVIEW, up)
-    assert expected is not None, f"explaining-the-exit.md claims a stop at +{up}% ROE but no tier has fired there"
-    assert expected == pytest.approx(promised), (
-        f"explaining-the-exit.md tells the user 'up {up}% -> stop at +{promised}%', but {_PRESET_IN_PREVIEW} "
-        f"gives +{expected:g}%. Re-derive the preview from dsl-presets.yaml."
-    )
-
-
-def test_the_no_lock_yet_threshold_is_the_first_trigger():
-    """'Below +N% nothing is locked in' has to be the preset's own first rung."""
-    first_trigger = _tiers(_PRESET_IN_PREVIEW)[0][0]
-    assert re.search(rf"Below \+{first_trigger}% . nothing is locked in", _GUIDE_TEXT), (
-        f"{_PRESET_IN_PREVIEW}'s first tier is +{first_trigger}%; explaining-the-exit.md's 'Below +N%' line disagrees"
-    )
-
-
-def test_the_downside_number_is_the_presets_max_loss():
-    """The floor quoted under the ladder must be the preset's real max_loss_pct."""
-    max_loss = _PRESETS_DOC[_PRESET_IN_PREVIEW]["dsl_preset"]["phase1"]["max_loss_pct"]
-    shown = re.search(r"only floor is the \*\*.(\d+)% max loss\*\*", _GUIDE_TEXT)
-    assert shown, "explaining-the-exit.md no longer states the max-loss floor under the ladder"
-    assert int(shown.group(1)) == int(max_loss), (
-        f"explaining-the-exit.md shows a {shown.group(1)}% max loss; {_PRESET_IN_PREVIEW} carries {max_loss}%"
-    )
-
-
-def test_the_preview_preset_still_has_no_time_cuts():
-    """explaining-the-exit.md tells the agent let_winners_run has none — so it must not grow one silently."""
-    dsl = _PRESETS_DOC[_PRESET_IN_PREVIEW]["dsl_preset"]
-    live = [k for k in ("hard_timeout", "weak_peak_cut", "dead_weight_cut")
-            if isinstance(dsl.get(k), dict) and dsl[k].get("enabled")]
-    assert not live, (
-        f"{_PRESET_IN_PREVIEW} now carries {live}; explaining-the-exit.md says it has none. "
-        "Update the preview's time-cut line."
-    )
-
-
-def test_no_shipped_preset_trips_the_unreachable_first_rung_rule():
-    """The ~40% warning must fire on hand-rolled ladders only, never on our own presets."""
-    offenders = {n: _tiers(n)[0][0] for n in _PRESETS_DOC if _tiers(n)[0][0] > 40}
-    assert not offenders, (
-        f"these presets would trigger explaining-the-exit.md's own 'first rung above ~40%' warning: {offenders}"
-    )
-
-
-def test_no_shipped_preset_carries_a_breakeven_rung():
-    """`lock_hw_pct: 0` exits flat and still pays fees — banned fleet-wide, and explaining-the-exit.md says so."""
-    offenders = {n: t for n in _PRESETS_DOC for t in _tiers(n) if t[1] == 0}
-    assert not offenders, f"lock_hw_pct: 0 rungs found: {offenders}"
-
-
-def test_the_time_cut_table_matches_the_presets():
-    """The table tells the agent which cuts to mention per preset; a retune must not silently
-    make it wrong — that is exactly how dsl-configuration.md rotted."""
-    for name, preset in _PRESETS_DOC.items():
-        dsl = preset["dsl_preset"]
-        live = {k for k in ("hard_timeout", "weak_peak_cut", "dead_weight_cut")
-                if isinstance(dsl.get(k), dict) and dsl[k].get("enabled")}
-        row = re.search(rf"^\| `{re.escape(name)}` \| (.+?) \|$", _GUIDE_TEXT, re.M)
-        assert row, f"{name} has no row in the time-cut table"
-        claims_none = row.group(1).strip() == "none"
-        assert claims_none == (not live), (
-            f"time-cut table says {name} is '{row.group(1).strip()}' but the preset carries "
-            f"{sorted(live) or 'nothing'}"
+    for up, promised in rungs:
+        active = max((lock for trig, lock in _tiers(_WORKED) if up >= trig), default=None)
+        assert active is not None, f"template claims a stop at +{up}% but no tier has fired there"
+        assert up * active / 100 == pytest.approx(promised), (
+            f"template says 'up {up}% -> stop at +{promised}%'; {_WORKED} gives "
+            f"+{up * active / 100:g}%. Re-derive from dsl-presets.yaml."
         )
+
+    first = _tiers(_WORKED)[0][0]
+    assert re.search(rf"Below \+{first}% . nothing is locked in", _GUIDE), \
+        f"{_WORKED}'s first tier is +{first}%; the 'Below +N%' line disagrees"
+
+    max_loss = _PRESETS[_WORKED]["dsl_preset"]["phase1"]["max_loss_pct"]
+    shown = re.search(r"only floor is the \*\*.(\d+)% max loss\*\*", _GUIDE)
+    assert shown and int(shown.group(1)) == int(max_loss), \
+        f"template shows {shown and shown.group(1)}% max loss; {_WORKED} carries {max_loss}%"
+
+
+@pytest.mark.parametrize("name", sorted(_PRESETS))
+def test_the_time_cut_table_agrees_on_whether_a_preset_has_cuts(name):
+    """Row says "none" iff the preset has no cuts. Deliberately none-vs-some, not which ones:
+    the row is prose and the value that matters is let_winners_run (the worked template) staying
+    cut-free. ponytail: widen to per-cut matching only if a row is ever wrong in detail."""
+    dsl = _PRESETS[name]["dsl_preset"]
+    live = {k for k in ("hard_timeout", "weak_peak_cut", "dead_weight_cut")
+            if isinstance(dsl.get(k), dict) and dsl[k].get("enabled")}
+    row = re.search(rf"^\| `{re.escape(name)}` \| (.+?) \|$", _GUIDE, re.M)
+    assert row, f"{name} has no row in the time-cut table"
+    assert (row.group(1).strip() == "none") == (not live), \
+        f"table says {name} is '{row.group(1).strip()}' but it carries {sorted(live) or 'nothing'}"
 
 
 if __name__ == "__main__":

--- a/senpi-strategy-author/tests/test_exit_preview_matches_presets.py
+++ b/senpi-strategy-author/tests/test_exit_preview_matches_presets.py
@@ -1,0 +1,137 @@
+"""The exit preview in explaining-the-exit.md must stay arithmetically true to dsl-presets.yaml.
+
+WHY THIS EXISTS (2026-09-08). `references/dsl-configuration.md` drifted away from
+`references/dsl-presets.yaml` in the same directory and spent weeks teaching ladders the presets
+had already banned (`phase1.enabled: true`, `lock_hw_pct: 0` rungs). A worked example in prose has
+no compiler, so it rots silently and the agent teaches the user numbers that are no longer real.
+
+SKILL.md's confirm step now shows users a worked `let_winners_run` preview. These tests recompute
+that example from the preset file using the engine's own formula, so the day someone retunes a
+preset the doc fails instead of lying:
+
+    floor ROE = high-water ROE x lock_hw_pct / 100        (dsl/engine/floors.ts computeTierFloor)
+    active tier = highest tier whose trigger_pct is <= ROE (dsl/engine/floors.ts tierIndexFromPrice)
+
+Run:
+  python3 -m pytest senpi-strategy-author/tests/test_exit_preview_matches_presets.py -q
+"""
+import pathlib
+import re
+
+import pytest
+import yaml
+
+_REFS = pathlib.Path(__file__).resolve().parents[1] / "references"
+_GUIDE = _REFS / "explaining-the-exit.md"
+_PRESETS = _REFS / "dsl-presets.yaml"
+
+_PRESET_IN_PREVIEW = "let_winners_run"
+
+_GUIDE_TEXT = _GUIDE.read_text(encoding="utf-8")
+_PRESETS_DOC = yaml.safe_load(_PRESETS.read_text(encoding="utf-8"))["presets"]
+
+
+def _tiers(name):
+    """[(trigger_pct, lock_hw_pct), ...] for one preset, in file order."""
+    return [
+        (t["trigger_pct"], t["lock_hw_pct"])
+        for t in _PRESETS_DOC[name]["dsl_preset"]["phase2"]["tiers"]
+    ]
+
+
+def _floor_roe(name, roe):
+    """The engine's floor at `roe`, or None when no tier has been reached yet."""
+    active = None
+    for trigger, lock in _tiers(name):          # tierIndexFromPrice: LAST tier at or below roe
+        if roe >= trigger:
+            active = lock
+    if active is None:
+        return None
+    return roe * active / 100                   # computeTierFloor
+
+
+def _preview_rungs():
+    """[(up_pct, stop_pct), ...] as explaining-the-exit.md promises them to the user."""
+    return [
+        (int(a), int(b))
+        for a, b in re.findall(r"Up (\d+)% . your stop moves to \*\*\+(\d+)%\*\*", _GUIDE_TEXT)
+    ]
+
+
+def test_the_preview_is_still_in_the_skill():
+    """Guard the guard: a preview that got deleted or reworded must not pass vacuously."""
+    assert _preview_rungs(), "no 'Up N% -> your stop moves to +M%' lines found in explaining-the-exit.md"
+
+
+@pytest.mark.parametrize("up,promised", _preview_rungs())
+def test_each_rung_matches_the_engine_arithmetic(up, promised):
+    """Every number shown to a user must be what the DSL engine would actually do."""
+    expected = _floor_roe(_PRESET_IN_PREVIEW, up)
+    assert expected is not None, f"explaining-the-exit.md claims a stop at +{up}% ROE but no tier has fired there"
+    assert expected == pytest.approx(promised), (
+        f"explaining-the-exit.md tells the user 'up {up}% -> stop at +{promised}%', but {_PRESET_IN_PREVIEW} "
+        f"gives +{expected:g}%. Re-derive the preview from dsl-presets.yaml."
+    )
+
+
+def test_the_no_lock_yet_threshold_is_the_first_trigger():
+    """'Below +N% nothing is locked in' has to be the preset's own first rung."""
+    first_trigger = _tiers(_PRESET_IN_PREVIEW)[0][0]
+    assert re.search(rf"Below \+{first_trigger}% . nothing is locked in", _GUIDE_TEXT), (
+        f"{_PRESET_IN_PREVIEW}'s first tier is +{first_trigger}%; explaining-the-exit.md's 'Below +N%' line disagrees"
+    )
+
+
+def test_the_downside_number_is_the_presets_max_loss():
+    """The floor quoted under the ladder must be the preset's real max_loss_pct."""
+    max_loss = _PRESETS_DOC[_PRESET_IN_PREVIEW]["dsl_preset"]["phase1"]["max_loss_pct"]
+    shown = re.search(r"only floor is the \*\*.(\d+)% max loss\*\*", _GUIDE_TEXT)
+    assert shown, "explaining-the-exit.md no longer states the max-loss floor under the ladder"
+    assert int(shown.group(1)) == int(max_loss), (
+        f"explaining-the-exit.md shows a {shown.group(1)}% max loss; {_PRESET_IN_PREVIEW} carries {max_loss}%"
+    )
+
+
+def test_the_preview_preset_still_has_no_time_cuts():
+    """explaining-the-exit.md tells the agent let_winners_run has none — so it must not grow one silently."""
+    dsl = _PRESETS_DOC[_PRESET_IN_PREVIEW]["dsl_preset"]
+    live = [k for k in ("hard_timeout", "weak_peak_cut", "dead_weight_cut")
+            if isinstance(dsl.get(k), dict) and dsl[k].get("enabled")]
+    assert not live, (
+        f"{_PRESET_IN_PREVIEW} now carries {live}; explaining-the-exit.md says it has none. "
+        "Update the preview's time-cut line."
+    )
+
+
+def test_no_shipped_preset_trips_the_unreachable_first_rung_rule():
+    """The ~40% warning must fire on hand-rolled ladders only, never on our own presets."""
+    offenders = {n: _tiers(n)[0][0] for n in _PRESETS_DOC if _tiers(n)[0][0] > 40}
+    assert not offenders, (
+        f"these presets would trigger explaining-the-exit.md's own 'first rung above ~40%' warning: {offenders}"
+    )
+
+
+def test_no_shipped_preset_carries_a_breakeven_rung():
+    """`lock_hw_pct: 0` exits flat and still pays fees — banned fleet-wide, and explaining-the-exit.md says so."""
+    offenders = {n: t for n in _PRESETS_DOC for t in _tiers(n) if t[1] == 0}
+    assert not offenders, f"lock_hw_pct: 0 rungs found: {offenders}"
+
+
+def test_the_time_cut_table_matches_the_presets():
+    """The table tells the agent which cuts to mention per preset; a retune must not silently
+    make it wrong — that is exactly how dsl-configuration.md rotted."""
+    for name, preset in _PRESETS_DOC.items():
+        dsl = preset["dsl_preset"]
+        live = {k for k in ("hard_timeout", "weak_peak_cut", "dead_weight_cut")
+                if isinstance(dsl.get(k), dict) and dsl[k].get("enabled")}
+        row = re.search(rf"^\| `{re.escape(name)}` \| (.+?) \|$", _GUIDE_TEXT, re.M)
+        assert row, f"{name} has no row in the time-cut table"
+        claims_none = row.group(1).strip() == "none"
+        assert claims_none == (not live), (
+            f"time-cut table says {name} is '{row.group(1).strip()}' but the preset carries "
+            f"{sorted(live) or 'nothing'}"
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/senpi-strategy-author/tests/test_exit_preview_matches_presets.py
+++ b/senpi-strategy-author/tests/test_exit_preview_matches_presets.py
@@ -26,15 +26,15 @@ def _tiers(name):
 
 def test_every_number_in_the_template_comes_from_the_preset():
     """The rungs, the 'nothing locked below N%' line, and the max-loss floor."""
-    rungs = [(int(a), int(b)) for a, b in
-             re.findall(r"Up (\d+)% . your stop moves to \*\*\+(\d+)%\*\*", _GUIDE)]
+    rungs = [(float(a), float(b)) for a, b in
+             re.findall(r"Up ([\d.]+)% . your stop moves to \*\*\+([\d.]+)%\*\*", _GUIDE)]
     assert rungs, "no 'Up N% -> your stop moves to +M%' lines found — template gone or reworded"
 
     for up, promised in rungs:
         active = max((lock for trig, lock in _tiers(_WORKED) if up >= trig), default=None)
-        assert active is not None, f"template claims a stop at +{up}% but no tier has fired there"
+        assert active is not None, f"template claims a stop at +{up:g}% but no tier has fired there"
         assert up * active / 100 == pytest.approx(promised), (
-            f"template says 'up {up}% -> stop at +{promised}%'; {_WORKED} gives "
+            f"template says 'up {up:g}% -> stop at +{promised:g}%'; {_WORKED} gives "
             f"+{up * active / 100:g}%. Re-derive from dsl-presets.yaml."
         )
 
@@ -49,17 +49,33 @@ def test_every_number_in_the_template_comes_from_the_preset():
 
 
 @pytest.mark.parametrize("name", sorted(_PRESETS))
-def test_the_time_cut_table_agrees_on_whether_a_preset_has_cuts(name):
-    """Row says "none" iff the preset has no cuts. Deliberately none-vs-some, not which ones:
-    the row is prose and the value that matters is let_winners_run (the worked template) staying
-    cut-free. ponytail: widen to per-cut matching only if a row is ever wrong in detail."""
+def test_the_time_cut_table_names_every_cut_and_its_real_duration(name):
+    """The durations are what the agent reads out to the user, so they are the payload.
+
+    Shipped with two wrong rows — mean_reversion's 2h weak_peak_cut written as 6h (copied from
+    balanced), and scalp's 45m dead_weight_cut written as 8h, longer than its own 90m
+    hard_timeout — under a none-vs-some check that could not see either.
+    """
     dsl = _PRESETS[name]["dsl_preset"]
-    live = {k for k in ("hard_timeout", "weak_peak_cut", "dead_weight_cut")
+    live = {k: dsl[k]["interval_in_minutes"]
+            for k in ("hard_timeout", "weak_peak_cut", "dead_weight_cut")
             if isinstance(dsl.get(k), dict) and dsl[k].get("enabled")}
     row = re.search(rf"^\| `{re.escape(name)}` \| (.+?) \|$", _GUIDE, re.M)
     assert row, f"{name} has no row in the time-cut table"
-    assert (row.group(1).strip() == "none") == (not live), \
-        f"table says {name} is '{row.group(1).strip()}' but it carries {sorted(live) or 'nothing'}"
+    text = row.group(1)
+
+    if not live:
+        assert text.strip() == "none", f"table says {name} is '{text.strip()}' but it has no cuts"
+        return
+
+    for cut, minutes in live.items():
+        m = re.search(rf"`{cut} (\d+(?:\.\d+)?)([mh])`", text)
+        assert m, f"{name} row must name `{cut} <duration>`; got '{text}'"
+        shown = float(m.group(1)) * (60 if m.group(2) == "h" else 1)
+        assert shown == minutes, \
+            f"{name} row says {cut} is {m.group(1)}{m.group(2)}; preset has {minutes}min"
+    for cut in set(("hard_timeout", "weak_peak_cut", "dead_weight_cut")) - set(live):
+        assert f"`{cut} " not in text, f"{name} row names {cut}, but the preset does not enable it"
 
 
 if __name__ == "__main__":

--- a/senpi-strategy-ops/tests/test_skill_surface.py
+++ b/senpi-strategy-ops/tests/test_skill_surface.py
@@ -29,7 +29,14 @@ TAXONOMY = REPO / "docs" / "error-code-taxonomy.md"
 # 51 blocks were bucket-1/rationale (docs/specs/2026-08-12-classification-table.md:176-232) and all
 # seven are gone. Cutting further means deleting a conversation rule, which this budget exists to
 # make visible, not to force.
-BODY_BUDGET = {"senpi-strategy-ops": 300, "senpi-strategy-author": 368}
+# author 368 -> 387 (2026-09-08): the exit-preview conversation rule. `lock N% at +M%` reads as
+# "take N% profit at +M%" to most users, so a ladder whose first rung sits above what the trade
+# reaches locks nothing while looking configured. The 19 resident lines are the parts that must fire on every
+# build and cannot be deferred to a pay-per-read file: the plain-English "a stop that climbs, not
+# profit-taking" sentence, the instruction to render the ladder as outcomes, and the four
+# doesn't-fit checks. The worked example, the template and the per-mismatch wording went to
+# references/explaining-the-exit.md, which is where this budget says depth belongs.
+BODY_BUDGET = {"senpi-strategy-ops": 300, "senpi-strategy-author": 387}
 
 
 def _skill_body(path):

--- a/senpi-strategy-ops/tests/test_skill_surface.py
+++ b/senpi-strategy-ops/tests/test_skill_surface.py
@@ -29,14 +29,14 @@ TAXONOMY = REPO / "docs" / "error-code-taxonomy.md"
 # 51 blocks were bucket-1/rationale (docs/specs/2026-08-12-classification-table.md:176-232) and all
 # seven are gone. Cutting further means deleting a conversation rule, which this budget exists to
 # make visible, not to force.
-# author 368 -> 387 (2026-09-08): the exit-preview conversation rule. `lock N% at +M%` reads as
+# author 368 -> 386 (2026-09-08): the exit-preview conversation rule. `lock N% at +M%` reads as
 # "take N% profit at +M%" to most users, so a ladder whose first rung sits above what the trade
-# reaches locks nothing while looking configured. The 19 resident lines are the parts that must fire on every
+# reaches locks nothing while looking configured. The 18 resident lines are the parts that must fire on every
 # build and cannot be deferred to a pay-per-read file: the plain-English "a stop that climbs, not
 # profit-taking" sentence, the instruction to render the ladder as outcomes, and the four
 # doesn't-fit checks. The worked example, the template and the per-mismatch wording went to
 # references/explaining-the-exit.md, which is where this budget says depth belongs.
-BODY_BUDGET = {"senpi-strategy-ops": 300, "senpi-strategy-author": 387}
+BODY_BUDGET = {"senpi-strategy-ops": 300, "senpi-strategy-author": 386}
 
 
 def _skill_body(path):
@@ -183,6 +183,26 @@ class CodesAreNamedNotExplained(unittest.TestCase):
                     counts[code] = counts.get(code, 0) + 1
                 over = {c: n for c, n in counts.items() if n > 2}
                 self.assertEqual(over, {}, f"codes explained rather than named: {over}")
+
+
+class ReadmeVersionsMatchSkills(unittest.TestCase):
+    """README's version column is hand-maintained and drifts silently. It sat at 2.4.2 for
+    senpi-strategy-author against a shipped 3.1.0, and senpi-trading-runtime was a whole major
+    behind. One assert is cheaper than noticing."""
+
+    def test_every_readme_row_matches_its_skill(self):
+        readme = (REPO / "README.md").read_text()
+        rows = re.findall(r"\| \[`(senpi-[a-z-]+)`\]\([^)]+\) \| ([0-9]+\.[0-9]+\.[0-9]+) \|", readme)
+        self.assertGreater(len(rows), 8, "README version table not found — did the format change?")
+        for name, shown in rows:
+            skill = REPO / name / "SKILL.md"
+            if not skill.is_file():
+                continue
+            with self.subTest(skill=name):
+                m = re.search(r'^\s*version:\s*"([^"]+)"', skill.read_text(), re.M)
+                self.assertIsNotNone(m, f"{name}/SKILL.md has no metadata.version")
+                self.assertEqual(m.group(1), shown,
+                                 f"README says {name} is {shown}; SKILL.md says {m.group(1)}")
 
 
 class SkillBodyWithinBudget(unittest.TestCase):


### PR DESCRIPTION
## The misread

`lock 10% at +100%` reads as *"take 10% profit at +100%"*. It actually means *once you are up 100%, put the stop at 10% of your best*. A trade that peaks at +93% never reaches that only rung, so **nothing is ever locked** and the whole gain round-trips to the stop.

The config is valid. It passes `senpi validate`. The strategy reports healthy the entire way down. The user finds out afterwards.

Nothing in the stack catches it. `parse-tiers.ts` validates only that `lock_hw_pct` lands in `[0, 100]` — no monotonicity check, no reachability check, and no enforcement of the `lock_hw_pct: 0` ban (that ban was applied by editing 129 files, not by putting it in code). `senpi-strategy-author` offered five presets with a one-line parenthetical each, and its confirm step replayed **the decisions**, never **the consequences**: it said *"you picked `let_winners_run`"*, never *"at +100% your stop sits at +85%; below +20% you have no floor at all."*

## What changed — three resident rules, 19 lines

**Decision 7 — say what it does before you name a preset.** One plain sentence, every time:

> "Your stop starts below your entry and only ever moves up. As the trade gains it follows behind, locking more of the gain in — so if the price dips you keep most of what you made instead of giving it back. It never sells while the trade is still going your way."

Plus the explicit correction: **a stop-loss that climbs, not profit-taking.** Nothing is sold on the way up; no rung ever closes a winner; a rung only raises the price at which a *reversal* closes you.

**The confirm step renders the ladder as outcomes, not YAML.** Nobody reads `{trigger_pct: 50, lock_hw_pct: 60}`; everybody reads what it does to their money. Computed the way the engine computes it — `floorRoe = highWaterRoe × lock_hw_pct / 100` at the highest tier whose `trigger_pct` has been passed (`dsl/engine/floors.ts`, `computeTierFloor` / `tierIndexFromPrice`):

> • Up 20% → your stop moves to **+5%**. From here the trade can't lose money.
> • Up 50% → your stop moves to **+30%**.
> • Up 100% → your stop moves to **+85%**.
> • Below +20% → nothing is locked in yet; your only floor is the **−8% max loss**.

**Four doesn't-fit checks, each of which must offer an alternative rather than a warning.** First rung above ~40% ROE · `lock_hw_pct: 0` · locks that shrink as triggers rise · a preset that contradicts the stated thesis. If the user keeps their choice after it's been explained, build what they asked for — the rule is that they choose knowingly, not that they choose what we would.

## Where the depth went

`references/explaining-the-exit.md` — the template, the worked `let_winners_run` example, the per-preset time-cut table, and the wording for each mismatch. That is what the body budget asks for: the 19 lines that stayed resident are the ones that must fire on every build and can't be deferred to a pay-per-read file.

**Body budget 368 → 387**, with the reason recorded at the constant rather than in a commit nobody re-reads. Its own comment says the budget exists to make the cost of a conversation rule *visible*, not to force one out, and there is no bucket-1 rationale left to trade against it.

## The guard

`test_exit_preview_matches_presets.py` recomputes every number in the worked example from `dsl-presets.yaml` using the engine's formula, and checks the time-cut table row by row.

This exists because **`references/dsl-configuration.md` already rotted this exact way** — it drifted from `dsl-presets.yaml` in the same directory and spent weeks teaching `phase1.enabled: true` and `lock_hw_pct: 0` rungs the presets had explicitly banned. Prose has no compiler. This gives it one.

## Also: this skill's tests had never run

`senpi-strategy-author/tests` was not in the CI pytest line, so its **10 existing tests had never executed in CI**. Added to the workflow — they pass.

## Verification

```
full CI suite (the workflow's own command)   667 passed, 9 skipped
  was 647/9 — +10 newly-lit, +10 new
min_budget golden + vendor parity            pass
```

Red-green proven in **both** drift directions:

- corrupt a rung in the guide, leave the preset → **1 failed**
- retune a preset's cut duration, leave the guide → **1 failed**
- rewrite a rung to a decimal floor → **1 failed**

MINOR bump `3.1.0` → `3.2.0`. README's version column had no test — added one, which found four stale rows including `senpi-trading-runtime` a whole major behind. All synced.

## Still open, deliberately not in this PR

- **`references/dsl-configuration.md` is still stale** against `dsl-presets.yaml` — `phase1.enabled: true` on all five presets, three `lock_hw_pct: 0` rungs, and an explicit *"Or skip presets entirely and hand-author every field"* that contradicts SKILL.md's "never hand-roll stops". It's the file an agent reaches for when it wants to *explain* DSL, so it undercuts this change. Next PR.
- **`parse-tiers.ts` still accepts any ladder** in `[0, 100]`. This PR makes the agent explain and challenge a bad ladder; it does not make the runtime refuse one. That belongs upstream in senpi-trading-runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

