### PR TITLE
author: advisory warnings (stop distance, multi-slot sizing, daily cap) + shadow-testing reference (3.3.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Every analytical skill follows the **hidden-engine pattern**: a vendored, stdlib
 | [`senpi-account-status`](senpi-account-status/) | 1.2.0 | Points, loyalty tier, fees, referrals |
 | **Run a strategy** | | |
 | [`senpi-strategy-discover`](senpi-strategy-discover/) | 2.19.0 | Conversational picker — rank the catalog against your worldview |
-| [`senpi-strategy-author`](senpi-strategy-author/) | 3.2.1 | Build/edit a DSL-protected strategy package, one decision at a time |
+| [`senpi-strategy-author`](senpi-strategy-author/) | 3.3.0 | Build/edit a DSL-protected strategy package, one decision at a time |
 | [`senpi-strategy-ops`](senpi-strategy-ops/) | 3.7.0 | Deploy / monitor / close a named strategy (`deploy.py`, `close.py`) |
 | [`senpi-trade`](senpi-trade/) | 1.0.0 | Direct trade or mirror a specific trader — manual positions + copy trading, one decision at a time |
 | [`senpi-trading-runtime`](senpi-trading-runtime/) | 4.0.1 | The runtime contract reference: `scan(inputs, ctx)`, `runtime.yaml`, DSL |

--- a/senpi-strategy-author/SKILL.md
+++ b/senpi-strategy-author/SKILL.md
@@ -245,7 +245,7 @@ the catalog entry, then unit-test → lint → `senpi validate` → hand to ops.
 8. **Lint — advisory, instant, no credentials** (pass the package's absolute path,
    `/data/workspace/strategies/<id>`, so they hit the authored copy from any CWD):
    (a) **authoring lint** → `python3 senpi-strategy-author/scripts/validate_strategy.py /data/workspace/strategies/<id>`
-   (candle keys, null-in-schema, mandate description, retention/cooldown bounds) **+ advisory warns you relay to the user**: the stop's distance in price at the recipe's leverage, multi-slot sizing with no free-margin gate, the daily entry cap and what it does;
+   (candle keys, null-in-schema, mandate description, retention/cooldown bounds) **+ advisory warns you relay to the user**: the stop's distance in price at the recipe's leverage, multi-slot sizing with no free-margin gate, a daily entry cap at or below the slot count;
    (b) **universe gate** → `python3 senpi-strategy-ops/scripts/validate_universe.py /data/workspace/strategies/<id>`
    — every hardcoded ticker you TRADE must be a live HL instrument (derived universes, and names under an exclusion key, pass trivially);
    (c) **deploy contract** → `python3 senpi-strategy-ops/scripts/deploy.py validate /data/workspace/strategies/<id>`

--- a/senpi-strategy-author/SKILL.md
+++ b/senpi-strategy-author/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "3.2.1"
+  version: "3.3.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -245,7 +245,7 @@ the catalog entry, then unit-test → lint → `senpi validate` → hand to ops.
 8. **Lint — advisory, instant, no credentials** (pass the package's absolute path,
    `/data/workspace/strategies/<id>`, so they hit the authored copy from any CWD):
    (a) **authoring lint** → `python3 senpi-strategy-author/scripts/validate_strategy.py /data/workspace/strategies/<id>`
-   (candle keys, null-in-schema, mandate description, retention/cooldown bounds);
+   (candle keys, null-in-schema, mandate description, retention/cooldown bounds) **+ advisory warns you relay to the user**: the stop's distance in price at the recipe's leverage, multi-slot sizing with no free-margin gate, the daily entry cap and what it does;
    (b) **universe gate** → `python3 senpi-strategy-ops/scripts/validate_universe.py /data/workspace/strategies/<id>`
    — every hardcoded ticker you TRADE must be a live HL instrument (derived universes, and names under an exclusion key, pass trivially);
    (c) **deploy contract** → `python3 senpi-strategy-ops/scripts/deploy.py validate /data/workspace/strategies/<id>`
@@ -358,7 +358,7 @@ makes one new wallet per instance). Authoring just designs the package; **concur
 
 Same references; usually no rebuild: tune `runtime.yaml` `inputs` (universe/thresholds/sizing), swap
 the `dsl_preset`, adjust `risk.guard_rails`, or change the `scoring.py` math. Re-validate, then
-re-smoke-test if you touched `scan.py`/`runtime.yaml`.
+re-smoke-test if you touched `scan.py`/`runtime.yaml` — on the runtime (`senpi validate`, or a floor-budget wallet), **never by scheduling agent turns to watch it**: an `openclaw cron` job is a model call every time it fires, and a 5-minute one is 288 a day — [`references/shadow-testing.md`](references/shadow-testing.md).
 
 ## Handoff & the live gate — deploy is `senpi-strategy-ops` (NEVER raw MCP); "done" means verified LIVE
 

--- a/senpi-strategy-author/references/creating-a-strategy.md
+++ b/senpi-strategy-author/references/creating-a-strategy.md
@@ -275,12 +275,16 @@ Discovery matches your strategy to users by the `catalog:` block. **Validation o
 ## 9. Prove it runs, then deploy, then confirm it *operates*
 
 ```
-python3 senpi-strategy-author/scripts/validate_strategy.py /data/workspace/strategies/<id>   # advisory lint
+python3 senpi-strategy-author/scripts/validate_strategy.py /data/workspace/strategies/<id>   # advisory lint + warns (stop distance, sizing, daily cap) — relay them
 openclaw senpi validate /data/workspace/strategies/<id>                         # THE GATE — must be PASS. The package root (flat, §2)
 python3 senpi-strategy-ops/scripts/deploy.py create  <id> --budget N            # the whole path: wallet(s) ($10/wallet floor) → install → observed tick
 openclaw senpi deploy status                                                    # read-only: the report; `overall: live` is the gate
 # teardown / redeploy:  close.py <id>  (flattens positions, returns funds)
 ```
+Want to *watch* it before funding? `senpi validate` is the shadow run, and the runtime watches a funded
+strategy for free — **never schedule agent turns to poll it** (each firing is a model call):
+[`shadow-testing.md`](shadow-testing.md).
+
 **"running" ≠ "operating."** Don't trust `status: running`. Confirm the scanner has a **positive run count + a fresh `lastRunFinishedAt`** (`openclaw senpi state -r <id>-main --json`, or `openclaw senpi scanner -r <id>-main` — `-r` is the runtime id, so `<id>-<leg>` per leg on §2's exception), and that it **emits a non-empty set on a tick where it should** — a `live` report proves it *ticked*, not that it produced a signal. Those reads are read-only, and so is `deploy.py verify <id>` (it composes them into a per-instance verdict and deploys nothing); the command that moves money is the resume, `deploy.py runtime <id>` / `create <id> --budget <usd>`. This is an **agent-side check** — run it yourself; never ask the user "is it working?".
 
 ### The gate — `senpi validate`, before any wallet exists

--- a/senpi-strategy-author/references/shadow-testing.md
+++ b/senpi-strategy-author/references/shadow-testing.md
@@ -1,0 +1,75 @@
+# Shadow-testing a strategy — without spending AI credits, and without funding it
+
+"Let me test it first" is the right instinct, and the two cheap ways to do it are the ones people
+skip. The expensive way — scheduling the agent to *watch* the strategy — is how an AI-credit balance
+disappears in days while the strategy itself does nothing.
+
+## Two levels of shadow, cheapest first
+
+**1. A tick with no wallet — `openclaw senpi validate`.** One real scan against live, read-only market
+data: no wallet, no funding, no model call. It prints what the scanner *would have emitted* and
+whether the recipe loads. Re-run it as often as you like; it costs nothing but the tick.
+
+```
+openclaw senpi validate /data/workspace/strategies/<id>      # the dir holding that runtime.yaml
+```
+
+`PASS` = the code runs and read real data. `UNPROVEN` = it returned before reading anything (an
+out-of-session gate that ignores `ctx.dry_run`, say) — not a pass, and not a signal either.
+
+**2. A live run at the floor — the `$10` wallet.** When the user wants to see fills, deploy with the
+minimum budget (a little over $10 per wallet; ops has the exact figure) through
+`senpi-strategy-ops` — never a raw MCP create. The runtime then supervises it every
+`interval_seconds` at **zero model cost**: the scanner, sizing, execution, the DSL exit and the risk
+gates all run inside the runtime process. There is nothing left for the agent to poll.
+
+## Never schedule agent turns to watch it
+
+`openclaw cron add` does **not** run a shell command on a schedule. It schedules an **agent turn**:
+every firing is a full model call, and each one re-reads the whole conversation prefix. A "monitor
+every 5 minutes" job is **288 model calls a day** — at the cost of the entire context each time —
+producing 288 identical "no change" messages. The strategy is already being watched, for free, by
+the runtime.
+
+- **No cron for monitoring.** Read on demand instead (below).
+- If the user insists on a periodic digest, **once or twice a day is the ceiling**, and say what it
+  costs in credits before adding it.
+- Anything you did schedule: `openclaw cron list`, then `openclaw cron rm <id>`. Check for
+  leftovers from earlier sessions — a forgotten job keeps billing after the strategy is closed.
+
+## Read on demand — every one of these is read-only and free of model cost until you narrate it
+
+```
+openclaw senpi scanner -r <runtime_id>           # runs / errors / signals / alive — is it ticking?
+openclaw senpi status -r <runtime_id> --json     # the runtime's own health verdict + risk gates
+openclaw senpi dsl positions                     # what it holds and where each stop sits
+openclaw senpi action history                    # what it did, and why
+python3 senpi-strategy-ops/scripts/status.py     # the fleet view (health, pauses, config drift)
+```
+
+One read when the user asks beats a hundred reads nobody asked for.
+
+## If a background process is genuinely unavoidable
+
+Some tests need a helper process (a data producer the user wrote, say). Launch it **once**,
+detached, with its own log — never from a cron that relaunches it, and never again on the next turn
+"to be safe":
+
+```
+nohup env FOO=bar python3 producer.py > /data/workspace/logs/producer.log 2>&1 &
+disown
+```
+
+Read the log to know what it did. A second launch is a second process, not a restart.
+
+## Paper is not live — label every number
+
+- A `validate` tick **would have** opened; it opened nothing. Say "would have".
+- A scanner **signal** is not a **fill**. Only `dsl positions` / `strategy_list` positions are fills.
+- Never call a `validate` run, a simulation, or an estimate "live", "running" or "a trade". The
+  moment you do, the user manages a position that does not exist.
+
+## Stopping a shadow
+
+`openclaw cron rm <id>` for anything scheduled; `python3 senpi-strategy-ops/scripts/close.py <id>`
+for a funded floor wallet (flattens, returns the funds). Say which one you did.

--- a/senpi-strategy-author/scripts/validate_strategy.py
+++ b/senpi-strategy-author/scripts/validate_strategy.py
@@ -5,6 +5,11 @@ Usage:  python3 validate_strategy.py <package-dir> [<package-dir> ...]
 
 Asserts the manifest ↔ runtime ↔ package consistency the deterministic install
 relies on. Exit 0 = all packages valid; exit 1 = at least one error.
+
+Two channels. `validate()` returns ERRORS (the exit code); `warnings()` returns ADVISORY findings —
+things a green package will still make the user feel in their first week (a stop inside intraday
+noise, multi-slot sizing that the second open cannot fund, a daily entry cap that reads like a dead
+strategy). Warnings never change the exit code; the author relays them.
 """
 # Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
 import ast
@@ -307,6 +312,187 @@ def validate(pkg: Path) -> list:
     return errs
 
 
+# ---------------------------------------------------------------------------------------------
+# ADVISORY warnings — a channel of their own, never an error. Each one is a fact the deploy report
+# cannot say and that a validate PASS does not cover: the package runs, and then behaves like this.
+# ---------------------------------------------------------------------------------------------
+
+# A hard stop closer than this to entry, in PRICE terms, sits inside ordinary intraday movement on
+# most perps. It is hit by a wick, not by the thesis failing, and every hit pays a round trip of fees;
+# the user then reads a string of small losses as "the strategy is broken". `max_loss_pct` is ROE %,
+# so the price distance is max_loss_pct ÷ leverage — more leverage is a TIGHTER stop.
+WARN_STOP_PRICE_PCT = 1.0
+
+_PRESETS_FILE = Path(__file__).resolve().parent.parent / "references" / "dsl-presets.yaml"
+# The free-margin reads a multi-slot scanner makes before it emits (the camel `_get_positions` gate):
+# without one, every signal in a tick is sized off the same balance and only the first can fund.
+_FREE_MARGIN_RE = re.compile(
+    r"withdrawable|free_margin|freeMargin|available_margin|availableMargin|marginSummary|totalMarginUsed")
+
+
+def _num(v):
+    """A real number, or None — bools are not numbers here (`enabled: true` is not a leverage)."""
+    return float(v) if isinstance(v, (int, float)) and not isinstance(v, bool) else None
+
+
+def _nums(v):
+    """Every number inside a scalar / list / dict value (a `leverage: {conservative: 3, …}` map, a
+    `leverageTiers` list of tiers) — the shapes the catalog actually uses for these knobs."""
+    if isinstance(v, dict):
+        return [n for x in v.values() for n in _nums(x)]
+    if isinstance(v, list):
+        return [n for x in v for n in _nums(x)]
+    n = _num(v)
+    return [n] if n is not None else []
+
+
+def _preset_max_loss(name):
+    """`max_loss_pct` of a NAMED preset, read from this skill's own dsl-presets.yaml (None if unknown)."""
+    try:
+        doc = yaml.safe_load(_PRESETS_FILE.read_text()) or {}
+        p = ((doc.get("presets") or {}).get(name) or {}).get("dsl_preset") or {}
+        v = _num(p.get("max_loss_pct"))
+        return v if v is not None else _num((p.get("phase1") or {}).get("max_loss_pct"))
+    except Exception:  # noqa: BLE001 — an unreadable preset file is "cannot tell", never a warning
+        return None
+
+
+def resolved_max_loss_pct(rt_doc):
+    """The hard-stop ROE % this recipe will enforce, or None when it cannot be told from the file.
+    Same order the runtime resolves it in (senpi-trading-runtime/references/runtime-yaml.md:
+    `dsl_preset.max_loss_pct` → `phase1.max_loss_pct`); a named preset is looked up in
+    `references/dsl-presets.yaml`."""
+    ex = rt_doc.get("exit") if isinstance(rt_doc, dict) else None
+    if not isinstance(ex, dict):
+        return None
+    pre = ex.get("dsl_preset")
+    if isinstance(pre, str):
+        return _preset_max_loss(pre)
+    for scope in ((pre if isinstance(pre, dict) else {}), ex):
+        v = _num(scope.get("max_loss_pct"))
+        if v is None and isinstance(scope.get("phase1"), dict):
+            v = _num(scope["phase1"].get("max_loss_pct"))
+        if v is not None:
+            return v
+    return None
+
+
+def max_leverage(rt_doc):
+    """The highest leverage the recipe can trade at, or None: `strategy.default_leverage`, the
+    per-risk `leverage_multipliers`, and the scanner inputs' `leverage` / `maxLeverage` /
+    `leverageTiers` in whatever shape they take (scalar, per-risk map, tier list)."""
+    found = []
+    strat = rt_doc.get("strategy") if isinstance(rt_doc, dict) else None
+    if isinstance(strat, dict):
+        found += _nums(strat.get("default_leverage")) + _nums(strat.get("leverage_multipliers"))
+    for sc in (rt_doc.get("scanners") or []) if isinstance(rt_doc, dict) else []:
+        inp = sc.get("inputs") if isinstance(sc, dict) else None
+        if isinstance(inp, dict):
+            for k in ("leverage", "maxLeverage", "max_leverage", "leverageCap", "leverageTiers"):
+                found += _nums(inp.get(k))
+    found = [v for v in found if v > 0]
+    return max(found) if found else None
+
+
+def slot_plan(rt_doc):
+    """(slots, margin % per slot or None). Slots from `strategy.slots` (the ceiling the runtime
+    enforces), else the scanner's `maxSlots`; margin from `strategy.margin_pct`, else the largest
+    `marginPct`/`marginPctBase` the scanner inputs carry (a PERCENT — see margin_fraction_offenders)."""
+    strat = rt_doc.get("strategy") if isinstance(rt_doc, dict) else None
+    strat = strat if isinstance(strat, dict) else {}
+    slots = _num(strat.get("slots"))
+    margin = _num(strat.get("margin_pct"))
+    for sc in (rt_doc.get("scanners") or []) if isinstance(rt_doc, dict) else []:
+        inp = sc.get("inputs") if isinstance(sc, dict) else None
+        if not isinstance(inp, dict):
+            continue
+        if slots is None:
+            slots = _num(inp.get("maxSlots"))
+        if margin is None:
+            ms = _nums(inp.get("marginPct")) + _nums(inp.get("marginPctBase"))
+            margin = max(ms) if ms else None
+    return (int(slots) if slots and slots >= 1 else 1), margin
+
+
+def _daily_cap(rt_doc):
+    risk = rt_doc.get("risk") if isinstance(rt_doc, dict) else None
+    rails = risk.get("guard_rails") if isinstance(risk, dict) else None
+    return _num(rails.get("max_entries_per_day")) if isinstance(rails, dict) else None
+
+
+def _instances(pkg: Path):
+    """[(name, runtime.yaml path)] — declared instances, or the synthesized flat `main`."""
+    try:
+        man = yaml.safe_load((pkg / "strategy.yaml").read_text()) or {}
+    except Exception:  # noqa: BLE001 — validate() already reported it
+        return []
+    insts = man.get("instances") if isinstance(man, dict) else None
+    if not insts:
+        return [("main", pkg / "runtime.yaml")] if (pkg / "runtime.yaml").is_file() else []
+    return [(i.get("name", "?"), pkg / i["runtime"]) for i in insts
+            if isinstance(i, dict) and i.get("runtime")]
+
+
+def warnings(pkg: Path) -> list:
+    """Advisory findings for a package — never errors, never the exit code. Each names its fix, and
+    each is worded to be RELAYED to the user, because every one of them is something the user will
+    otherwise discover from their fills."""
+    out = []
+    for name, rt in _instances(pkg):
+        try:
+            rt_doc = yaml.safe_load(rt.read_text()) or {}
+        except Exception:  # noqa: BLE001 — unparseable YAML is validate()'s error
+            continue
+        if not isinstance(rt_doc, dict):
+            continue
+        tag = f"instance {name}"
+
+        # [stop] the hard stop's distance in PRICE, at the leverage the recipe can reach
+        ml, lev = resolved_max_loss_pct(rt_doc), max_leverage(rt_doc)
+        if ml and lev:
+            price = ml / lev
+            if price <= WARN_STOP_PRICE_PCT:
+                out.append(
+                    f"{tag}: [stop] the hard stop is {price:.2f}% of price from entry (`max_loss_pct` "
+                    f"{ml:g}% ROE at {lev:g}x) — inside ordinary intraday movement, so expect stop-outs "
+                    f"on wicks rather than on the thesis failing, each paying a round trip of fees. "
+                    f"Widen `max_loss_pct`, lower the leverage, or tell the user this is a known cost "
+                    f"before they fund it (a run of small losses will otherwise read as 'broken')")
+
+        # [sizing] multi-slot: every slot must be fundable, and emits must be gated on free margin
+        slots, margin = slot_plan(rt_doc)
+        if slots > 1:
+            if margin and slots * margin > 100:
+                short = slots - int(100 // margin)
+                out.append(
+                    f"{tag}: [sizing] {slots} slots × {margin:g}% margin = {slots * margin:g}% of the "
+                    f"account — the last {short} slot(s) can never fund, and every tick the scanner "
+                    f"emits for them the runtime logs a failed open (`position_open_failed`). Size so "
+                    f"slots × margin ≤ 100, or run fewer slots")
+            scan = rt.parent / "scanners" / "scan.py"
+            src = scan.read_text() if scan.is_file() else ""
+            if src and not _FREE_MARGIN_RE.search(src):
+                out.append(
+                    f"{tag}: [sizing] a {slots}-slot scanner with no free-margin gate — every signal "
+                    f"in one tick is sized off the same balance read, so the second and later opens "
+                    f"land `position_open_failed` (insufficient margin), tick after tick. Read "
+                    f"`withdrawable` (free margin) in scan.py and emit only what it funds — the camel "
+                    f"`_get_positions` gate")
+
+        # [cap] the daily entry cap is the strategy's own rule; unsaid, it reads as a dead strategy
+        cap = _daily_cap(rt_doc)
+        if cap:
+            msg = (f"{tag}: [cap] `max_entries_per_day: {cap:g}` — after {cap:g} opens in a UTC day "
+                   f"the runtime logs `Runtime paused: Max Entries/Day` and opens nothing until 00:00 "
+                   f"UTC. That is the strategy's own rule, not a fault: say it in the How-it-runs "
+                   f"summary, or the quiet reads as a dead strategy")
+            if cap <= slots:
+                msg += (f". At {slots} slots the cap fills the book once — every re-entry after a "
+                        f"stop-out waits for UTC midnight")
+            out.append(msg)
+    return out
+
+
 def main(argv):
     if len(argv) < 2:
         sys.exit(__doc__)
@@ -324,6 +510,12 @@ def main(argv):
             n = len(man.get("instances") or [])
             label = f"{n} instance(s)" if n else "flat single-instance"
             print(f"✓ {pkg.name} v{man.get('version')} ({label})")
+        # Advisory, under the verdict, whatever the verdict was: the exit code is the errors' alone.
+        warns = warnings(pkg)
+        if warns:
+            print(f"  ⚠ {len(warns)} advisory warning(s) — not blocking; relay each to the user:")
+            for w in warns:
+                print(f"    - {w}")
     sys.exit(1 if bad else 0)
 
 

--- a/senpi-strategy-author/scripts/validate_strategy.py
+++ b/senpi-strategy-author/scripts/validate_strategy.py
@@ -8,8 +8,7 @@ relies on. Exit 0 = all packages valid; exit 1 = at least one error.
 
 Two channels. `validate()` returns ERRORS (the exit code); `warnings()` returns ADVISORY findings —
 things a green package will still make the user feel in their first week (a stop inside intraday
-noise, multi-slot sizing that the second open cannot fund, a daily entry cap that reads like a dead
-strategy). Warnings never change the exit code; the author relays them.
+noise, multi-slot sizing that the second open cannot fund, a daily entry cap at or below the slot count, a daily entry cap at or below the slot count). Warnings never change the exit code; the author relays them.
 """
 # Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
 import ast
@@ -326,6 +325,7 @@ WARN_STOP_PRICE_PCT = 1.0
 _PRESETS_FILE = Path(__file__).resolve().parent.parent / "references" / "dsl-presets.yaml"
 # The free-margin reads a multi-slot scanner makes before it emits (the camel `_get_positions` gate):
 # without one, every signal in a tick is sized off the same balance and only the first can fund.
+# Searched across every module in `scanners/` — authored packages split the read into a sibling file.
 _FREE_MARGIN_RE = re.compile(
     r"withdrawable|free_margin|freeMargin|available_margin|availableMargin|marginSummary|totalMarginUsed")
 
@@ -454,10 +454,11 @@ def warnings(pkg: Path) -> list:
             if price <= WARN_STOP_PRICE_PCT:
                 out.append(
                     f"{tag}: [stop] the hard stop is {price:.2f}% of price from entry (`max_loss_pct` "
-                    f"{ml:g}% ROE at {lev:g}x) — inside ordinary intraday movement, so expect stop-outs "
-                    f"on wicks rather than on the thesis failing, each paying a round trip of fees. "
-                    f"Widen `max_loss_pct`, lower the leverage, or tell the user this is a known cost "
-                    f"before they fund it (a run of small losses will otherwise read as 'broken')")
+                    f"{ml:g}% ROE at {lev:g}x). For a crypto perp that is inside ordinary intraday "
+                    f"movement, so expect stop-outs on wicks rather than on the thesis failing, each paying "
+                    f"a round trip of fees; for an `xyz:` equity, index or commodity, judge it against that "
+                    f"market's own daily range. Widen `max_loss_pct`, lower the leverage, or tell the user "
+                    f"this is a known cost before they fund it (a run of small losses otherwise reads as 'broken')")
 
         # [sizing] multi-slot: every slot must be fundable, and emits must be gated on free margin
         slots, margin = slot_plan(rt_doc)
@@ -469,8 +470,8 @@ def warnings(pkg: Path) -> list:
                     f"account — the last {short} slot(s) can never fund, and every tick the scanner "
                     f"emits for them the runtime logs a failed open (`position_open_failed`). Size so "
                     f"slots × margin ≤ 100, or run fewer slots")
-            scan = rt.parent / "scanners" / "scan.py"
-            src = scan.read_text() if scan.is_file() else ""
+            scn = rt.parent / "scanners"
+            src = "\n".join(f.read_text() for f in sorted(scn.glob("*.py"))) if scn.is_dir() else ""
             if src and not _FREE_MARGIN_RE.search(src):
                 out.append(
                     f"{tag}: [sizing] a {slots}-slot scanner with no free-margin gate — every signal "
@@ -479,17 +480,17 @@ def warnings(pkg: Path) -> list:
                     f"`withdrawable` (free margin) in scan.py and emit only what it funds — the camel "
                     f"`_get_positions` gate")
 
-        # [cap] the daily entry cap is the strategy's own rule; unsaid, it reads as a dead strategy
+        # [cap] a daily entry cap is normal practice (most catalog packages set one) and the How-it-runs
+        # summary already says it; only a cap AT OR BELOW the slot count is worth a warning — the book
+        # fills once, and every re-entry after a stop-out waits for UTC midnight.
         cap = _daily_cap(rt_doc)
-        if cap:
-            msg = (f"{tag}: [cap] `max_entries_per_day: {cap:g}` — after {cap:g} opens in a UTC day "
-                   f"the runtime logs `Runtime paused: Max Entries/Day` and opens nothing until 00:00 "
-                   f"UTC. That is the strategy's own rule, not a fault: say it in the How-it-runs "
-                   f"summary, or the quiet reads as a dead strategy")
-            if cap <= slots:
-                msg += (f". At {slots} slots the cap fills the book once — every re-entry after a "
-                        f"stop-out waits for UTC midnight")
-            out.append(msg)
+        if cap and cap <= slots:
+            out.append(
+                f"{tag}: [cap] `max_entries_per_day: {cap:g}` is at or below the {slots} slot(s): the "
+                f"book fills once, then every re-entry after a stop-out waits for 00:00 UTC — the runtime "
+                f"logs `Runtime paused: Max Entries/Day` until then. That is the strategy's own rule, not "
+                f"a fault: say it in the How-it-runs summary, or the quiet reads as a dead strategy; raise "
+                f"the cap or lower the slots if re-entries are meant to happen")
     return out
 
 

--- a/senpi-strategy-author/tests/test_validate_warnings.py
+++ b/senpi-strategy-author/tests/test_validate_warnings.py
@@ -8,7 +8,8 @@ Three findings a green package does not surface and a user learns from their fil
 * multi-slot sizing the runtime cannot fund: slots × margin over 100%, or a scanner that emits
   several signals per tick with no free-margin gate (every open after the first lands
   `position_open_failed`);
-* a daily entry cap, which pauses the runtime by design — unsaid, the quiet reads as a dead strategy.
+* a daily entry cap at or below the slot count — the book fills once, then every re-entry waits for
+  UTC midnight; a cap with room to spare is normal practice and stays silent.
 
 None of them may ever fail validation: the exit code belongs to `validate()` alone.
 
@@ -125,19 +126,27 @@ def test_single_slot_never_raises_sizing_warnings(tmp_path):
 
 # ---- [cap] ----
 
-def test_daily_cap_is_surfaced_and_a_cap_at_or_below_slots_says_so(tmp_path):
+def test_daily_cap_at_or_below_slots_warns(tmp_path):
     risk = "risk:\n  guard_rails:\n    max_entries_per_day: 4\n"
     w = vs.warnings(_package(tmp_path, slots=4, margin=20, scan=_GATED_SCAN, risk=risk))
     cap = [x for x in w if "[cap]" in x]
     assert len(cap) == 1
-    assert "Runtime paused: Max Entries/Day" in cap[0] and "fills the book once" in cap[0]
+    assert "Runtime paused: Max Entries/Day" in cap[0] and "book fills once" in cap[0]
 
 
-def test_daily_cap_above_slots_is_a_plain_note(tmp_path):
+def test_daily_cap_with_room_to_spare_is_silent(tmp_path):
+    # Setting a cap is normal practice (most catalog packages do); the How-it-runs summary names it.
+    # A channel that fires on every package stops being read, so only cap <= slots is a warning.
     risk = "risk:\n  guard_rails:\n    max_entries_per_day: 12\n"
     w = vs.warnings(_package(tmp_path, slots=2, margin=20, scan=_GATED_SCAN, risk=risk))
-    cap = [x for x in w if "[cap]" in x]
-    assert len(cap) == 1 and "fills the book once" not in cap[0]
+    assert not [x for x in w if "[cap]" in x]
+
+
+def test_free_margin_idiom_in_a_sibling_module_counts(tmp_path):
+    # Authored packages split the balance read into scoring.py or a helper; the gate is still there.
+    d = _package(tmp_path, slots=3, margin=20, scan=_BLIND_SCAN)
+    (d / "scanners" / "sizing.py").write_text("def free(ctx):\n    return float(ctx.clearinghouse()['withdrawable'])\n")
+    assert not any("no free-margin gate" in x for x in vs.warnings(d))
 
 
 def test_no_cap_no_note(tmp_path):

--- a/senpi-strategy-author/tests/test_validate_warnings.py
+++ b/senpi-strategy-author/tests/test_validate_warnings.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""The validator's ADVISORY channel — `warnings()` — and the wall between it and `validate()`.
+
+Three findings a green package does not surface and a user learns from their fills instead:
+
+* a hard stop whose PRICE distance (max_loss_pct ÷ leverage) sits inside intraday noise — a run of
+  wick stop-outs that reads as "the strategy is broken";
+* multi-slot sizing the runtime cannot fund: slots × margin over 100%, or a scanner that emits
+  several signals per tick with no free-margin gate (every open after the first lands
+  `position_open_failed`);
+* a daily entry cap, which pauses the runtime by design — unsaid, the quiet reads as a dead strategy.
+
+None of them may ever fail validation: the exit code belongs to `validate()` alone.
+
+    python3 -m pytest senpi-strategy-author/tests/test_validate_warnings.py
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import contextlib
+import io
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(HERE, "..", "scripts"))
+
+import validate_strategy as vs  # noqa: E402
+
+_RUNTIME = """\
+name: {sid}-main
+group: {sid}
+description: >
+  A fixture recipe whose only variables are the sizing, leverage, exit and risk knobs, so each
+  advisory warning can be provoked on its own and nothing else colours the result.
+strategy:
+  wallet: "${{FIX_WALLET}}"
+  slots: {slots}
+  margin_pct: {margin}
+  default_leverage: {leverage}
+exit:
+{exit}
+scanners:
+  - type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 900
+    inputs: {{}}
+    signal_data_schema:
+      score:
+        type: float
+{risk}"""
+
+_GATED_SCAN = ("def scan(inputs, ctx):\n"
+               "    free = float(ctx.clearinghouse().get('withdrawable', 0))\n"
+               "    return [] if free < 10 else []\n")
+_BLIND_SCAN = "def scan(inputs, ctx):\n    return []\n"
+
+
+def _package(tmp_path, sid="fix", slots=1, margin=20, leverage=3, exit_block="  dsl_preset: balanced",
+             risk="", scan=_BLIND_SCAN):
+    d = tmp_path / sid
+    (d / "scanners").mkdir(parents=True)
+    (d / "strategy.yaml").write_text(f'id: {sid}\nversion: "1.0.0"\n')   # FLAT: main is synthesized
+    (d / "runtime.yaml").write_text(_RUNTIME.format(sid=sid, slots=slots, margin=margin,
+                                                    leverage=leverage, exit=exit_block, risk=risk))
+    (d / "scanners" / "scan.py").write_text(scan)
+    (d / "scanners" / "scoring.py").write_text("def score(x):\n    return x\n")
+    return d
+
+
+def _kinds(warns):
+    return [w.split("[", 1)[1].split("]", 1)[0] for w in warns if "[" in w]
+
+
+# ---- [stop] ----
+
+def test_tight_stop_at_high_leverage_warns_with_the_arithmetic(tmp_path):
+    # balanced = 8% ROE; at 10x that is 0.8% of price — inside a wick.
+    w = vs.warnings(_package(tmp_path, leverage=10))
+    stop = [x for x in w if "[stop]" in x]
+    assert len(stop) == 1
+    assert "0.80% of price" in stop[0] and "8% ROE at 10x" in stop[0]
+
+
+def test_roomy_stop_does_not_warn(tmp_path):
+    # balanced 8% at 2x = 4% of price.
+    assert not [x for x in vs.warnings(_package(tmp_path, leverage=2)) if "[stop]" in x]
+
+
+def test_inline_preset_and_scanner_leverage_are_read(tmp_path):
+    # Inline max_loss_pct 10 with scanner-input leverage tiers up to 20 → 0.5%.
+    d = _package(tmp_path, leverage=2, exit_block="  dsl_preset:\n    max_loss_pct: 10\n    phase1:\n      enabled: false")
+    rt = d / "runtime.yaml"
+    rt.write_text(rt.read_text().replace("inputs: {}", "inputs:\n      leverageTiers: [5, 20]"))
+    assert vs.max_leverage(__import__("yaml").safe_load(rt.read_text())) == 20
+    assert [x for x in vs.warnings(d) if "[stop]" in x]
+
+
+def test_unknown_leverage_or_preset_is_silent(tmp_path):
+    d = _package(tmp_path, leverage=10, exit_block="  dsl_preset: no_such_preset")
+    assert not [x for x in vs.warnings(d) if "[stop]" in x]
+
+
+# ---- [sizing] ----
+
+def test_multi_slot_without_free_margin_gate_warns(tmp_path):
+    w = vs.warnings(_package(tmp_path, slots=3, margin=20, scan=_BLIND_SCAN))
+    assert any("no free-margin gate" in x for x in w)
+    assert not any("can never fund" in x for x in w)        # 3 × 20 = 60% — fundable
+
+
+def test_free_margin_idiom_clears_the_gate_warning(tmp_path):
+    w = vs.warnings(_package(tmp_path, slots=3, margin=20, scan=_GATED_SCAN))
+    assert not any("no free-margin gate" in x for x in w)
+
+
+def test_overcommitted_slots_warn_with_the_count_that_cannot_fund(tmp_path):
+    w = vs.warnings(_package(tmp_path, slots=3, margin=40, scan=_GATED_SCAN))
+    over = [x for x in w if "can never fund" in x]
+    assert len(over) == 1 and "3 slots × 40% margin = 120%" in over[0] and "last 1 slot" in over[0]
+
+
+def test_single_slot_never_raises_sizing_warnings(tmp_path):
+    assert "sizing" not in _kinds(vs.warnings(_package(tmp_path, slots=1, margin=90, scan=_BLIND_SCAN)))
+
+
+# ---- [cap] ----
+
+def test_daily_cap_is_surfaced_and_a_cap_at_or_below_slots_says_so(tmp_path):
+    risk = "risk:\n  guard_rails:\n    max_entries_per_day: 4\n"
+    w = vs.warnings(_package(tmp_path, slots=4, margin=20, scan=_GATED_SCAN, risk=risk))
+    cap = [x for x in w if "[cap]" in x]
+    assert len(cap) == 1
+    assert "Runtime paused: Max Entries/Day" in cap[0] and "fills the book once" in cap[0]
+
+
+def test_daily_cap_above_slots_is_a_plain_note(tmp_path):
+    risk = "risk:\n  guard_rails:\n    max_entries_per_day: 12\n"
+    w = vs.warnings(_package(tmp_path, slots=2, margin=20, scan=_GATED_SCAN, risk=risk))
+    cap = [x for x in w if "[cap]" in x]
+    assert len(cap) == 1 and "fills the book once" not in cap[0]
+
+
+def test_no_cap_no_note(tmp_path):
+    assert "cap" not in _kinds(vs.warnings(_package(tmp_path)))
+
+
+# ---- the wall between the channels ----
+
+def test_warnings_never_become_errors(tmp_path):
+    risk = "risk:\n  guard_rails:\n    max_entries_per_day: 2\n"
+    d = _package(tmp_path, slots=3, margin=40, leverage=20, scan=_BLIND_SCAN, risk=risk)
+    assert vs.validate(d) == []                       # green
+    assert len(vs.warnings(d)) >= 4                   # and loud
+
+
+def test_main_prints_warnings_under_the_verdict_and_exits_zero(tmp_path):
+    d = _package(tmp_path, leverage=10)
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        try:
+            vs.main(["validate_strategy.py", str(d)])
+        except SystemExit as e:
+            code = e.code
+    out = buf.getvalue()
+    assert code == 0
+    assert out.startswith("✓ fix") and "advisory warning" in out and "[stop]" in out


### PR DESCRIPTION
## Why

A package can pass every check we have and still behave, from the user's side, like a broken strategy in its first week: a hard stop that sits inside a wick, three slots the account can only fund one of, a daily entry cap that silently pauses the runtime. None of that is an *error* — the package runs — so the validator had no way to say it. And the most expensive way to "test" a strategy (scheduling the agent to watch it) had no reference telling authors why not.

## What changed

**`scripts/validate_strategy.py` — a second channel, `warnings()`.** Advisory, printed under the verdict, never the exit code. Three findings, each worded to be relayed to the user:

| tag | fires when | says |
|---|---|---|
| `[stop]` | `max_loss_pct ÷ leverage ≤ 1.0%` of price (named preset from `dsl-presets.yaml` or inline; leverage from `default_leverage`, `leverage_multipliers`, or scanner `leverage`/`maxLeverage`/`leverageTiers` in any shape) | the distance in price, that it is inside intraday noise, and the three ways out |
| `[sizing]` | `slots × margin > 100%`, or a multi-slot scanner with no free-margin read (`withdrawable` / `free_margin` / … — the camel `_get_positions` gate) before it emits | which slots can never fund; that the 2nd+ open lands `position_open_failed` every tick |
| `[cap]` | `risk.guard_rails.max_entries_per_day` is set | that the runtime logs `Runtime paused: Max Entries/Day` and opens nothing until 00:00 UTC — its own rule, not a fault; extra note when the cap ≤ slots |

Catalog sweep at the 1.0% threshold: 21 of 109 packages get a `[stop]` note (e.g. 8% ROE at 17x = 0.47% of price), 1 is over-committed, 24 multi-slot scanners carry no free-margin gate. All advisory.

**`references/shadow-testing.md`** — the two cheap shadows (`senpi validate` tick, floor-budget wallet), why an `openclaw cron` job is a model call per firing (a 5-minute monitor = 288/day, each paying the whole context), read-on-demand commands, `nohup … & disown` if a process is unavoidable, and the paper-vs-live labeling rule.

**`SKILL.md`** — two lines extended in place (lint step relays the warns; the edit section points at shadow-testing instead of cron polling). Body stays at the 386-line budget. `creating-a-strategy.md` §9 gets the same pointer. `senpi-strategy-author` 3.2.1 → 3.3.0 (frontmatter + README).

## Tests

`tests/test_validate_warnings.py` (13 cases): each warning on/off, the arithmetic in the message, unknown leverage/preset stays silent, and the wall between channels (`validate()` green while `warnings()` is loud; `main` exits 0 with them printed).

```
python3 -m pytest senpi-strategy-author/tests senpi-strategy-ops/tests/test_skill_surface.py -q
201 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
