### PR TITLE
feat(portfolio): answer "why hasn't it traded?" from the outcome codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Every analytical skill follows the **hidden-engine pattern**: a vendored, stdlib
 | Skill | Ver | Role |
 |---|---|---|
 | **Analyze** | | |
-| [`senpi-portfolio`](senpi-portfolio/) | 1.15.0 | All-wallet portfolio, positions, DSL protection, per-strategy mandate reads |
+| [`senpi-portfolio`](senpi-portfolio/) | 1.16.0 | All-wallet portfolio, positions, DSL protection, per-strategy mandate reads |
 | [`senpi-market-pulse`](senpi-market-pulse/) | 1.2.0 | Daily cross-asset market read (crypto, equities, commodities, macro, funding regime) |
 | [`senpi-smart-money`](senpi-smart-money/) | 1.2.0 | Where the most-profitable wallets are positioned vs. the crowd |
 | [`senpi-trader-research`](senpi-trader-research/) | 1.4.0 | Rank + vet Hyperliquid traders before copying them (mirror-aware: copyability, min-budget, live book) |

--- a/senpi-portfolio/SKILL.md
+++ b/senpi-portfolio/SKILL.md
@@ -168,7 +168,7 @@ so is the useful reply.
 
 | reason code | what to tell the user | do they act? |
 |---|---|---|
-| `withdrawable_unavailable` | "Your available balance was not available during **N** recent scans, resulting in these eligible positions being skipped. If this problem persists, I'd recommend closing the strategy and relaunching it. If that doesn't fix it, contact Senpi Support." | only if it persists |
+| `withdrawable_unavailable` | "Your available balance couldn't be read during **N** recent scans, so these eligible positions were skipped. Your funds aren't affected and it usually clears on its own within a few scans. If it's still happening after that, contact Senpi Support." | only if it persists |
 | `insufficient_margin` | "Your available balance is fully deployed, resulting in these eligible positions being skipped." It opens on its own as soon as a position closes. | no |
 | `no_margin_configured` | The strategy has no way to size a position, so it can never open one. Redeploy it, or contact Senpi Support if redeploying doesn't fix it. | **yes** |
 | `no_slots` | Every slot is already holding a position — working as designed. | no |
@@ -176,15 +176,62 @@ so is the useful reply.
 | `risk_gate_COOLDOWN` | A guard rail is holding it back — the per-asset or global cooldown from its own config. | no |
 | `risk_gate_CLOSED` | A guard rail tripped — daily loss limit, drawdown halt, or consecutive-loss brake. The gate carries its own `reason`, so name **which one**; never just "a risk gate". | no, until it resets |
 | `position_already_exists` | It already holds that asset; it will not double up. | no |
+| `strategy_backend_paused` | The strategy is paused — it will not open anything until it is resumed. | **yes** — unpause it |
+| `position_open_failed` | It tried to open and the exchange rejected the order. Give the exchange's own message, which rides the outcome. | depends on the message |
+| `invalid_direction` | A defect — the signal carried neither LONG nor SHORT. Contact Senpi Support. | **yes** |
 
-**`no_margin_configured` is the only one that is a defect**, and it is the only one where the user
-should be sent to redeploy. Do not send them to redeploy for the others — a fully deployed balance
-and a missed balance read both resolve on their own, and telling someone to tear down a working
-strategy over either is worse than saying nothing.
+**Do not offer "close and relaunch" for `withdrawable_unavailable`.** It reads like the obvious fix
+and it is not one: relaunching rebuilds the same percent-sized recipe against the same balance read,
+and a fresh wallet does not mend a read that is wedged. Wait, then support.
 
-**Never say "it isn't trading" without a reason code to hand.** If the engine surfaces no evaluated
-signals at all, that is a different answer — the scanner is not producing candidates, which is the
-"ACTIVE ≠ running" case below, not a sizing one.
+Do not send anyone to redeploy over a row marked "no". A fully deployed balance and a missed balance
+read both resolve on their own, and tearing down a working strategy over either is worse than saying
+nothing.
+
+### No signals at all — the scanner is alive but producing nothing
+
+The table above only applies to signals that were **evaluated**. A scanner that has gone blind
+produces none, so there is no reason code to read and the codes above will tell you nothing. Its
+fingerprint is in `senpi runtime list`, and the CLI already flags it in plain words:
+
+```
+scanner ext mode=external health=healthy runs=3 errors=0 consec_errors=0 signals=0 alive=1700 last=ok (no signals yet)
+```
+
+`(no signals yet)` means `runs > 0` and `signals == 0` — wired, ticking, emitting nothing. **Note
+`health=healthy` and `errors=0`**: a blind scanner looks perfect on every other field, which is why
+users find it by noticing their strategy has been quiet, not by anything we showed them.
+
+Two things produce that shape, and you must not conflate them:
+
+- **Nothing qualified.** Normal, and the right answer for a selective strategy — the entry bar simply
+  has not been met. Judge against the mandate: a slow, high-conviction design is *supposed* to sit.
+- **The scanner is wedged.** Its market-data connection broke and every read has failed since, while
+  it kept reporting `ok`. The tell is a scanner that **used to** produce signals and has produced
+  none for hours while `alive` keeps advancing and `errors` stays 0.
+
+You usually cannot separate these from one read. Say which one you are looking at, and if it is the
+second, say so plainly and give the action:
+
+> "Your scanner has been running for the last 9 hours but hasn't produced a single candidate, and it
+> was producing them before. That pattern usually means its market-data connection dropped — the
+> strategy isn't broken and your funds aren't affected, but it isn't looking at the market either.
+> Restarting the strategy clears it. If it comes back, contact Senpi Support."
+
+Never tell the user "everything looks healthy" on the strength of `health=healthy` alone — for this
+failure that field is exactly the thing that is wrong.
+
+### No reason codes at all — read it the right way round
+
+"No codes" splits three ways, and routing it wrong sends the user to the wrong place:
+
+- **No codes AND no signals** → the scanner, as above.
+- **No codes but signals ARE present** → look for `clearinghouse_unknown`. The runtime refuses to open
+  against an exchange view it could not read, so it skips the whole batch wholesale. It is the one
+  outcome that never reaches the per-signal path, so it carries **no `reason_code`** and will not
+  appear in the table. The scanner is working fine; the exchange read is not. Same family as the
+  wedge above, and the same answer: it clears on its own or on a restart, and persisting means support.
+- **No runtime registered at all** → the "ACTIVE ≠ running" section below, not this one.
 
 ### "ACTIVE" ≠ running — a strategy with no runtime registered is NOT alive, and NOT protected
 

--- a/senpi-portfolio/SKILL.md
+++ b/senpi-portfolio/SKILL.md
@@ -178,6 +178,8 @@ so is the useful reply.
 | `position_already_exists` | It already holds that asset; it will not double up. | no |
 | `strategy_backend_paused` | The strategy is paused — it will not open anything until it is resumed. | **yes** — unpause it |
 | `position_open_failed` | It tried to open and the exchange rejected the order. Give the exchange's own message, which rides the outcome. | depends on the message |
+| `timeout` | **Not a rejection — the order may have filled.** The runtime recorded a failure after the send timed out, so the user can be holding a position it does not know about. Check live positions before saying anything, and never suggest retrying until you have. | check positions first |
+| `exception` | An unexpected error on the open path, with the message on the outcome. Contact Senpi Support if it repeats. | if it repeats |
 | `invalid_direction` | A defect — the signal carried neither LONG nor SHORT. Contact Senpi Support. | **yes** |
 
 **Do not offer "close and relaunch" for `withdrawable_unavailable`.** It reads like the obvious fix
@@ -190,36 +192,32 @@ nothing.
 
 ### No signals at all — the scanner is alive but producing nothing
 
-The table above only applies to signals that were **evaluated**. A scanner that has gone blind
-produces none, so there is no reason code to read and the codes above will tell you nothing. Its
-fingerprint is in `senpi runtime list`, and the CLI already flags it in plain words:
+The table above only covers signals that were **evaluated**. A scanner producing none has no reason
+code at all, so the codes tell you nothing.
 
-```
-scanner ext mode=external health=healthy runs=3 errors=0 consec_errors=0 signals=0 alive=1700 last=ok (no signals yet)
-```
+Two commands, and they answer different questions — `senpi runtime list` prints only id, source and
+status, so it will show you `running` and leave you stuck. It does carry the sibling failure,
+`running — NO ENTRY SCANNERS`. The per-scanner view is **`senpi scanner`**, which flags a barren one
+in plain words (`(no signals yet)` = it has run and emitted nothing). For anything deeper, hand off to
+`senpi-strategy-ops` `diagnose.py <id> --run-scan` as below — this skill interprets, it does not
+re-derive.
 
-`(no signals yet)` means `runs > 0` and `signals == 0` — wired, ticking, emitting nothing. **Note
-`health=healthy` and `errors=0`**: a blind scanner looks perfect on every other field, which is why
-users find it by noticing their strategy has been quiet, not by anything we showed them.
-
-Two things produce that shape, and you must not conflate them:
+**The interpretation is the part that is yours**, because both of these look identical on every field:
 
 - **Nothing qualified.** Normal, and the right answer for a selective strategy — the entry bar simply
   has not been met. Judge against the mandate: a slow, high-conviction design is *supposed* to sit.
-- **The scanner is wedged.** Its market-data connection broke and every read has failed since, while
-  it kept reporting `ok`. The tell is a scanner that **used to** produce signals and has produced
-  none for hours while `alive` keeps advancing and `errors` stays 0.
+- **The scanner is blind.** Its market-data connection broke and every read has failed since, while it
+  kept reporting healthy. The tell is a scanner that **used to** produce signals and has produced none
+  for hours with no errors.
 
-You usually cannot separate these from one read. Say which one you are looking at, and if it is the
-second, say so plainly and give the action:
+**Never call it healthy on the strength of `health=healthy`.** For this failure that field is exactly
+the thing that is wrong — which is why users find it by noticing the quiet, not from anything we show
+them. When it is the second one, say so and give the action:
 
-> "Your scanner has been running for the last 9 hours but hasn't produced a single candidate, and it
-> was producing them before. That pattern usually means its market-data connection dropped — the
-> strategy isn't broken and your funds aren't affected, but it isn't looking at the market either.
-> Restarting the strategy clears it. If it comes back, contact Senpi Support."
-
-Never tell the user "everything looks healthy" on the strength of `health=healthy` alone — for this
-failure that field is exactly the thing that is wrong.
+> "Your scanner has been running for the last 9 hours without producing a single candidate, and it was
+> producing them before. That usually means its market-data connection dropped — the strategy isn't
+> broken and your funds aren't affected, but it isn't looking at the market either. Restarting clears
+> it. If it comes back, contact Senpi Support."
 
 ### No reason codes at all — read it the right way round
 

--- a/senpi-portfolio/SKILL.md
+++ b/senpi-portfolio/SKILL.md
@@ -16,7 +16,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "1.15.0"
+  version: "1.16.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -153,6 +153,38 @@ capital to redeploy elsewhere, and never "dead money."** That capital is *commit
 it's the dry powder the other half of the design needs to do its job. Only truly-free
 `idle_in_embedded` (and, with care, a *whole* strategy's idle) is redeployable — a flat sleeve of a
 live multi-wallet strategy is not.
+
+### "Why hasn't it traded?" / "why didn't it open that position?" — answer from the outcome codes
+
+A running, healthy strategy that has not traded is the single most common "is it broken?" question,
+and the answer is almost never "it's broken". Every evaluated signal carries a
+`senpi.outcome.reason_code`, so **say which one, how many, and whether the user needs to do
+anything** — never "I'm not sure why."
+
+**Two rules before you answer.** Count the signals rather than describing one, and name the assets
+that were skipped, because "3 eligible entries were skipped" is the part the user actually feels.
+And lead with whether they need to act: for most of these the honest answer is *nothing*, and saying
+so is the useful reply.
+
+| reason code | what to tell the user | do they act? |
+|---|---|---|
+| `withdrawable_unavailable` | "Your available balance was not available during **N** recent scans, resulting in these eligible positions being skipped. If this problem persists, I'd recommend closing the strategy and relaunching it. If that doesn't fix it, contact Senpi Support." | only if it persists |
+| `insufficient_margin` | "Your available balance is fully deployed, resulting in these eligible positions being skipped." It opens on its own as soon as a position closes. | no |
+| `no_margin_configured` | The strategy has no way to size a position, so it can never open one. Redeploy it, or contact Senpi Support if redeploying doesn't fix it. | **yes** |
+| `no_slots` | Every slot is already holding a position — working as designed. | no |
+| `below_min_notional` | The position would be smaller than the $10 exchange minimum. More budget, or higher leverage, would clear it. | their call |
+| `risk_gate_COOLDOWN` | A guard rail is holding it back — the per-asset or global cooldown from its own config. | no |
+| `risk_gate_CLOSED` | A guard rail tripped — daily loss limit, drawdown halt, or consecutive-loss brake. The gate carries its own `reason`, so name **which one**; never just "a risk gate". | no, until it resets |
+| `position_already_exists` | It already holds that asset; it will not double up. | no |
+
+**`no_margin_configured` is the only one that is a defect**, and it is the only one where the user
+should be sent to redeploy. Do not send them to redeploy for the others — a fully deployed balance
+and a missed balance read both resolve on their own, and telling someone to tear down a working
+strategy over either is worse than saying nothing.
+
+**Never say "it isn't trading" without a reason code to hand.** If the engine surfaces no evaluated
+signals at all, that is a different answer — the scanner is not producing candidates, which is the
+"ACTIVE ≠ running" case below, not a sizing one.
 
 ### "ACTIVE" ≠ running — a strategy with no runtime registered is NOT alive, and NOT protected
 


### PR DESCRIPTION
**Stacked on #564.** Review after that one; merge order #564 → this.

## Problem

A running, healthy strategy that hasn't opened a position is the most common "is it broken?" question — and `senpi-portfolio` has no answer for it today. The agent guesses or says nothing, and the user can't see the logs that hold the reason.

## Solution

Every evaluated signal already carries `senpi.outcome.reason_code`. This maps **all 11** codes `outcome()` emits to **what to tell the user** and **whether they need to act**:

| code | act? |
|---|---|
| `withdrawable_unavailable` | only if it persists — it usually clears within a few scans, then support |
| `insufficient_margin` | no — balance fully deployed, opens when a position closes |
| `no_margin_configured` · `invalid_direction` · `strategy_backend_paused` | **yes** |
| `position_open_failed` | depends on the exchange's own message, which rides the outcome |
| `no_slots` · `risk_gate_COOLDOWN` · `risk_gate_CLOSED` · `position_already_exists` | no |
| `below_min_notional` | their call — more budget or leverage |

For **most of them the honest answer is "nothing"**, and saying that plainly is the useful reply.

**Two cases with no reason code at all**, because neither reaches the per-signal path:

- **A scanner that has gone blind** — `runs > 0`, `signals = 0`, and `health=healthy` with `errors=0`, which is why users find it by noticing the quiet rather than from anything we show them. Distinguished from a merely selective strategy by whether it *used to* produce signals.
- **`clearinghouse_unknown`** — the runtime refuses to open against an exchange view it could not read and skips the batch wholesale, never calling `outcome()`. Scanner fine, exchange read not.

So "no codes" splits three ways: no codes **and** no signals → the scanner · no codes **with** signals → look for `clearinghouse_unknown` · no runtime at all → the "ACTIVE ≠ running" case.

## Depends on Senpi-ai/senpi-trading-runtime#387

That PR splits `withdrawable_unavailable` out of `no_margin_configured`, and makes a `$0` balance report as `insufficient_margin`. Until it ships, both states arrive as `no_margin_configured` and the agent will wrongly tell the user to redeploy — which is exactly the bug #387 fixes. The section is still a net improvement before then (six codes are unaffected), but the two margin rows only become correct with it.

## Verification

All 11 codes checked against the runtime rather than recalled. **`risk_gate_OPEN` is not reachable** — `open-position.action.ts` emits `risk_gate_${gate.gate}` only when the gate is *not* `OPEN` — so it's deliberately absent. I had it in a first draft; the check caught it.

**Review round 1 (@IgnasPeciura):** the table covered 8 of 11 — added `strategy_backend_paused`, `position_open_failed`, `invalid_direction`. The "no codes" fallback sent `clearinghouse_unknown` to "the scanner isn't producing candidates", when the scanner is fine and the exchange read is not; rewritten. And the `withdrawable_unavailable` remedy said "close and relaunch", which contradicted #387's own log and could not work — relaunching rebuilds the same percent-sized recipe against the same read. Now: wait, then support, with a line saying why relaunch is *not* the fix.

`827 passed / 9 skipped`. senpi-portfolio 1.15.0 → 1.16.0, README synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
