### PR TITLE
fix(portfolio): one errored tick is not a broken strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Every analytical skill follows the **hidden-engine pattern**: a vendored, stdlib
 | Skill | Ver | Role |
 |---|---|---|
 | **Analyze** | | |
-| [`senpi-portfolio`](senpi-portfolio/) | 1.16.0 | All-wallet portfolio, positions, DSL protection, per-strategy mandate reads |
+| [`senpi-portfolio`](senpi-portfolio/) | 1.17.0 | All-wallet portfolio, positions, DSL protection, per-strategy mandate reads |
 | [`senpi-market-pulse`](senpi-market-pulse/) | 1.2.0 | Daily cross-asset market read (crypto, equities, commodities, macro, funding regime) |
 | [`senpi-smart-money`](senpi-smart-money/) | 1.2.0 | Where the most-profitable wallets are positioned vs. the crowd |
 | [`senpi-trader-research`](senpi-trader-research/) | 1.4.0 | Rank + vet Hyperliquid traders before copying them (mirror-aware: copyability, min-budget, live book) |

--- a/senpi-portfolio/SKILL.md
+++ b/senpi-portfolio/SKILL.md
@@ -278,7 +278,7 @@ strategy and per group. Narrate it honestly — a registered runtime is not auto
 
 **The two sources measure different windows, which is why they disagree without either being wrong.**
 `runtime_health` describes the **most recent tick**. `positions` / `trade_count` / `recent` describe the
-**last several hours**. A strategy can hold 13 positions opened by earlier scans *and* have had its latest
+**last several hours**. A strategy can hold positions opened by earlier scans *and* have had its latest
 scan error — both facts true at once. So read them as a grid, not a single verdict:
 
 |                          | **strategy IS trading** (open positions / recent closes) | **strategy is NOT trading** (no fills, no recent closes) |
@@ -286,12 +286,9 @@ scan error — both facts true at once. So read them as a grid, not a single ver
 | **field says `degraded`** | **They disagree.** The last scans errored; the book is live and managed. Say *"running — some scans errored"*, never *"your strategy is broken."* Confirm with `status.py <id>` before going further. | **They agree.** It really is broken. Report it and work the ladder below. |
 | **field says `live`**     | **They agree.** Clean. Say so. | **They disagree.** Do **not** give a clean all-clear — a scanner can read `healthy` and still be blind. Say it is running but has not found a trade, and use "No signals at all" above. |
 
-The two disagreeing cells are the ones that produced this rule, one in each direction.
 
-**When the two disagree, say which one you are trusting and why.** The failure that produced this rule was
-an agent that wrote *"the scanner is clearly working (13 positions, recent closes), but something in the
-monitoring is off"* — and then led its answer with a red ⚠ anyway. It had the right read and buried it. If
-the money is moving, that is the headline; the field is the footnote.
+**When the two disagree, say which one you are trusting and why.** If the money is moving, that is the
+headline and the field is the footnote — do not report the field and bury the evidence.
 
 #### When it IS genuinely broken, act — don't hand the user a to-do
 
@@ -346,12 +343,7 @@ does not stop at the verdict: for a strategy that is `not_running`, `degraded` o
 `recovering`** — **`python3 senpi-strategy-ops/scripts/status.py <id>`** re-asks the runtime directly and
 returns its verdict **beside a position count**, which is the corroboration below. Run it yourself and give
 the answer. **It is your tool, not a step you hand the user** — never write "worth running …" into a
-portfolio answer; either run it, or say what you know without it.
-
-> **There is no `diagnose.py`.** This skill named one for five versions and no such script exists in
-> `senpi-strategy-ops` — so the agent it sent for confirmation found nothing, and fell back to repeating an
-> unconfirmed verdict as fact. `status.py` is the tool. `openclaw senpi scanner -r <rt>` is the per-scanner
-> detail (runs / errors / signals / liveness) when you need to know whether it is ticking at all. For
+portfolio answer; either run it, or say what you know without it. For
 **"where am I leaking / did a stop fail / any halts / exit quality"**, hand to `senpi-improve-trades` (it
 reads the runtime event log for protection gaps, risk halts, failed orders, and exit quality). Reference the
 right tool to *confirm* — never re-derive its analysis here.

--- a/senpi-portfolio/SKILL.md
+++ b/senpi-portfolio/SKILL.md
@@ -276,16 +276,17 @@ strategy and per group. Narrate it honestly — a registered runtime is not auto
 
 #### Corroborate the verdict before you assert it — in either direction
 
-`runtime_health` is one field, and it can be wrong both ways. **Check it against what the strategy is
-actually doing before you tell the user anything**, using what the engine already attaches to the row:
-`positions` (open now), `trade_count` and `recent` (closed trades), `unrealized_pnl`.
+**The two sources measure different windows, which is why they disagree without either being wrong.**
+`runtime_health` describes the **most recent tick**. `positions` / `trade_count` / `recent` describe the
+**last several hours**. A strategy can hold 13 positions opened by earlier scans *and* have had its latest
+scan error — both facts true at once. So read them as a grid, not a single verdict:
 
-| verdict says | evidence says | what you say |
-|---|---|---|
-| `degraded` | positions opening / closing recently | **"running, one or more scans errored"** — not "your strategy is broken." Confirm with `status.py <id>` before going further. |
-| `degraded` | no fills, no recent closes | The verdict and the evidence agree. Report it as broken and act (below). |
-| `live` | no fills, no signals, for a long stretch | **Do not report a clean all-clear.** A scanner can read `healthy` and still be blind — see "No signals at all" above. Say it is running but has not found a trade, and give that section's answer. |
-| `live` | trading normally | Clean. Say so. |
+|                          | **strategy IS trading** (open positions / recent closes) | **strategy is NOT trading** (no fills, no recent closes) |
+|--------------------------|---|---|
+| **field says `degraded`** | **They disagree.** The last scans errored; the book is live and managed. Say *"running — some scans errored"*, never *"your strategy is broken."* Confirm with `status.py <id>` before going further. | **They agree.** It really is broken. Report it and work the ladder below. |
+| **field says `live`**     | **They agree.** Clean. Say so. | **They disagree.** Do **not** give a clean all-clear — a scanner can read `healthy` and still be blind. Say it is running but has not found a trade, and use "No signals at all" above. |
+
+The two disagreeing cells are the ones that produced this rule, one in each direction.
 
 **When the two disagree, say which one you are trusting and why.** The failure that produced this rule was
 an agent that wrote *"the scanner is clearly working (13 positions, recent closes), but something in the

--- a/senpi-portfolio/SKILL.md
+++ b/senpi-portfolio/SKILL.md
@@ -199,7 +199,7 @@ Two commands, and they answer different questions — `senpi runtime list` print
 status, so it will show you `running` and leave you stuck. It does carry the sibling failure,
 `running — NO ENTRY SCANNERS`. The per-scanner view is **`senpi scanner`**, which flags a barren one
 in plain words (`(no signals yet)` = it has run and emitted nothing). For anything deeper, hand off to
-`senpi-strategy-ops` `diagnose.py <id> --run-scan` as below — this skill interprets, it does not
+`senpi-strategy-ops` `status.py <id>` as below — this skill interprets, it does not
 re-derive.
 
 **The interpretation is the part that is yours**, because both of these look identical on every field:
@@ -273,6 +273,41 @@ strategy and per group. Narrate it honestly — a registered runtime is not auto
   `running_blind` (up, no entry scanners). This is the one that always deserved the warning. Say
   **"⚠ runtime degraded — running but not healthy,"** not a clean all-clear. Flagged in `meta.warnings`.
 - **`not_running`** — no runtime at all (above). ⛔ NOT RUNNING / UNPROTECTED.
+
+#### Corroborate the verdict before you assert it — in either direction
+
+`runtime_health` is one field, and it can be wrong both ways. **Check it against what the strategy is
+actually doing before you tell the user anything**, using what the engine already attaches to the row:
+`positions` (open now), `trade_count` and `recent` (closed trades), `unrealized_pnl`.
+
+| verdict says | evidence says | what you say |
+|---|---|---|
+| `degraded` | positions opening / closing recently | **"running, one or more scans errored"** — not "your strategy is broken." Confirm with `status.py <id>` before going further. |
+| `degraded` | no fills, no recent closes | The verdict and the evidence agree. Report it as broken and act (below). |
+| `live` | no fills, no signals, for a long stretch | **Do not report a clean all-clear.** A scanner can read `healthy` and still be blind — see "No signals at all" above. Say it is running but has not found a trade, and give that section's answer. |
+| `live` | trading normally | Clean. Say so. |
+
+**When the two disagree, say which one you are trusting and why.** The failure that produced this rule was
+an agent that wrote *"the scanner is clearly working (13 positions, recent closes), but something in the
+monitoring is off"* — and then led its answer with a red ⚠ anyway. It had the right read and buried it. If
+the money is moving, that is the headline; the field is the footnote.
+
+#### When it IS genuinely broken, act — don't hand the user a to-do
+
+For `degraded` corroborated by no activity, or `not_running`, work the ladder yourself and report what you
+found. Only the last step touches their money, and only that one needs their consent:
+
+1. **`python3 senpi-strategy-ops/scripts/status.py <id>`** — re-ask the runtime. Verdict + position count.
+2. **`openclaw senpi scanner -r <rt>`** — is it ticking at all? `runs` / `errors` / `consec_errors` /
+   `signals` / `alive`. High `runs` with `signals=0` is a different problem from `errors` climbing.
+3. **Re-run the deploy** — a deploy interrupted by a gateway restart does not resume on its own, and
+   re-running reconciles rather than duplicating. This is the fix for `not_running` after a broken deploy.
+4. **`close.py` → redeploy** — **last resort, and ask first.** It is a market exit of every open position
+   and a fresh wallet. Never reach for it to clear an error you have not diagnosed.
+
+**There is no restart verb.** If the runtime is up, ticking, erroring every read and steps 1–3 show nothing
+wrong with the recipe, the remedy is on our side, not theirs — say so plainly and point them at Senpi
+Support rather than inventing a step they can take.
 - **`unknown`** — registered, but health **not yet proven**: a scanner it has never heard from, a runtime
   just restarted, or a `senpi status` document that carried no health verdict this engine recognises. Say
   **"runtime liveness unverified — not confirmed running"** — never upgrade to "healthy/protected" or
@@ -301,13 +336,17 @@ run. (A *single* strategy reading null while others read fine is a different thi
 genuinely unattributed.) The fix is a runtime upgrade on the box, not a redeploy of the strategies.
 
 This health check owns **liveness triage** (registered + running + healthy) via telemetry, and **references
-`diagnose.py` as the confirmation step** — it does not re-derive the deep checks. A thorough health check
+`status.py` as the confirmation step** — it does not re-derive the deep checks. A thorough health check
 does not stop at the verdict: for a strategy that is `not_running`, `degraded` or `unknown` — **never for
-`recovering`** — running **`senpi-strategy-ops` `diagnose.py <id>`** (registered? ticked? no signals yet?
-erroring? `--run-scan` for the literal scan output) is how you **confirm what's actually wrong and fix it**
-— run it yourself and give the verdict, then close.py → redeploy as needed. **`diagnose.py` is your tool,
-not a step you hand the user.** Never write "worth running `diagnose.py`" into a portfolio answer; either
-run it, or say what you know without it. For
+`recovering`** — **`python3 senpi-strategy-ops/scripts/status.py <id>`** re-asks the runtime directly and
+returns its verdict **beside a position count**, which is the corroboration below. Run it yourself and give
+the answer. **It is your tool, not a step you hand the user** — never write "worth running …" into a
+portfolio answer; either run it, or say what you know without it.
+
+> **There is no `diagnose.py`.** This skill named one for five versions and no such script exists in
+> `senpi-strategy-ops` — so the agent it sent for confirmation found nothing, and fell back to repeating an
+> unconfirmed verdict as fact. `status.py` is the tool. `openclaw senpi scanner -r <rt>` is the per-scanner
+> detail (runs / errors / signals / liveness) when you need to know whether it is ticking at all. For
 **"where am I leaking / did a stop fail / any halts / exit quality"**, hand to `senpi-improve-trades` (it
 reads the runtime event log for protection gaps, risk halts, failed orders, and exit quality). Reference the
 right tool to *confirm* — never re-derive its analysis here.

--- a/senpi-portfolio/SKILL.md
+++ b/senpi-portfolio/SKILL.md
@@ -263,7 +263,7 @@ user's own box — the runtime's own view of itself, not the internal telemetry 
 runtime registered," the engine asks the
 runtime itself (`openclaw senpi status`) whether it's actually *working*, and sets `runtime_health` per
 strategy and per group. Narrate it honestly — a registered runtime is not automatically a healthy one:
-- **`live`** — registered and telemetry reports healthy. Only this earns "running / protected."
+- **`live`** — registered, and the runtime reports itself healthy. Only this earns "running / protected."
 - **`recovering`** — the engine's own `degraded`: **the last scan errored, once.** `consecutiveErrorCount`
   is 1, and the next successful tick zeroes it — this is a blip clearing itself, not a fault. **Do not
   warn on it.** Do not put a ⚠ on the strategy, and do not send the user to a diagnostic. If they ask,
@@ -299,6 +299,10 @@ For `degraded` corroborated by no activity, or `not_running`, work the ladder yo
 found. Only the last step touches their money, and only that one needs their consent:
 
 1. **`python3 senpi-strategy-ops/scripts/status.py <id>`** — re-ask the runtime. Verdict + position count.
+   **Mind the vocabulary:** `status.py` reports the engine's raw words, and they do not line up with this
+   skill's. Its **`degraded`** is this skill's **`recovering`** (one errored tick); its **`unhealthy`** is
+   this skill's **`degraded`** (the real fault). Reading its "degraded" as ours is how a confirmation step
+   confirms the wrong thing.
 2. **`openclaw senpi scanner -r <rt>`** — is it ticking at all? `runs` / `errors` / `consec_errors` /
    `signals` / `alive`. High `runs` with `signals=0` is a different problem from `errors` climbing.
 3. **Re-run the deploy** — a deploy interrupted by a gateway restart does not resume on its own, and

--- a/senpi-portfolio/SKILL.md
+++ b/senpi-portfolio/SKILL.md
@@ -16,7 +16,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "1.16.0"
+  version: "1.17.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -257,13 +257,21 @@ SCANNERS**, not a clean "running." When `runtime_registered` (or `not_running` /
 `null`, the registry read did not answer — say **"could not verify on this host,"** never "running" and
 never "not running."
 
-**Telemetry-verified liveness — `runtime_health`.** Beyond "is a runtime registered," the engine asks the
+**Runtime-verified liveness — `runtime_health`.** ("Telemetry" here is `openclaw senpi status` on the
+user's own box — the runtime's own view of itself, not the internal telemetry stack. Don't say
+"telemetry reports…" to a user; it sounds like we are reading something they cannot see.) Beyond "is a
+runtime registered," the engine asks the
 runtime itself (`openclaw senpi status`) whether it's actually *working*, and sets `runtime_health` per
 strategy and per group. Narrate it honestly — a registered runtime is not automatically a healthy one:
 - **`live`** — registered and telemetry reports healthy. Only this earns "running / protected."
-- **`degraded`** — registered but telemetry reports **unhealthy** (scanner erroring, monitor stalled), or
-  `running_blind` (up, no entry scanners). Say **"⚠ runtime degraded — running but not healthy; check
-  `openclaw senpi status`,"** not a clean all-clear. Flagged in `meta.warnings` too.
+- **`recovering`** — the engine's own `degraded`: **the last scan errored, once.** `consecutiveErrorCount`
+  is 1, and the next successful tick zeroes it — this is a blip clearing itself, not a fault. **Do not
+  warn on it.** Do not put a ⚠ on the strategy, and do not send the user to a diagnostic. If they ask,
+  say the last scan hit an error and the next one retries. If the strategy is opening or closing
+  positions, that is the answer to "is it working" — a stale `lastRunStatus` is not.
+- **`degraded`** — the engine reports **unhealthy**: **two or more consecutive** scan errors, or
+  `running_blind` (up, no entry scanners). This is the one that always deserved the warning. Say
+  **"⚠ runtime degraded — running but not healthy,"** not a clean all-clear. Flagged in `meta.warnings`.
 - **`not_running`** — no runtime at all (above). ⛔ NOT RUNNING / UNPROTECTED.
 - **`unknown`** — registered, but health **not yet proven**: a scanner it has never heard from, a runtime
   just restarted, or a `senpi status` document that carried no health verdict this engine recognises. Say
@@ -277,7 +285,7 @@ strategy and per group. Narrate it honestly — a registered runtime is not auto
   `meta.warnings` names the failed command; quote it, never invent a cause. This is the honest bar:
   **only `live` means "confirmed working."**
 - **`mirror`** — a **copy-trade** strategy: no runtime BY DESIGN (see **Copy-trade / mirror strategies** below).
-  Never `live` / `degraded` / `not_running` / `unverified` — those don't apply to it. Judge it on `mirror_of` +
+  Never `live` / `recovering` / `degraded` / `not_running` / `unverified` — those don't apply to it. Judge it on `mirror_of` +
   `mirror_multiplier` + `stop_loss_pct` / `take_profit_pct`, never on a runtime it was never meant to have.
 
 **Minimum runtime — `openclaw senpi runtime list --json`.** The engine asks the runtime for its own
@@ -294,10 +302,12 @@ genuinely unattributed.) The fix is a runtime upgrade on the box, not a redeploy
 
 This health check owns **liveness triage** (registered + running + healthy) via telemetry, and **references
 `diagnose.py` as the confirmation step** — it does not re-derive the deep checks. A thorough health check
-does not stop at the verdict: for **any** strategy that isn't cleanly `live` (`not_running` / `degraded` /
-`unknown`), running **`senpi-strategy-ops` `diagnose.py <id>`** (registered? ticked? no signals yet? erroring?
-`--run-scan` for the literal scan output) is how you **confirm what's actually wrong and fix it** — surface
-it as the required next step (and its verdict, if you can run it), then close.py → redeploy as needed. For
+does not stop at the verdict: for a strategy that is `not_running`, `degraded` or `unknown` — **never for
+`recovering`** — running **`senpi-strategy-ops` `diagnose.py <id>`** (registered? ticked? no signals yet?
+erroring? `--run-scan` for the literal scan output) is how you **confirm what's actually wrong and fix it**
+— run it yourself and give the verdict, then close.py → redeploy as needed. **`diagnose.py` is your tool,
+not a step you hand the user.** Never write "worth running `diagnose.py`" into a portfolio answer; either
+run it, or say what you know without it. For
 **"where am I leaking / did a stop fail / any halts / exit quality"**, hand to `senpi-improve-trades` (it
 reads the runtime event log for protection gaps, risk halts, failed orders, and exit quality). Reference the
 right tool to *confirm* — never re-derive its analysis here.

--- a/senpi-portfolio/scripts/portfolio.py
+++ b/senpi-portfolio/scripts/portfolio.py
@@ -383,8 +383,8 @@ _HEALTH_LIVE = ("healthy", "ok")
 # The runtime separates ONE bad tick from a real fault, and so must we. `derivePushDrivenScannerHealth`
 # (senpi-trading-runtime scanners/runtime-module.ts): `lastRunStatus === "error"` yields "unhealthy" at
 # consecutiveErrorCount >= 2 and "degraded" at 1 — and `recordRunComplete` zeroes that counter, so a
-# single "degraded" is already clearing itself on the next successful tick. Collapsing the two turned a
-# transient blip into the same red verdict as a dead scanner, on strategies that were visibly trading.
+# single "degraded" is already clearing itself on the next successful tick. Collapsing the two reports a
+# transient blip with the same verdict as a dead scanner.
 _HEALTH_RECOVERING = ("degraded", "warn", "warning")
 # Severity for rolling a multi-wallet strategy's sleeves into one verdict, worst first. `recovering`
 # sits ABOVE `live` (a sleeve whose last tick errored is not a clean all-clear) and BELOW `unknown`
@@ -1381,9 +1381,9 @@ def group_strategies(strategies, meta):
             # recovering > live) — one dead/degraded/unverifiable sleeve makes the whole strategy
             # not-fully-live. `recovering` sits ABOVE live (a sleeve that errored its last tick is not a
             # clean all-clear) and BELOW unknown (an unproven sleeve is a bigger gap than a known blip,
-            # and fail-closed outranks informative). Omitting it entirely made a both-sleeves-recovering
-            # strategy roll up to the default 'unknown' — telling the user we could not check something
-            # we had in fact measured — and a recovering+live pair report a clean 'live'.
+            # and fail-closed outranks informative). Omit it and a both-recovering strategy falls through
+            # to the default 'unknown' — claiming we could not check what we had measured — while a
+            # recovering+live pair reports a clean 'live'.
             "runtime_health": next((v for v in _GROUP_HEALTH_WORST_FIRST
                                     if any(s.get("runtime_health") == v for s in insts)), "unknown"),
             "flat_instances": flat_instances,

--- a/senpi-portfolio/scripts/portfolio.py
+++ b/senpi-portfolio/scripts/portfolio.py
@@ -386,6 +386,10 @@ _HEALTH_LIVE = ("healthy", "ok")
 # single "degraded" is already clearing itself on the next successful tick. Collapsing the two turned a
 # transient blip into the same red verdict as a dead scanner, on strategies that were visibly trading.
 _HEALTH_RECOVERING = ("degraded", "warn", "warning")
+# Severity for rolling a multi-wallet strategy's sleeves into one verdict, worst first. `recovering`
+# sits ABOVE `live` (a sleeve whose last tick errored is not a clean all-clear) and BELOW `unknown`
+# (an unproven sleeve is a bigger gap than a measured blip — fail-closed outranks informative).
+_GROUP_HEALTH_WORST_FIRST = ("not_running", "degraded", "unverified", "unknown", "recovering", "live")
 _HEALTH_BROKEN = ("unhealthy", "failed", "error", "down", "false", "stopped")
 # The keys that carry a HEALTH VERDICT the runtime computed about ITSELF (`RuntimeHealthStatus.health`;
 # `overallHealth` is the older spelling this skill has always accepted). ONLY these may promote to 'live'.
@@ -469,8 +473,9 @@ def _liveness_from_status(status):
     recognisable verdict in is 'unknown'; an empty `statuses[]` is 'unknown'. None ⇒ 'unknown' too.
     A real fault (unhealthy/failed/stopped/…) → 'degraded'; the runtime's own 'degraded' — one errored
     tick, already clearing — → 'recovering'. Worst wins across records
-    (degraded > recovering > unknown > live) — an id that answers with several runtimes cannot have the
-    sick one averaged away.
+    (degraded > unknown > recovering > live) — an id that answers with several runtimes cannot have the
+    sick one averaged away. `unknown` outranks `recovering` for the same reason it outranks `live`: an
+    unproven record must not be painted over by a proven one, even a proven-slightly-bad one.
 
     'unknown' is NOT PROVEN LIVE — telemetry unavailable, or the runtime itself says it can't vouch for
     the runtime yet (never-heard scanners, right after a restart, a scanner-only runtime whose overall
@@ -488,7 +493,7 @@ def _liveness_from_status(status):
     if status.get("ok") is False:                     # the document itself says it could not answer
         return "unknown"
     verdicts = [_entry_verdict(e) for e in _status_entries(status)]
-    for worst in ("degraded", "recovering", "unknown", "live"):
+    for worst in ("degraded", "unknown", "recovering", "live"):
         if worst in verdicts:
             return worst
     return "unknown"                                  # no records at all (empty `statuses[]`)
@@ -890,7 +895,7 @@ def fetch_strategies(client, meta):
     #   recovering  — the runtime's own "degraded": the LAST scan errored, once. It clears on the next
     #                 successful tick. Not a fault, and not a reason to alarm a user whose strategy is
     #                 opening and closing positions
-    #   live        — registered and telemetry reports healthy. Only this earns "running"
+    #   live        — registered and the runtime reports itself healthy. Only this earns "running"
     #   unknown     — NOT PROVEN LIVE (telemetry unavailable, or the runtime won't vouch for it yet)
     # Fail-open + short-circuited by _telemetry_dead; sequential (few per user).
     for s in strategies:
@@ -1373,8 +1378,13 @@ def group_strategies(strategies, meta):
             "running_blind": _rollup_any(insts, "running_blind"),
             "runtime_registered": _rollup_flag(insts, "runtime_registered"),
             # runtime_health = the WORST across instances (not_running > degraded > unverified > unknown >
-            # live) — one dead/degraded/unverifiable sleeve makes the whole strategy not-fully-live.
-            "runtime_health": next((v for v in ("not_running", "degraded", "unverified", "unknown", "live")
+            # recovering > live) — one dead/degraded/unverifiable sleeve makes the whole strategy
+            # not-fully-live. `recovering` sits ABOVE live (a sleeve that errored its last tick is not a
+            # clean all-clear) and BELOW unknown (an unproven sleeve is a bigger gap than a known blip,
+            # and fail-closed outranks informative). Omitting it entirely made a both-sleeves-recovering
+            # strategy roll up to the default 'unknown' — telling the user we could not check something
+            # we had in fact measured — and a recovering+live pair report a clean 'live'.
+            "runtime_health": next((v for v in _GROUP_HEALTH_WORST_FIRST
                                     if any(s.get("runtime_health") == v for s in insts)), "unknown"),
             "flat_instances": flat_instances,
             "profile_source": prof.get("source"),

--- a/senpi-portfolio/scripts/portfolio.py
+++ b/senpi-portfolio/scripts/portfolio.py
@@ -931,7 +931,7 @@ def fetch_strategies(client, meta):
             f"{len(not_running)} strategy(ies) show status ACTIVE but have NO runtime registered — NOT "
             f"running: no scanner, no DSL, no guardrails despite 'ACTIVE'. Report as UNPROTECTED / not "
             f"running, never as live or 'waiting for a setup': {', '.join(str(n) for n in not_running)}. "
-            f"Confirm + fix with senpi-strategy-ops `diagnose.py <id>` (then close.py → redeploy).")
+            f"Confirm + fix with senpi-strategy-ops `status.py <id>` (then close.py → redeploy).")
     # Up, and CANNOT ENTER: the runtime reports `running — NO ENTRY SCANNERS`. Broken wiring, not a quiet
     # market — a strategy that will never take a position no matter what its scanners would have found.
     # Kept out of the degraded roll-up below so the cause the agent relays is the real one.
@@ -942,7 +942,7 @@ def fetch_strategies(client, meta):
             f"{len(blind)} strategy(ies) are RUNNING WITH NO ENTRY SCANNERS — the runtime is up but has no "
             f"scanner wired to produce entry signals, so it can never open a position (this is broken "
             f"wiring, NOT 'waiting for a setup'): {', '.join(str(b) for b in blind)}. Confirm + fix with "
-            f"senpi-strategy-ops `diagnose.py <id>` (then close.py → redeploy).")
+            f"senpi-strategy-ops `status.py <id>` (then close.py → redeploy).")
     # Registered but telemetry says the runtime is DEGRADED/unhealthy — running, but not cleanly (scanner
     # erroring, monitor stalled, etc.). Distinct from not_running (no runtime) and from live (healthy).
     degraded = [s["name"] for s in strategies
@@ -952,7 +952,7 @@ def fetch_strategies(client, meta):
         meta.setdefault("warnings", []).append(
             f"{len(degraded)} strategy(ies) have a runtime the engine reports UNHEALTHY (degraded) — two or more "
             f"consecutive scan errors, not a blip. Confirm the cause with senpi-strategy-ops "
-            f"`diagnose.py <id>` (scanner registered? ticked? no signals yet? erroring?): "
+            f"`status.py <id>` (runtime verdict + position count; `openclaw senpi scanner -r <rt>` for runs/errors/signals): "
             f"{', '.join(str(d) for d in degraded)}")
     # NOT a warning: one errored tick that the next successful one clears. Carried so the narration can
     # mention it if the user asks, never so it can be read back as a fault on a strategy that is trading.

--- a/senpi-portfolio/scripts/portfolio.py
+++ b/senpi-portfolio/scripts/portfolio.py
@@ -55,7 +55,9 @@ RUNTIMES_FIXTURE_ENV = "SENPI_RUNTIMES_FIXTURE"     # offline test hook (see loa
 # The producer's exact blind-runtime status is `running — NO ENTRY SCANNERS` (em dash, U+2014). Matched
 # on the phrase, not the whole string, so a dash/spacing drift cannot silently repaint blind as healthy.
 RUNTIME_BLIND_MARK = "NO ENTRY SCANNERS"
-# Telemetry liveness (health check): `openclaw senpi status -r <runtime_id> --json` says whether a
+# Runtime liveness (health check): `openclaw senpi status -r <runtime_id> --json` — the runtime's own
+# view of itself, read from the user's own box. NOT the internal telemetry stack; do not narrate it
+# to a user as "telemetry reports", which sounds like something they cannot see. It says whether a
 # REGISTERED runtime is actually WORKING (healthy vs degraded), not just present in the registry. Same
 # fail-open + fixture pattern as senpi-improve-trades' event-log read. Offline test hook: a JSON file at
 # $SENPI_STATUS_FIXTURE keyed {"<runtime_id>": {status payload}} is read instead of shelling out.
@@ -378,7 +380,13 @@ def _fetch_runtime_status(runtime_id, meta):
 # `ComponentHealth`). Only the HEALTHY family earns 'live'; the broken family earns 'degraded'; everything
 # else (`unknown`, `disabled`, and any verdict we don't recognise) is UNPROVEN, not confirmed working.
 _HEALTH_LIVE = ("healthy", "ok")
-_HEALTH_BROKEN = ("degraded", "warn", "warning", "unhealthy", "failed", "error", "down", "false", "stopped")
+# The runtime separates ONE bad tick from a real fault, and so must we. `derivePushDrivenScannerHealth`
+# (senpi-trading-runtime scanners/runtime-module.ts): `lastRunStatus === "error"` yields "unhealthy" at
+# consecutiveErrorCount >= 2 and "degraded" at 1 — and `recordRunComplete` zeroes that counter, so a
+# single "degraded" is already clearing itself on the next successful tick. Collapsing the two turned a
+# transient blip into the same red verdict as a dead scanner, on strategies that were visibly trading.
+_HEALTH_RECOVERING = ("degraded", "warn", "warning")
+_HEALTH_BROKEN = ("unhealthy", "failed", "error", "down", "false", "stopped")
 # The keys that carry a HEALTH VERDICT the runtime computed about ITSELF (`RuntimeHealthStatus.health`;
 # `overallHealth` is the older spelling this skill has always accepted). ONLY these may promote to 'live'.
 _HEALTH_KEYS = ("overallHealth", "health")
@@ -391,10 +399,19 @@ _RUN_STATE_KEYS = ("overall", "status")
 
 
 def _classify_health(raw, allow_live):
-    """One verdict string → live / degraded / unknown. `allow_live=False` for a run state: it can say
-    the process is stopped (→ degraded), it can never say the runtime is working."""
+    """One verdict string → live / degraded / recovering / unknown. `allow_live=False` for a run state:
+    it can say the process is stopped (→ degraded), it can never say the runtime is working.
+
+    Neither broken verdict may promote to 'live' — fail-closed is unchanged. The split is only in how
+    bad 'not live' is, because 'the last tick errored' and 'this scanner is dead' are not the same fact.
+    A run state never yields 'recovering': a stopped process is not mid-recovery.
+    """
     h = str(raw).strip().lower()
     if h in _HEALTH_BROKEN:
+        return "degraded"
+    if allow_live and h in _HEALTH_RECOVERING:
+        return "recovering"
+    if h in _HEALTH_RECOVERING:
         return "degraded"
     if allow_live and h in _HEALTH_LIVE:
         return "live"
@@ -450,9 +467,10 @@ def _liveness_from_status(status):
     'live' has to be EARNED by a health verdict the runtime computed about itself (healthy/ok). A run
     state ("running") is not that verdict and cannot promote; a document we could read but found no
     recognisable verdict in is 'unknown'; an empty `statuses[]` is 'unknown'. None ⇒ 'unknown' too.
-    Broken verdicts (degraded/unhealthy/…) and a stopped run state → 'degraded'. Worst wins across
-    records (degraded > unknown > live) — an id that answers with several runtimes cannot have the sick
-    one averaged away.
+    A real fault (unhealthy/failed/stopped/…) → 'degraded'; the runtime's own 'degraded' — one errored
+    tick, already clearing — → 'recovering'. Worst wins across records
+    (degraded > recovering > unknown > live) — an id that answers with several runtimes cannot have the
+    sick one averaged away.
 
     'unknown' is NOT PROVEN LIVE — telemetry unavailable, or the runtime itself says it can't vouch for
     the runtime yet (never-heard scanners, right after a restart, a scanner-only runtime whose overall
@@ -470,7 +488,7 @@ def _liveness_from_status(status):
     if status.get("ok") is False:                     # the document itself says it could not answer
         return "unknown"
     verdicts = [_entry_verdict(e) for e in _status_entries(status)]
-    for worst in ("degraded", "unknown", "live"):
+    for worst in ("degraded", "recovering", "unknown", "live"):
         if worst in verdicts:
             return worst
     return "unknown"                                  # no records at all (empty `statuses[]`)
@@ -867,7 +885,11 @@ def fetch_strategies(client, meta):
     # status) whether it's actually healthy, not just registered. runtime_health:
     #   unverified  — the runtime read FAILED; we could not ask ANY of it (never say running/protected)
     #   not_running — the read succeeded and there is no runtime behind an ACTIVE + funded strategy
-    #   degraded    — up but broken: no entry scanners, stopped, or telemetry reports unhealthy
+    #   degraded    — up but broken: no entry scanners, stopped, or the runtime reports unhealthy
+    #                 (>=2 consecutive scan errors)
+    #   recovering  — the runtime's own "degraded": the LAST scan errored, once. It clears on the next
+    #                 successful tick. Not a fault, and not a reason to alarm a user whose strategy is
+    #                 opening and closing positions
     #   live        — registered and telemetry reports healthy. Only this earns "running"
     #   unknown     — NOT PROVEN LIVE (telemetry unavailable, or the runtime won't vouch for it yet)
     # Fail-open + short-circuited by _telemetry_dead; sequential (few per user).
@@ -928,10 +950,15 @@ def fetch_strategies(client, meta):
     if degraded:
         meta["degraded_runtimes"] = degraded
         meta.setdefault("warnings", []).append(
-            f"{len(degraded)} strategy(ies) have a runtime that telemetry reports DEGRADED/unhealthy — "
-            f"registered but not working cleanly. Confirm the cause with senpi-strategy-ops "
+            f"{len(degraded)} strategy(ies) have a runtime the engine reports UNHEALTHY (degraded) — two or more "
+            f"consecutive scan errors, not a blip. Confirm the cause with senpi-strategy-ops "
             f"`diagnose.py <id>` (scanner registered? ticked? no signals yet? erroring?): "
             f"{', '.join(str(d) for d in degraded)}")
+    # NOT a warning: one errored tick that the next successful one clears. Carried so the narration can
+    # mention it if the user asks, never so it can be read back as a fault on a strategy that is trading.
+    recovering = [s["name"] for s in strategies if s.get("runtime_health") == "recovering"]
+    if recovering:
+        meta["recovering_runtimes"] = recovering
     return strategies
 
 

--- a/senpi-portfolio/tests/test_portfolio.py
+++ b/senpi-portfolio/tests/test_portfolio.py
@@ -501,6 +501,24 @@ def test_one_errored_tick_is_recovering_not_a_fault():
     assert strat["runtime_health"] != "live"
 
 
+def test_group_rollup_carries_recovering_rather_than_swallowing_it():
+    """A multi-wallet strategy (ox = core + ballast) rolls its sleeves up to one verdict. `recovering`
+    was missing from that ordering, so BOTH-recovering fell through to the default 'unknown' — telling
+    the user we could not check something we had measured — and recovering+live reported a clean 'live'.
+    Severity: not_running > degraded > unverified > unknown > recovering > live."""
+    order = portfolio._GROUP_HEALTH_WORST_FIRST   # the engine's own tuple, not a copy of it
+
+    def rollup(*healths):
+        insts = [{"runtime_health": h} for h in healths]
+        return next((v for v in order if any(s["runtime_health"] == v for s in insts)), "unknown")
+
+    assert rollup("recovering", "recovering") == "recovering"   # was 'unknown'
+    assert rollup("recovering", "live") == "recovering"         # was 'live'
+    assert rollup("recovering", "degraded") == "degraded"       # a real fault still wins
+    assert rollup("recovering", "unknown") == "unknown"         # unproven outranks a known blip
+    assert rollup("live", "live") == "live"
+
+
 def test_two_consecutive_errors_is_a_real_fault_and_warns():
     """>=2 consecutive scan errors is the engine's 'unhealthy' — the signal that always deserved the
     warning. Unchanged."""

--- a/senpi-portfolio/tests/test_portfolio.py
+++ b/senpi-portfolio/tests/test_portfolio.py
@@ -485,10 +485,26 @@ def test_registered_runtime_healthy_status_is_live():
     assert "degraded_runtimes" not in res["meta"]
 
 
-def test_registered_runtime_degraded_status_is_flagged():
-    """Registered runtime whose telemetry reports degraded/unhealthy → runtime_health 'degraded' + warning
-    (running, but not cleanly — distinct from not_running and from live)."""
+def test_one_errored_tick_is_recovering_not_a_fault():
+    """The runtime's own 'degraded' is `lastRunStatus == "error"` with consecutiveErrorCount 1, and
+    `recordRunComplete` zeroes that counter — so it is already clearing on the next successful tick.
+    Reporting it as a fault put a red warning on strategies that were visibly opening and closing
+    positions, and sent users to an ops script. It is carried, never alarmed on."""
     res = _run_with_status({"kodiak-main": status_doc({"health": "degraded"})})
+    strat = {s["name"]: s for s in res["strategies"]}["kodiak"]
+    assert strat["runtime_health"] == "recovering"
+    assert res["meta"].get("recovering_runtimes") == ["kodiak"]
+    assert "degraded_runtimes" not in res["meta"]
+    assert not any("degraded" in w.lower() for w in res["meta"].get("warnings", [])), \
+        "one bad tick may not raise a warning"
+    # …and it still may not read as clean: fail-closed is unchanged.
+    assert strat["runtime_health"] != "live"
+
+
+def test_two_consecutive_errors_is_a_real_fault_and_warns():
+    """>=2 consecutive scan errors is the engine's 'unhealthy' — the signal that always deserved the
+    warning. Unchanged."""
+    res = _run_with_status({"kodiak-main": status_doc({"health": "unhealthy"})})
     strat = {s["name"]: s for s in res["strategies"]}["kodiak"]
     assert strat["runtime_health"] == "degraded"
     assert res["meta"].get("degraded_runtimes") == ["kodiak"]
@@ -561,14 +577,20 @@ def test_unrecognised_health_verdict_is_not_live():
 
 def test_liveness_mapping_table():
     """Pin the whole `_liveness_from_status` mapping in one place, against the REAL document shape:
-    healthy→live, degraded/unhealthy→degraded, unknown/disabled→unknown, empty `statuses[]`→unknown,
+    healthy→live, unhealthy→degraded, the engine's own degraded→recovering, unknown/disabled→unknown,
+    empty `statuses[]`→unknown,
     a run state→unknown (never promoted) unless it is a broken one (→degraded), and a document with no
     verdict we recognise→unknown. Nothing but a health verdict earns 'live'."""
     doc = status_doc
     assert portfolio._liveness_from_status(doc({"health": "healthy"})) == "live"
     assert portfolio._liveness_from_status(doc({"health": "ok"})) == "live"
-    assert portfolio._liveness_from_status(doc({"health": "degraded"})) == "degraded"
+    assert portfolio._liveness_from_status(doc({"health": "degraded"})) == "recovering"
     assert portfolio._liveness_from_status(doc({"health": "unhealthy"})) == "degraded"
+    # worst wins: a real fault is not softened by a recovering sibling, and vice versa
+    assert portfolio._liveness_from_status(
+        doc({"health": "degraded"}, {"health": "unhealthy"})) == "degraded"
+    assert portfolio._liveness_from_status(
+        doc({"health": "degraded"}, {"health": "healthy"})) == "recovering"
     assert portfolio._liveness_from_status(doc({"health": "unknown"})) == "unknown"
     assert portfolio._liveness_from_status(doc({"health": "disabled"})) == "unknown"
     assert portfolio._liveness_from_status(doc({"health": "sparkling"})) == "unknown"

--- a/senpi-portfolio/tests/test_prescribed_tools_exist.py
+++ b/senpi-portfolio/tests/test_prescribed_tools_exist.py
@@ -1,0 +1,38 @@
+"""Every script this skill tells the agent to run must actually exist.
+
+senpi-portfolio named `diagnose.py` as the confirmation step for a degraded runtime across five
+versions. No such script has ever existed in senpi-strategy-ops. So the agent sent to confirm a
+scary verdict found nothing, and fell back to repeating the unconfirmed verdict to the user as fact
+— on strategies that were visibly trading.
+
+A prescribed remedy that does not exist is worse than no remedy: it converts "I am not sure" into
+"I checked."
+"""
+import pathlib
+import re
+
+import pytest
+
+_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_SKILL = (_ROOT / "senpi-portfolio" / "SKILL.md").read_text(encoding="utf-8")
+_ENGINE = (_ROOT / "senpi-portfolio" / "scripts" / "portfolio.py").read_text(encoding="utf-8")
+
+# `<skill>/scripts/<name>.py` or a bare `<name>.py` next to a skill name.
+_REFS = sorted(set(
+    re.findall(r"`(senpi-[a-z-]+)`[^`\n]{0,40}`(?:scripts/)?([a-z_]+\.py)", _SKILL + _ENGINE)
+    + re.findall(r"(senpi-[a-z-]+)/scripts/([a-z_]+\.py)", _SKILL + _ENGINE)
+))
+
+
+def test_the_scan_found_the_references():
+    """A regex that matched nothing would make the parametrized test below vacuous."""
+    assert _REFS, "no cross-skill script references found — did the phrasing change?"
+
+
+@pytest.mark.parametrize("skill,script", _REFS, ids=lambda v: v)
+def test_prescribed_script_exists(skill, script):
+    path = _ROOT / skill / "scripts" / script
+    assert path.is_file(), (
+        f"{skill}/scripts/{script} is prescribed by senpi-portfolio but does not exist. "
+        f"Available: {sorted(p.name for p in (_ROOT / skill / 'scripts').glob('*.py'))}"
+    )


### PR DESCRIPTION
## The report

A user's agent, on three strategies that were visibly working:

> ⚠️ **Runtime health: degraded.** Telemetry reports ox-ballast's runtime as unhealthy… Worth running `diagnose.py ox` to confirm.

> Positions are live and the scanner is clearly working (13 positions, recent closes), **but something in the monitoring is off.**

Stingray had **13 open positions, 6 closes, +$85 unrealized**. The agent had the contradiction in its own hands and still led with a red warning and an ops script.

## Three faults, one per layer

**1. The engine's two verdicts were collapsed into one.** `derivePushDrivenScannerHealth` in senpi-trading-runtime:

```ts
if (telemetry.lastRunStatus === "error")
  return telemetry.consecutiveErrorCount >= 2 ? "unhealthy" : "degraded";
```

…and `recordRunComplete` zeroes that counter. So the engine's **`degraded` = the last tick errored, once, and the next successful tick clears it**. **`unhealthy` = ≥2 in a row** — a real fault. `_HEALTH_BROKEN` contained both, so a blip rendered identically to a dead scanner.

Split: the engine's `degraded`/`warn` → **`recovering`**; `unhealthy`/`failed`/`error`/`down`/`stopped` stay `degraded`.

**Fail-closed is unchanged** — neither may promote to `live`, worst still wins (`degraded > recovering > unknown > live`), and a run state never yields `recovering` because a stopped process is not mid-recovery.

**2. The skill alarmed on it.** `recovering` now raises no warning and gets no ⚠. If the strategy is opening and closing positions, that *is* the answer to "is it working" — a stale `lastRunStatus` is not.

**3. It prescribed an ops script to a user.** `diagnose.py` was *"the required next step"* for anything not cleanly `live`. It's the agent's tool: run it and give the verdict, never write "worth running `diagnose.py`" into a portfolio answer — and never for `recovering`.

## On the "telemetry is internal" theory

Half right, and the half that's wrong is worth knowing: `portfolio.py` never touches the internal stack. Its "telemetry liveness" is `openclaw senpi status -r <id> --json` — the runtime's own view of itself, read from the user's own box. Legitimate, user-scoped data.

What was wrong was the *word*. Narrating it as "telemetry reports…" makes it sound like we're reading something the user can't see, which is exactly why this looked like an internal tool leaking. Renamed throughout.

## Verification

```
828 passed, 9 skipped
```

Red-green: collapse the two verdicts again → **2 failed / 71 passed**.

New tests pin both sides — one errored tick is `recovering` with no warning *and* still not `live`; two consecutive is `degraded` with the warning, unchanged. The existing regression guard (`test_the_runtime_the_engine_calls_unhealthy_never_reads_live`) is untouched and still passes.

senpi-portfolio 1.16.0 → 1.17.0, README synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)