### PR TITLE
portfolio + ops: quote the runtime's own reason when a strategy is degraded

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Every analytical skill follows the **hidden-engine pattern**: a vendored, stdlib
 | Skill | Ver | Role |
 |---|---|---|
 | **Analyze** | | |
-| [`senpi-portfolio`](senpi-portfolio/) | 1.17.0 | All-wallet portfolio, positions, DSL protection, per-strategy mandate reads |
+| [`senpi-portfolio`](senpi-portfolio/) | 1.18.0 | All-wallet portfolio, positions, DSL protection, per-strategy mandate reads |
 | [`senpi-market-pulse`](senpi-market-pulse/) | 1.2.0 | Daily cross-asset market read (crypto, equities, commodities, macro, funding regime) |
 | [`senpi-smart-money`](senpi-smart-money/) | 1.2.0 | Where the most-profitable wallets are positioned vs. the crowd |
 | [`senpi-trader-research`](senpi-trader-research/) | 1.4.0 | Rank + vet Hyperliquid traders before copying them (mirror-aware: copyability, min-budget, live book) |
@@ -69,7 +69,7 @@ Every analytical skill follows the **hidden-engine pattern**: a vendored, stdlib
 | **Run a strategy** | | |
 | [`senpi-strategy-discover`](senpi-strategy-discover/) | 2.19.0 | Conversational picker — rank the catalog against your worldview |
 | [`senpi-strategy-author`](senpi-strategy-author/) | 3.2.1 | Build/edit a DSL-protected strategy package, one decision at a time |
-| [`senpi-strategy-ops`](senpi-strategy-ops/) | 3.7.0 | Deploy / monitor / close a named strategy (`deploy.py`, `close.py`) |
+| [`senpi-strategy-ops`](senpi-strategy-ops/) | 3.8.0 | Deploy / monitor / close a named strategy (`deploy.py`, `close.py`) |
 | [`senpi-trade`](senpi-trade/) | 1.0.0 | Direct trade or mirror a specific trader — manual positions + copy trading, one decision at a time |
 | [`senpi-trading-runtime`](senpi-trading-runtime/) | 4.0.1 | The runtime contract reference: `scan(inputs, ctx)`, `runtime.yaml`, DSL |
 | **Move money / positioning** | | |

--- a/senpi-portfolio/SKILL.md
+++ b/senpi-portfolio/SKILL.md
@@ -16,7 +16,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "1.17.0"
+  version: "1.18.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -294,6 +294,12 @@ headline and the field is the footnote — do not report the field and bury the 
 
 For `degraded` corroborated by no activity, or `not_running`, work the ladder yourself and report what you
 found. Only the last step touches their money, and only that one needs their consent:
+
+**Before the ladder: if the row carries `runtime_reason`, say it.** It is the runtime's own last error,
+read off `senpi status --json`'s scanner rows (runtime ≥ 3.0.105) — e.g. `jackal_main_signals:
+candidates_rejected: all 2 candidates this tick were rejected at the delivery boundary (last: data key
+'persistenceHours' has wrong type …); nothing delivered`. Quote it in those words; it usually answers
+"why hasn't it traded" before step 1 is needed.
 
 1. **`python3 senpi-strategy-ops/scripts/status.py <id>`** — re-ask the runtime. Verdict + position count.
    **Mind the vocabulary:** `status.py` reports the engine's raw words, and they do not line up with this

--- a/senpi-portfolio/scripts/portfolio.py
+++ b/senpi-portfolio/scripts/portfolio.py
@@ -499,6 +499,22 @@ def _liveness_from_status(status):
     return "unknown"                                  # no records at all (empty `statuses[]`)
 
 
+def _scanner_reasons(status):
+    """The runtime's own words for WHY a scanner is not healthy: each `components.scanners.scanners[]`
+    row's `degradedReason` (runtime >= 3.0.105 — the supervisor's crash-loop cause, else the last tick
+    error while the scanner is erroring). ['<scanner>: <reason>', …] in document order; [] when the
+    runtime carried none. Quoted to the user, never interpreted here."""
+    out = []
+    for entry in (_status_entries(status) if isinstance(status, dict) else []):
+        comps = entry.get("components") if isinstance(entry, dict) else None
+        comp = comps.get("scanners") if isinstance(comps, dict) else None
+        rows = comp.get("scanners") if isinstance(comp, dict) else (comp if isinstance(comp, list) else None)
+        for r in rows or []:
+            if isinstance(r, dict) and r.get("degradedReason"):
+                out.append(f"{r.get('scannerId') or r.get('name') or 'scanner'}: {r['degradedReason']}")
+    return out
+
+
 # ──────────────────────────────────────────────────────────────── strategy profile (catalog enrichment)
 def _catalog_facets(rec):
     """The OPTIONAL template-only enrichment facets, pulled from a strategy's catalog record (its
@@ -918,7 +934,11 @@ def fetch_strategies(client, meta):
             s["runtime_health"] = "degraded"       # the inventory itself says the process is stopped
         else:
             rid = runtime_id_map.get(str(s.get("wallet")).lower())
-            s["runtime_health"] = _liveness_from_status(_fetch_runtime_status(rid, meta) if rid else None)
+            doc = _fetch_runtime_status(rid, meta) if rid else None
+            s["runtime_health"] = _liveness_from_status(doc)
+            reasons = _scanner_reasons(doc)
+            if reasons:
+                s["runtime_reason"] = "; ".join(reasons)   # the runtime's own words — quote them
     # Roll up any strategy reported ACTIVE but holding $0 (empty wallet) — status/clearinghouse mismatch.
     dormant = [s["name"] for s in strategies if s.get("empty")]
     if dormant:
@@ -952,13 +972,17 @@ def fetch_strategies(client, meta):
     # erroring, monitor stalled, etc.). Distinct from not_running (no runtime) and from live (healthy).
     degraded = [s["name"] for s in strategies
                 if s.get("runtime_health") == "degraded" and not s.get("running_blind")]
+    degraded_text = ", ".join(
+        f"{s['name']} ({s['runtime_reason']})" if s.get("runtime_reason") else str(s["name"])
+        for s in strategies if s.get("runtime_health") == "degraded" and not s.get("running_blind"))
     if degraded:
         meta["degraded_runtimes"] = degraded
         meta.setdefault("warnings", []).append(
             f"{len(degraded)} strategy(ies) have a runtime the engine reports UNHEALTHY (degraded) — two or more "
             f"consecutive scan errors, not a blip. Confirm the cause with senpi-strategy-ops "
             f"`status.py <id>` (runtime verdict + position count; `openclaw senpi scanner -r <rt>` for runs/errors/signals): "
-            f"{', '.join(str(d) for d in degraded)}")
+            f"{degraded_text}. A reason in parentheses is the runtime's own last error — tell the user "
+            f"that, in those words, before anything else.")
     # NOT a warning: one errored tick that the next successful one clears. Carried so the narration can
     # mention it if the user asks, never so it can be read back as a fault on a strategy that is trading.
     recovering = [s["name"] for s in strategies if s.get("runtime_health") == "recovering"]

--- a/senpi-portfolio/tests/test_portfolio.py
+++ b/senpi-portfolio/tests/test_portfolio.py
@@ -529,6 +529,21 @@ def test_two_consecutive_errors_is_a_real_fault_and_warns():
     assert any("degraded" in w.lower() for w in res["meta"]["warnings"])
 
 
+def test_a_degraded_runtime_quotes_the_runtimes_own_reason():
+    """The health row's `degradedReason` (runtime >= 3.0.105) is the runtime's own words for why — the
+    thing the user actually asked. Carried on the row and quoted in the warning, verbatim."""
+    reason = ("candidates_rejected: all 2 candidates this tick were rejected at the delivery boundary "
+              "(last: data key 'persistenceHours' has wrong type (expected number, got NoneType)); nothing delivered")
+    res = _run_with_status({"kodiak-main": status_doc({
+        "runtimeName": "kodiak-main", "health": "unhealthy",
+        "components": {"scanners": {"scanners": [
+            {"scannerId": "kodiak_main_signals", "health": "unhealthy", "degradedReason": reason}]}}})})
+    strat = {s["name"]: s for s in res["strategies"]}["kodiak"]
+    assert strat["runtime_health"] == "degraded"
+    assert strat["runtime_reason"] == f"kodiak_main_signals: {reason}"
+    assert any("persistenceHours" in w for w in res["meta"]["warnings"]), "the warning must carry the reason"
+
+
 def test_the_runtime_the_engine_calls_unhealthy_never_reads_live():
     """THE regression this branch made load-bearing, measured against the document the producer really
     writes: `{ok, statuses:[{health:'unhealthy', …}]}`. The verdict lives INSIDE `statuses[]`; a mapper

--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -22,7 +22,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "3.7.0"
+  version: "3.8.0"
   platform: senpi
   exchange: hyperliquid
   requires:

--- a/senpi-strategy-ops/scripts/_cli.py
+++ b/senpi-strategy-ops/scripts/_cli.py
@@ -362,24 +362,36 @@ def scanner_health_in_status(status_entry, scanner_name):
     health verdict for us here. Returns None both when status is unreadable and when the scanner isn't
     (yet) in the list — the caller treats both the same (a running runtime supervises the scanner
     regardless), so there is intentionally no 'was the list populated?' distinction to return."""
+    for r in scanner_rows(status_entry):
+        if dig(r, "scannerId", "name", "scanner") == scanner_name:
+            return str(dig(r, "health") or "").lower() or None
+    return None
+
+
+def scanner_rows(status_entry):
+    """`components.scanners.scanners[]` of a `senpi status` entry, tolerant of a flatter/rewrapped
+    shape; [] when the entry carries none."""
     comp = None
     comps = dig(status_entry, "components")
     if isinstance(comps, dict):
         comp = comps.get("scanners")
     if not isinstance(comp, dict):
-        comp = _deep_first(status_entry, ["scanners"])  # tolerate a flatter/rewrapped shape
+        comp = _deep_first(status_entry, ["scanners"])
     if isinstance(comp, dict):
         rows = comp.get("scanners")
     elif isinstance(comp, list):
         rows = comp
     else:
         rows = None
-    if not isinstance(rows, list):
-        return None
-    for r in rows:
-        if dig(r, "scannerId", "name", "scanner") == scanner_name:
-            return str(dig(r, "health") or "").lower() or None
-    return None
+    return rows if isinstance(rows, list) else []
+
+
+def scanner_reasons(status_entry):
+    """The runtime's own words for why a scanner is not healthy — each row's `degradedReason`
+    (runtime >= 3.0.105: the supervisor's crash-loop cause, else the last tick error while it errors).
+    ['<scanner>: <reason>', …] for QUOTING; [] when the runtime carried none."""
+    return [f"{dig(r, 'scannerId', 'name', 'scanner') or 'scanner'}: {r['degradedReason']}"
+            for r in scanner_rows(status_entry) if isinstance(r, dict) and r.get("degradedReason")]
 
 
 def runtime_health_map(timeout=15):

--- a/senpi-strategy-ops/scripts/status.py
+++ b/senpi-strategy-ops/scripts/status.py
@@ -135,12 +135,14 @@ def build(mcp, only_pkg=None, deep=True):
         # (managed in the app). Only an autonomous PACKAGE strategy (skillName, no trader) is expected to
         # have a runtime — a missing one there is the real anomaly.
         positions = None
+        reason = None
         if rt and _cli.runtime_running(rt):
             health = "running"
             entry = health_by_name.get(_cli.runtime_name(rt))  # from the single fleet-wide status --json
             if entry:  # upgrade process-level "running" to the runtime's own verdict (+ positions)
                 health = _cli.health_verdict(entry) or "running"
                 positions = _cli.active_positions(entry)
+                reason = "; ".join(_cli.scanner_reasons(entry)) or None  # the runtime's words, for quoting
             if _cli.runtime_no_entry_scanners(rt):
                 # positive wiring-failure evidence from the inventory itself ("running — NO ENTRY
                 # SCANNERS"): the runtime is up but cannot produce entry signals — own class, not
@@ -166,7 +168,7 @@ def build(mcp, only_pkg=None, deep=True):
                      "name": name, "name_source": name_source,
                      "strategyId": _cli.strategy_id_of(s), "wallet": wallet,
                      "status": _cli.strategy_status(s), "funded": _cli.strategy_funded(s),
-                     "positions": positions,
+                     "positions": positions, "reason": reason,
                      "runtime": _cli.runtime_name(rt) if rt else None, "health": health})
     # runtimes with no matching OPEN strategy (orphans — trading nothing / on a gone wallet)
     orphans = [{"runtime": _cli.runtime_name(r), "wallet": _cli.runtime_wallet(r),
@@ -231,6 +233,8 @@ def main(argv):
             rt = f"  · runtime {r['runtime']}" if r["runtime"] else ""
             print(f"  {_ICON.get(r['health'], ' ')} {r['health']:<15} {_name_cell(r):<22} "
                   f"{r['wallet'][:10]}…  {_funded(r):>8}  [{(r['strategyId'] or '')[:8]}]{pos}{rt}")
+            if r.get("reason"):
+                print(f"      ↳ {r['reason']}")
     if any(r.get("name_source") != "strategyName" for r in rows):
         print("\nℹ `*` after a name means the strategy record carried NO name of its own — what's shown "
               "is its package id (every instance of that package renders the same), not a name this "

--- a/senpi-strategy-ops/tests/test_status_health.py
+++ b/senpi-strategy-ops/tests/test_status_health.py
@@ -21,6 +21,20 @@ import _cli    # noqa: E402
 import status  # noqa: E402
 
 
+class TestScannerReasons(unittest.TestCase):
+    def test_quotes_each_rows_degraded_reason_by_scanner_name(self):
+        entry = {"health": "unhealthy", "components": {"scanners": {"scanners": [
+            {"scannerId": "jackal_main_signals", "health": "unhealthy",
+             "degradedReason": "candidates_rejected: all 2 candidates this tick were rejected"},
+            {"scannerId": "position_tracker", "health": "healthy"}]}}}
+        self.assertEqual(_cli.scanner_reasons(entry),
+                         ["jackal_main_signals: candidates_rejected: all 2 candidates this tick were rejected"])
+
+    def test_no_rows_or_no_reason_is_an_empty_list_not_none(self):
+        self.assertEqual(_cli.scanner_reasons({"health": "healthy"}), [])
+        self.assertEqual(_cli.scanner_reasons({"components": {"scanners": {"scanners": []}}}), [])
+
+
 class TestHealthVerdict(unittest.TestCase):
     def test_unknown_passes_through(self):
         self.assertEqual(_cli.health_verdict({"health": "unknown"}), "unknown")


### PR DESCRIPTION
## Problem

When a strategy's runtime is degraded, both skills can only say *that*. The reason the runtime recorded (`candidates_rejected: all 2 candidates … (last: data key 'persistenceHours' …)`) never reaches the user — the skills read `senpi status --json`, and until [runtime #395](https://github.com/Senpi-ai/senpi-trading-runtime/pull/395) that read didn't carry it. So "why hasn't it traded?" ends with "run status.py".

## Solution

- **senpi-portfolio 1.18.0** — `runtime_reason` on the strategy row (the runtime's words, from the health rows' `degradedReason`), quoted inside the degraded warning; SKILL.md tells the agent to say it before the ladder.
- **senpi-strategy-ops 3.8.0** — `_cli.scanner_reasons()` beside `scanner_health_in_status()` (both over a shared `scanner_rows()`), `reason` on `status.py` rows, printed under sick ones.

Nothing changes for a healthy runtime (no reason, no line). Tests: one per skill; README version table updated (the surface test enforces it).

Companion: runtime PR #395 (populates the field). Before it ships the field is simply absent and both skills behave as today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
