### PR TITLE
ops: deploy.py update wrapper, risk-gate pause + config drift in status.py, approval-gate rule (3.8.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ Every analytical skill follows the **hidden-engine pattern**: a vendored, stdlib
 | **Run a strategy** | | |
 | [`senpi-strategy-discover`](senpi-strategy-discover/) | 2.19.0 | Conversational picker — rank the catalog against your worldview |
 | [`senpi-strategy-author`](senpi-strategy-author/) | 3.2.1 | Build/edit a DSL-protected strategy package, one decision at a time |
-| [`senpi-strategy-ops`](senpi-strategy-ops/) | 3.7.0 | Deploy / monitor / close a named strategy (`deploy.py`, `close.py`) |
+| [`senpi-strategy-ops`](senpi-strategy-ops/) | 3.8.0 | Deploy / monitor / close a named strategy (`deploy.py`, `close.py`) |
 | [`senpi-trade`](senpi-trade/) | 1.0.0 | Direct trade or mirror a specific trader — manual positions + copy trading, one decision at a time |
-| [`senpi-trading-runtime`](senpi-trading-runtime/) | 4.0.1 | The runtime contract reference: `scan(inputs, ctx)`, `runtime.yaml`, DSL |
+| [`senpi-trading-runtime`](senpi-trading-runtime/) | 4.0.2 | The runtime contract reference: `scan(inputs, ctx)`, `runtime.yaml`, DSL |
 | **Move money / positioning** | | |
 | [`senpi-deposit-withdraw-transfer`](senpi-deposit-withdraw-transfer/) | 1.1.0 | The money-movement rails (funds in via embedded wallet or in-app USDC purchase; out via the app) |
 | [`senpi-why`](senpi-why/) | 1.0.3 | "Why Senpi / vs. other tools" — the positioning answer |

--- a/senpi-strategy-author/SKILL.md
+++ b/senpi-strategy-author/SKILL.md
@@ -352,10 +352,10 @@ loop every time:
 > deployed package — "make my live strategy more aggressive", re-tune, re-score) — then hand it to
 > **`senpi-strategy-ops`**, which applies it IN PLACE with `openclaw senpi update`: no close, no fresh
 > wallet, no market exit. **Re-running `create` will NOT apply it** — the deploy verb is idempotent, so it
-> adopts the existing wallet and leaves the deployed scanner as it is. Tell the user two things: exit
-> changes are **forward-only**, so a tightened `dsl_preset` governs new entries and never reaches a
-> position already open; and a changed `strategy.wallet`, a renamed or moved scanner or a changed
-> `action_type` still forces a close-and-redeploy — a market exit. Below is the not-yet-live path.
+> adopts the existing wallet and leaves the deployed scanner as it is. Tell the user two things:
+> `dsl_preset` is **forward-only** — new entries only, never a position already open (other `exit:` fields
+> like `order_type` DO reach open ones); and a changed `strategy.wallet`, a renamed or moved external
+> scanner or a changed `action_type` still forces close-and-redeploy — a market exit. Below: the not-yet-live path.
 
 1. **Confirm with the user** — budget + "ready to deploy?" Funding a wallet is real money and one-way, so
    this is an explicit yes, not an assumption.

--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -310,10 +310,10 @@ the deployed scanner as it is.
 **Apply it in place — `openclaw senpi update`.** No close, no fresh wallet, no market exit; DSL state,
 scanner stores and action history survive. `senpi validate <instance-dir>` writes the proof `--apply`
 needs; `senpi update <instance-dir> --id <runtime_id>` PLANS, the same with `--apply` commits. **Read the
-plan out first**: exit changes are **forward-only** — a tightened `dsl_preset` governs new entries only and
-never reaches one already open, so never let "I made it tighter" be heard as "my open trades are tighter".
+plan out first**: `dsl_preset` is **forward-only** — new entries only, never one already open (other `exit:`
+fields, e.g. `order_type`, DO reach open positions) — never let "tighter" be heard as "my open trades are tighter".
 
-**Only a changed `strategy.wallet`, a renamed or moved scanner, or a changed `action_type` still need
+**Only a changed `strategy.wallet`, a renamed or moved external scanner, or a changed `action_type` still need
 close-and-redeploy**, which market-exits every open position and drops any custom ratchet ladder — take
 **explicit consent in those words first**. Everything else: [`references/editing-a-live-strategy.md`](references/editing-a-live-strategy.md).
 

--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -22,7 +22,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "3.7.0"
+  version: "3.8.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -210,9 +210,7 @@ in [`references/refusal-playbook.md`](references/refusal-playbook.md):
 
 ### Report from the structured output, not raw logs
 
-Then always close with the **How it runs** block below. `funded` is the backend's `totalFunded` and the
-tick line is the scanner row's own fields — **quote both verbatim** (the document's shape:
-[`references/lifecycle.md`](references/lifecycle.md)).
+Then always close with the **How it runs** block below. `funded` is the backend's `totalFunded` and the tick line is the scanner row's own fields — **quote both verbatim** (the document's shape: [`references/lifecycle.md`](references/lifecycle.md)).
 
 ### The funded path — `deploy.py create|runtime`
 
@@ -238,11 +236,8 @@ one resumes, adopting whatever already exists.
 > [`references/refusal-playbook.md`](references/refusal-playbook.md).
 
 ### Host prerequisites
-`openclaw` + the `@senpi-ai/runtime` plugin running, and a plugin **new enough to carry the `senpi
-deploy` verb** — on a skewed box the start fails at exit `1` saying which side is behind, with
-**nothing dispatched**: no job, no wallet, no funds ([`references/lifecycle.md`](references/lifecycle.md)
-has both directions and the fix). Also: `SENPI_AUTH_TOKEN` exported (the same token the MCP session
-uses); **Python 3 only — no PyYAML/pip needed**. Smoke with `deploy.py validate <id>` first.
+`openclaw` + the `@senpi-ai/runtime` plugin running, **new enough to carry the `senpi deploy` verb** — on a skewed box the start fails at exit `1` saying which side is behind, with **nothing dispatched**: no job, no wallet, no funds ([`references/lifecycle.md`](references/lifecycle.md) has both directions and the fix).
+Also `SENPI_AUTH_TOKEN` exported (the same token the MCP session uses); **Python 3 only — no PyYAML/pip needed**. Smoke with `deploy.py validate <id>` first.
 
 ### Final step — tell the user HOW each strategy runs (REQUIRED on every deploy)
 
@@ -252,7 +247,9 @@ The user just funded a strategy; the last thing they see must explain **how the 
 - **Scoring — what it grades and the entry bar.** One or two sentences: the catalog `belief_plain`/`thesis` (what signal it scores) + the runtime `inputs` gate (`minScore` and the conviction bands, `leverageTiers`/`marginPctTiers`). e.g. "ranks the book by relative strength + smart-money lean; opens a name only above its score threshold, sizing bigger at higher conviction (leverage steps up base→apex)."
 - **Protection — the DSL exit ladder.** From `exit.dsl_preset`: the hard stop (`phase1.max_loss_pct`), the profit-lock ladder (`phase2.tiers`: first `trigger_pct` → top `lock_hw_pct`), and any time cut (`weak_peak_cut`/`hard_timeout`). State whether it has a manual close action or is **DSL-only** (no `CLOSE_POSITION` action → "no manual exits — the stop does all the selling"). e.g. "hard stop at −18% from entry; as a winner runs, a trailing floor ratchets up, locking profit from +8% to +80%; a stalled position is cut at 48h."
 
-Keep it to ~3 short lines per strategy. Multi-instance packages whose legs differ (e.g. a long book vs a short book, core vs ballast) get one block each **or** a shared block that names the per-side difference. This is what turns "it's live" into "here's exactly how it trades" — required even when the user didn't ask.
+- **Cap — how many entries a day.** From `risk.guard_rails.max_entries_per_day`: say the number, and that once it is hit the runtime logs `Runtime paused: Max Entries/Day` and opens nothing until 00:00 UTC — its own rule, not a fault. While it holds, `status.py` shows the row as **⏸ paused** (health stays ✅).
+
+Keep it to ~4 short lines per strategy. Multi-instance packages whose legs differ (e.g. a long book vs a short book, core vs ballast) get one block each **or** a shared block that names the per-side difference. This is what turns "it's live" into "here's exactly how it trades" — required even when the user didn't ask.
 
 ## Monitor — what am I running? / is it actually live?
 
@@ -264,6 +261,8 @@ ephemeral deploy state — so **don't hand-compose `strategy_list`**. A strategy
 "broken"**: it is just not autonomous, and `status.py` labels how it is managed (copy, manual, …) — never
 call it idle. The one real anomaly is an autonomous package strategy missing its runtime
 (**no-runtime**). Full label set: [`references/lifecycle.md`](references/lifecycle.md).
+Two more facts ride every deep row, because health alone misleads on both: **⏸ paused** — the runtime's OWN risk gate (`components.risk`) holds entries (daily cap, loss halt, cooldown), printed with the gate's reason and reset verbatim; health stays ✅, nothing is broken, and closing/redeploying resets nothing but the book. **✎ running recipe ≠ disk** — the descriptor the runtime renders differs from the package on disk: an edit that was never applied → `deploy.py update` (below).
+When YOU call a trade tool (`ratchet_stop_add`, `strategy_close`, `create_position`…) it runs behind the user's trade-approval gate: an unapproved call times out, is **denied**, and returns an **EMPTY** result. Empty = not executed — say the approval timed out and nothing was placed; never report it as done, never re-issue it in a loop.
 
 **"Are my open positions protected? / do they have a stop-loss?"** → the DSL coverage verdict (PROTECTED
 / UNPROTECTED / STOP-NOT-ON-VENUE) — a separate read, not the runtime list above. Key trap: an
@@ -309,7 +308,7 @@ the deployed scanner as it is.
 
 **Apply it in place — `openclaw senpi update`.** No close, no fresh wallet, no market exit; DSL state,
 scanner stores and action history survive. `senpi validate <instance-dir>` writes the proof `--apply`
-needs; `senpi update <instance-dir> --id <runtime_id>` PLANS, the same with `--apply` commits. **Read the
+needs; `python3 senpi-strategy-ops/scripts/deploy.py update <pkg> --id <runtime_id>` PLANS (the structural preflight, then the verb; add `--apply` to commit — it stops if the box has no `update` verb yet: then STOP too, never close-and-redeploy). **Read the
 plan out first**: `dsl_preset` is **forward-only** — new entries only, never one already open (other `exit:`
 fields, e.g. `order_type`, DO reach open positions) — never let "tighter" be heard as "my open trades are tighter".
 
@@ -325,6 +324,4 @@ close-and-redeploy**, which market-exits every open position and drops any custo
 
 ## Install — include the MCP helper
 
-The scripts in `scripts/` import a vendored MCP helper, `scripts/mcp_client.py`, at runtime.
-**Install the whole `scripts/` directory** — omitting `mcp_client.py` fails with `No module named
-'mcp_client'`. Stdlib only, no other runtime dependencies.
+The scripts import a vendored MCP helper, `scripts/mcp_client.py`, at runtime — **install the whole `scripts/` directory** (omitting `mcp_client.py` fails with `No module named 'mcp_client'`). Stdlib only, no other runtime dependencies.

--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -262,7 +262,7 @@ ephemeral deploy state — so **don't hand-compose `strategy_list`**. A strategy
 call it idle. The one real anomaly is an autonomous package strategy missing its runtime
 (**no-runtime**). Full label set: [`references/lifecycle.md`](references/lifecycle.md).
 Two more facts ride every deep row, because health alone misleads on both: **⏸ paused** — the runtime's OWN risk gate (`components.risk`) holds entries (daily cap, loss halt, cooldown), printed with the gate's reason and reset verbatim; health stays ✅, nothing is broken, and closing/redeploying resets nothing but the book. **✎ running recipe ≠ disk** — the descriptor the runtime renders differs from the package on disk: an edit that was never applied → `deploy.py update` (below).
-When YOU call a trade tool (`ratchet_stop_add`, `strategy_close`, `create_position`…) it runs behind the user's trade-approval gate: an unapproved call times out, is **denied**, and returns an **EMPTY** result. Empty = not executed — say the approval timed out and nothing was placed; never report it as done, never re-issue it in a loop.
+When YOU call a trade tool (`ratchet_stop_add`, `strategy_close`, `create_position`…) it runs behind the user's trade-approval gate: an unapproved call times out, is **denied**, and returns an **EMPTY** result. Empty = not executed — say the approval timed out and nothing was placed; never report it as done, never re-issue it in a loop (the same rule senpi-trade's guardrail row carries — keep the two in sync).
 
 **"Are my open positions protected? / do they have a stop-loss?"** → the DSL coverage verdict (PROTECTED
 / UNPROTECTED / STOP-NOT-ON-VENUE) — a separate read, not the runtime list above. Key trap: an

--- a/senpi-strategy-ops/references/editing-a-live-strategy.md
+++ b/senpi-strategy-ops/references/editing-a-live-strategy.md
@@ -23,6 +23,17 @@ openclaw senpi update <recipe-dir> --id <runtime_id>
 openclaw senpi update <recipe-dir> --id <runtime_id> --apply
 ```
 
+**The wrapper — `python3 senpi-strategy-ops/scripts/deploy.py update <pkg> --id <runtime_id> [--apply] [--code-only] [--json]`.**
+Same verb, three things around it: the structural preflight `create` runs (a package the deployer would
+refuse is refused here too, before the verb is called); the instance dir resolved from `--id` on a
+multi-instance package; and a clear stop when the box's runtime has no `update` verb yet — exit `1`,
+"the edit is on disk and NOT applied" — instead of a Commander parse error that reads like nothing.
+It never deletes or re-creates a runtime: there is no path from this command to a fresh wallet. Its
+exit codes are the verb's (`0` planned/applied · `1` failed during apply · `2` refused, nothing changed
+· `3` bad invocation). `status.py` prints **✎ running recipe ≠ disk** for a runtime whose rendered
+descriptor differs from the package on disk — that is the "did my edit ever land?" check, and its fix
+is this command.
+
 `--id` names which runtime; on a multi-instance package each arm is its own runtime, so this is how
 you re-tune one sleeve and leave its siblings untouched. `--address <wallet>` works too. Changed only
 `scan.py`/`scoring.py`? Add `--code-only` and it refuses if the recipe moved as well.

--- a/senpi-strategy-ops/references/lifecycle.md
+++ b/senpi-strategy-ops/references/lifecycle.md
@@ -542,6 +542,14 @@ own verdict + active-position count. Classes:
   verdict). The money path near this surface is the RESUME, `deploy.py runtime <id>` — that one starts
   the deploy verb and can fund/install; degraded/unknown print a read-only triage hint.
 - **runtime-stopped** — ACTIVE + runtime exists but not running.
+- **⏸ paused** (a second fact beside health, never a health class) — the runtime's OWN risk gate
+  (`status --json` → `components.risk.eligibility` `CLOSED`/`COOLDOWN`) holds entries; the row shows
+  `⏸ CLOSED`, and a section prints each gate's `reason` verbatim plus when it lets go (daily cap and
+  daily loss halt: 00:00 UTC; cooldowns: on their own). Health stays `healthy`: it ticks, it manages what
+  it holds, it opens nothing. By design — say so; never close/redeploy to clear it.
+- **✎ running recipe ≠ disk** — the descriptor the runtime renders (`runtime list --json`) differs from
+  the package on disk (`dsl_preset` name, `description`, or the recipe hash when the runtime publishes
+  one): an edit that was never applied. Printed with `deploy.py update <pkg> --id <rt>`.
 - **no-runtime** — autonomous *package* strategy (`skillName`, no `traderAddress`) with **no runtime** →
   the only no-runtime anomaly (funded but not running, likely an interrupted deploy); printed with the fix
   (`deploy.py runtime <id>` to start, or `close.py <id>` to recover funds).

--- a/senpi-strategy-ops/scripts/_cli.py
+++ b/senpi-strategy-ops/scripts/_cli.py
@@ -6,6 +6,7 @@ The openclaw/MCP JSON shapes are not strictly pinned, so every extractor tries a
 spellings and degrades gracefully (returns None / []) rather than throwing on a missing field.
 """
 # Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import hashlib
 import json
 import os
 import re
@@ -460,6 +461,134 @@ def active_positions(status_json):
     if isinstance(n, list):
         return len(n)
     return None
+
+
+# ---- risk-gate pause: the runtime's own entry eligibility ----
+
+RISK_PAUSED = ("CLOSED", "COOLDOWN")
+# When each gate lets entries resume — the reader's next question. Ids are the runtime's `RiskGateId`
+# (senpi-trading-runtime src/health/types.ts); an id this table does not know prints without a reset.
+RISK_GATE_RESET = {
+    "max_entries_day": "resets at 00:00 UTC",
+    "daily_loss_halt": "resets at 00:00 UTC",
+    "drawdown_halt": "holds until PnL recovers from its peak (or the day rollover, if configured)",
+    "consecutive_loss": "expires on its own after the cooldown",
+    "per_asset_cooldown": "expires on its own, for that asset",
+}
+
+
+def risk_pause(status_entry):
+    """The runtime's own verdict on whether it may OPEN anything — `components.risk` of a
+    `RuntimeHealthStatus` — as `{"eligibility": "CLOSED"|"COOLDOWN", "gates": [{gate, id, status,
+    reason, reset}]}` while a guard rail holds entries, else None. None also when the record carries
+    no risk component (older runtime, risk disabled): "cannot tell" is not "paused".
+
+    This is NOT health, and it is why health alone misleads: a runtime paused by its own daily cap
+    reports `health: healthy` — the scanner ticks, the DSL runs, and nothing opens. Left unsaid, the
+    quiet reads as a dead strategy, and the wrong fix (close + redeploy) market-exits the book and
+    starts the same gate again from zero."""
+    comps = dig(status_entry, "components") if isinstance(status_entry, dict) else None
+    risk = dig(comps, "risk") if isinstance(comps, dict) else None
+    if not isinstance(risk, dict):
+        return None
+    elig = str(risk.get("eligibility") or "").upper()
+    if elig not in RISK_PAUSED:
+        return None
+    gates = []
+    for g in risk.get("gates") or []:
+        if not isinstance(g, dict) or str(g.get("status") or "").upper() not in RISK_PAUSED:
+            continue
+        gid = str(g.get("gateId") or "") or None
+        gates.append({"gate": g.get("gateName") or gid or "risk gate", "id": gid,
+                      "status": str(g.get("status")).upper(), "reason": g.get("reason"),
+                      "reset": RISK_GATE_RESET.get(gid or "")})
+    return {"eligibility": elig, "gates": gates}
+
+
+def describe_pause(pause):
+    """One line for a `risk_pause` value — the gate's OWN words, then when it lets go:
+    `CLOSED — Max Entries/Day: Max entries: 4/4 entries today (resets at 00:00 UTC)`."""
+    if not pause:
+        return ""
+    bits = []
+    for g in pause.get("gates") or []:
+        s = str(g.get("gate") or "risk gate")
+        if g.get("reason"):
+            s += f": {g['reason']}"
+        if g.get("reset"):
+            s += f" ({g['reset']})"
+        bits.append(s)
+    return f"{pause['eligibility']} — " + ("; ".join(bits) if bits else "a risk gate holds entries")
+
+
+# ---- the running recipe vs the package on disk ----
+
+def runtime_descriptors(timeout=15):
+    """`runtime list --json` → {runtime name: descriptor} for every runtime that carries one. The
+    engine renders the descriptor from the recipe it is actually RUNNING (senpi-trading-runtime
+    `describeRuntimeEntry`), so it is the one read that can say whether an edit on disk ever reached
+    the runtime. Fail-open `{}`: older builds print no JSON here, and a status surface must not
+    crash on that."""
+    obj = cli_json(["openclaw", "senpi", "runtime", "list", "--json"], timeout)
+    out = {}
+    for e in (find_list(obj, "runtimes") if obj else []):
+        if isinstance(e, dict) and isinstance(e.get("descriptor"), dict):
+            name = e["descriptor"].get("name") or e.get("id") or e.get("name")
+            if name:
+                out[str(name)] = e["descriptor"]
+    return out
+
+
+# Recipe lines deploy REWRITES between the authored file and the running text: the wallet it
+# creates, and the decision model it injects for an `llm` action. Dropped on both sides before
+# hashing, so equal digests mean "the running recipe is this file" and nothing else differs.
+RECIPE_HASH_DROP_KEYS = ("wallet", "model", "decision_model")
+_RECIPE_DROP_LINE = re.compile(r"^\s*(%s)\s*:" % "|".join(RECIPE_HASH_DROP_KEYS))
+
+
+def recipe_hash(text):
+    """sha256 of a recipe's NORMALIZED text: blank and comment-only lines out, trailing whitespace
+    off, `RECIPE_HASH_DROP_KEYS` lines out. The runtime publishes the same digest as the descriptor's
+    `recipeHash` (when its build carries it); `config_drift` compares the two."""
+    lines = []
+    for ln in str(text or "").splitlines():
+        s = ln.rstrip()
+        if not s.strip() or s.lstrip().startswith("#") or _RECIPE_DROP_LINE.match(s):
+            continue
+        lines.append(s)
+    return hashlib.sha256(("\n".join(lines) + "\n").encode("utf-8")).hexdigest()
+
+
+def _collapse(s):
+    return re.sub(r"\s+", " ", str(s or "")).strip()
+
+
+def config_drift(descriptor, runtime_text, runtime_doc):
+    """What differs between the RUNNING recipe (the descriptor) and the package ON DISK, as
+    `[(field, running, on_disk)]`. `[]` = nothing this read can see differs; None = cannot compare
+    (no descriptor, unparseable file). Compares only what the descriptor renders: the recipe hash
+    when the runtime publishes one, the NAMED `dsl_preset`, and the collapsed `description` — an
+    edited inline ladder with an unchanged name is invisible here until the hash ships, and this
+    says "no drift seen", never "current"."""
+    if not isinstance(descriptor, dict) or not isinstance(runtime_doc, dict):
+        return None
+    diffs = []
+    rh = descriptor.get("recipeHash")
+    if isinstance(rh, str) and rh:
+        local = recipe_hash(runtime_text)
+        if local != rh:
+            diffs.append(("recipe", rh[:12], local[:12]))
+    ex = runtime_doc.get("exit")
+    local_preset = ex.get("dsl_preset") if isinstance(ex, dict) else None
+    running_preset = descriptor.get("dslPreset")
+    if isinstance(local_preset, str) and isinstance(running_preset, str) \
+            and local_preset != running_preset:
+        diffs.append(("dsl_preset", running_preset, local_preset))
+    ld, rd = _collapse(runtime_doc.get("description")), _collapse(descriptor.get("description"))
+    if ld and rd and ld != rd:
+        short = lambda s: s if len(s) <= 48 else s[:48] + "…"  # noqa: E731
+        diffs.append(("description", short(rd), short(ld)))
+    return diffs
 
 
 # ---- strategy lookups (MCP strategy_list) ----

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -1473,6 +1473,120 @@ def _verify_unreadable(pkg_id, reasons, as_json, tail=None, job_running=None):
     return VERIFY_UNREADABLE
 
 
+# ---------- update: an edit applied IN PLACE ----------
+
+UPDATE_TIMEOUT = 180   # an --apply reloads scanner code and re-registers; a plan is seconds
+
+
+def update_target(pkg, runtime_id=None, address=None):
+    """Which instance dir `senpi update` is pointed at, and the selector it is handed. Returns
+    `(instance, selector_args, refusal_text)` — exactly one of instance / refusal_text is set.
+
+    `--id` names the runtime (`<id>-<instance>`), and a multi-instance package MUST name one: each
+    arm is its own runtime, and pointing the verb at the wrong arm's dir re-tunes the wrong sleeve.
+    A one-instance package implies it. The selector is ALWAYS sent (the verb needs one whenever
+    several runtimes are installed on the box — which has nothing to do with how many this package
+    has); `--address` passes through only where it cannot be ambiguous."""
+    insts = list(pkg.instances)
+    ids = ", ".join(str(i.runtime_name) for i in insts) or "(none)"
+    if runtime_id:
+        inst = next((i for i in insts if i.runtime_name == runtime_id), None)
+        if inst is None:
+            return None, [], (f"✗ {pkg.id}: no instance of this package runs as {runtime_id!r} — its "
+                              f"runtime ids are: {ids}. Nothing was changed.")
+        return inst, ["--id", runtime_id], None
+    if len(insts) == 1:
+        inst = insts[0]
+        return inst, (["--address", address] if address else ["--id", str(inst.runtime_name)]), None
+    return None, [], (f"✗ {pkg.id}: {len(insts)} instances — name the one to update with --id "
+                      f"(one of: {ids}). Each arm is its own runtime; nothing was changed.")
+
+
+def cmd_update(a):
+    """Apply an edit to a LIVE strategy IN PLACE — `openclaw senpi update` — plan by default,
+    `--apply` commits. Around the verb, three things: the same structural preflight `create` runs
+    (a package the deployer would refuse is refused here, before the verb is called); the instance
+    dir resolved from `--id`; and a clear stop when the box's runtime has no `update` verb yet.
+
+    What it will never do: delete a runtime, create one, fund a wallet, or close anything. There is
+    no path from this command to a fresh wallet — an edit that `update` refuses (a changed
+    `strategy.wallet`, a renamed/moved external scanner, a changed `action_type`) is a close-and-
+    redeploy CONVERSATION with the user, not a fallback this wrapper takes on its own.
+
+    Exit codes are the verb's: 0 planned/applied · 1 FAILED DURING APPLY (the runtime may not be
+    where you left it — read the message) · 2 refused, nothing changed (also this wrapper's own
+    refusals) · 3 bad invocation. A box with no `update` verb exits 1 with the edit left on disk."""
+    try:
+        pkg = local_pkg(a.package)
+    except _pkg.BadPackage as e:
+        print(f"✗ {a.package}: could not be read as a package — {e}. Nothing was changed.",
+              file=sys.stderr)
+        return EXIT_CODES["refused"]
+    if pkg is None:
+        print(f"✗ {a.package!r} is not a package on disk here — `update` applies an EDITED package, "
+              f"so it never fetches one; pass the directory you edited. Nothing was changed.",
+              file=sys.stderr)
+        return EXIT_CODES["refused"]
+    gate = full_validate(pkg)
+    if gate:
+        print(f"✗ {pkg.id}: {len(gate)} issue(s) to fix before it can be applied — the verb was not "
+              f"called, nothing was changed:", file=sys.stderr)
+        for e in gate:
+            print(f"    - {e}", file=sys.stderr)
+        return EXIT_CODES["refused"]
+    inst, selector, refusal = update_target(pkg, getattr(a, "runtime_id", None),
+                                            getattr(a, "address", None))
+    if refusal:
+        print(refusal, file=sys.stderr)
+        return EXIT_CODES["refused"]
+    target = inst.runtime_path.parent
+    if a.apply and not (target / PROOF_FILE).is_file():
+        # The verb refuses this too (`E_UPDATE_PROOF_REQUIRED`); saying it here saves the round-trip
+        # and names the exact command. A STALE proof is the verb's call, not ours — it knows the bytes.
+        print(f"✗ {pkg.id}: no proof in {target} — `--apply` needs a PASS from\n"
+              f"    openclaw senpi validate {target}\n"
+              f"  first (it records the proof `update --apply` requires). The verb was not called; "
+              f"nothing was changed.", file=sys.stderr)
+        return EXIT_CODES["refused"]
+    argv = ["openclaw", "senpi", "update", str(target)] + list(selector)
+    if a.apply:
+        argv.append("--apply")
+    if getattr(a, "code_only", False):
+        argv.append("--code-only")
+    if a.json:
+        argv.append("--json")
+    rc, out, err = _cli.run_cli(argv, timeout=UPDATE_TIMEOUT)
+    tail = _cli.error_tail(err, out)
+    if rc != 0 and _cli_rejected_the_command(tail, ours=argv):
+        # A parser answered, not the verb: this runtime build predates `senpi update`. The edit is
+        # on disk, unapplied — and the ONE thing not to do about that is close and redeploy.
+        print(tail, file=sys.stderr)
+        print(f"✗ {pkg.id}: this runtime has no `senpi update` verb yet, so the edit in {target} is "
+              f"on disk and NOT applied — nothing was changed. Do NOT close and redeploy to apply it "
+              f"(that market-exits every open position and drops their stops): tell the user the "
+              f"runtime plugin needs the release that carries `senpi update`, and leave the running "
+              f"strategy as it is.", file=sys.stderr)
+        return EXIT_INTERNAL
+    if out:
+        sys.stdout.write(out if out.endswith("\n") else out + "\n")
+    if err and err.strip():
+        sys.stderr.write(err if err.endswith("\n") else err + "\n")
+    if rc == 0 and not a.json:
+        if a.apply:
+            print(f"applied. Re-read what is running now: python3 {Path(__file__).with_name('status.py').name}"
+                  f" {pkg.id}   — and remember `dsl_preset` is forward-only: positions already open "
+                  f"keep the ladder they were opened under (the plan named them).", file=sys.stderr)
+        else:
+            print(f"PLAN only — nothing changed. Read it to the user, then commit with:\n"
+                  f"    python3 {Path(__file__).name} update {a.package} {' '.join(selector)} --apply",
+                  file=sys.stderr)
+    if rc in (0, 1, 2, 3):
+        return rc
+    print(f"✗ {pkg.id}: `senpi update` did not answer (rc {rc}) — {tail or 'no output'}. Read the "
+          f"runtime before retrying: openclaw senpi runtime list --json", file=sys.stderr)
+    return EXIT_INTERNAL
+
+
 # ---------- cli ----------
 
 def main(argv):
@@ -1540,6 +1654,21 @@ def main(argv):
     pval = sub.add_parser("validate",
                           help="Preflight: is the package structurally deploy-ready? (structure + render — no money moved, nothing installed; a bare catalog id IS fetched to disk)")
     common(pval)
+
+    # `update` is the in-place edit path: the same preflight as `create`, then `openclaw senpi
+    # update`. Plans by default; `--apply` commits. It fetches nothing (it applies the package you
+    # EDITED) and it can never delete, create, fund or close — see `cmd_update`.
+    pu = sub.add_parser("update",
+                        help="Apply an edit to a LIVE strategy IN PLACE via `openclaw senpi update` — plans by default, --apply commits. Never closes or re-creates anything.")
+    pu.add_argument("package", help="The edited package: its directory, or an id already on disk. Fetches nothing.")
+    pu.add_argument("--id", dest="runtime_id", default=None,
+                    help="Runtime to update (<id>-<instance>). Required on a multi-instance package; implied on a one-instance one.")
+    pu.add_argument("--address", default=None, help="Alternative to --id (one-instance packages only).")
+    pu.add_argument("--apply", action="store_true",
+                    help="Commit the change. Needs a PASS proof in the instance dir (openclaw senpi validate <dir>). Without it: plan only.")
+    pu.add_argument("--code-only", dest="code_only", action="store_true",
+                    help="Assert only scanner code changed; the verb refuses if the recipe moved too.")
+    pu.add_argument("--json", action="store_true", help="The verb's report as one JSON document on stdout.")
 
     a = ap.parse_args(argv[1:])
     log = (lambda m: None) if a.json else (lambda m: print(m))
@@ -1627,6 +1756,9 @@ def main(argv):
                       f"  (`create`/`runtime` DO fetch a bare catalog id, and so does `validate` — "
                       f"this check is the one that does not.)")))
         sys.exit(cmd_verify(pkg, a))
+
+    if a.cmd == "update":
+        sys.exit(cmd_update(a))
 
     pkg = ensure_pkg(a.package, a.ref, log)
 

--- a/senpi-strategy-ops/scripts/status.py
+++ b/senpi-strategy-ops/scripts/status.py
@@ -23,6 +23,12 @@ OPEN strategy it classifies the runtime:
                      NOT a diagnosis (run status.py on the runtime host for the real verdict)
   copy             — copy-trading strategy (follows a traderAddress) — run by Senpi's copy engine, no runtime
   manual           — manual / app-managed strategy — you manage it in the app, no runtime
+Two more facts ride every deep row, because health alone misleads on both:
+  paused           — the runtime's OWN risk gate holds entries (daily cap, loss halt, cooldown) — health
+                     stays healthy, nothing opens, and the gate's reason + reset are printed verbatim.
+                     By design, not a fault; never redeploy to clear it.
+  config_drift     — the recipe the runtime is RUNNING (its rendered descriptor) differs from the
+                     package on disk: an edit that was never applied. Printed with the in-place fix.
 and separately flags orphan runtimes (a runtime with no open strategy). A strategy off the runtime is NOT
 broken — it's just not autonomous; status.py says how it's managed. Scanner health is fail-closed: an
 external scanner never proven by a tick reads `unknown`, not `healthy` — prove it on a READ-ONLY surface
@@ -41,6 +47,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import _cli  # noqa: E402
+import _pkg  # noqa: E402
 from mcp_client import MCPClient  # noqa: E402
 
 _ICON = {"healthy": "✅", "running": "✅", "degraded": "⚠", "unhealthy": "❌", "unknown": "❔",
@@ -105,6 +112,30 @@ def _read_or_refuse(rows, why):
         "run. Fix the cause and re-run:  python3 status.py")
 
 
+def _config_drift(pkg_id, rt_name, descriptors):
+    """The running recipe vs the package on disk — `{"diffs": [...], "dir", "package_dir"}` when
+    they differ, None when they agree or nothing can be compared (package not on disk here, no
+    descriptor, unreadable YAML). Read-only and fail-open: a status surface may not crash on a
+    package it cannot find, and "could not compare" renders as nothing, never as "current"."""
+    desc = descriptors.get(rt_name) if (descriptors and rt_name) else None
+    if not desc or not pkg_id:
+        return None
+    try:
+        if not (_pkg.resolve_pkg_dir(pkg_id) / "strategy.yaml").is_file():
+            return None
+        pkg = _pkg.load(pkg_id)
+        inst = next((i for i in pkg.instances if i.runtime_name == rt_name), None)
+        if inst is None or inst.runtime_doc is None:
+            return None
+        diffs = _cli.config_drift(desc, inst.runtime_text, inst.runtime_doc)
+    except Exception:  # noqa: BLE001 — fail-open on a read-only surface
+        return None
+    if not diffs:
+        return None
+    return {"diffs": [{"field": f, "running": a, "on_disk": b} for f, a, b in diffs],
+            "dir": str(inst.runtime_path.parent), "package_dir": str(pkg.dir)}
+
+
 def build(mcp, only_pkg=None, deep=True):
     why = []
     strategies = _read_or_refuse(
@@ -117,6 +148,8 @@ def build(mcp, only_pkg=None, deep=True):
     runtimes = _cli.list_runtimes() if cli_ok else []
     # ONE status --json for the whole fleet — only when runtimes actually exist (skip the flaky call otherwise)
     health_by_name = _cli.runtime_health_map() if (deep and runtimes) else {}
+    # ONE `runtime list --json` for the rendered descriptors — what each runtime is actually running.
+    descriptors = _cli.runtime_descriptors() if (deep and runtimes) else {}
     matched_rt = set()  # runtime names already matched to a strategy
     rows = []
     for s in opens:
@@ -134,13 +167,17 @@ def build(mcp, only_pkg=None, deep=True):
         # strategy. Explain it by type: copy-trading (follows a trader, run by the copy engine) or manual
         # (managed in the app). Only an autonomous PACKAGE strategy (skillName, no trader) is expected to
         # have a runtime — a missing one there is the real anomaly.
-        positions = None
+        positions, paused, drift = None, None, None
         if rt and _cli.runtime_running(rt):
             health = "running"
             entry = health_by_name.get(_cli.runtime_name(rt))  # from the single fleet-wide status --json
             if entry:  # upgrade process-level "running" to the runtime's own verdict (+ positions)
                 health = _cli.health_verdict(entry) or "running"
                 positions = _cli.active_positions(entry)
+                # The runtime's own entry gate — separate from health, because a paused runtime is
+                # healthy: it ticks, it manages what it holds, and it opens nothing.
+                paused = _cli.risk_pause(entry)
+            drift = _config_drift(skill, _cli.runtime_name(rt), descriptors)
             if _cli.runtime_no_entry_scanners(rt):
                 # positive wiring-failure evidence from the inventory itself ("running — NO ENTRY
                 # SCANNERS"): the runtime is up but cannot produce entry signals — own class, not
@@ -166,7 +203,7 @@ def build(mcp, only_pkg=None, deep=True):
                      "name": name, "name_source": name_source,
                      "strategyId": _cli.strategy_id_of(s), "wallet": wallet,
                      "status": _cli.strategy_status(s), "funded": _cli.strategy_funded(s),
-                     "positions": positions,
+                     "positions": positions, "paused": paused, "config_drift": drift,
                      "runtime": _cli.runtime_name(rt) if rt else None, "health": health})
     # runtimes with no matching OPEN strategy (orphans — trading nothing / on a gone wallet)
     orphans = [{"runtime": _cli.runtime_name(r), "wallet": _cli.runtime_wallet(r),
@@ -208,9 +245,13 @@ def main(argv):
     unproven = [r for r in rows if r["health"] == "unknown"]
     sick = [r for r in rows if r["health"] in ("degraded", "unhealthy", "runtime-stopped", "no-entry-scanners")]
     off = [r for r in rows if r["health"] in _OFF_RUNTIME]
+    paused = [r for r in rows if r.get("paused")]
+    drifted = [r for r in rows if r.get("config_drift")]
     bits = [f"{running} autonomous (on runtime)"]
     if sick:
         bits.append(f"{len(sick)} degraded")
+    if paused:
+        bits.append(f"{len(paused)} paused by a risk gate")
     if unproven:
         bits.append(f"{len(unproven)} unknown (not proven live)")
     if idle:
@@ -229,8 +270,10 @@ def main(argv):
             # the one that maps to a wallet. Of the two ids the runtime id is the one a human needs least
             # here — the triage lines below hand it back, with the command it belongs to.
             rt = f"  · runtime {r['runtime']}" if r["runtime"] else ""
+            # The pause rides the row itself: a reader skimming a ✅ row must see that it opens nothing.
+            hold = f"  ⏸ {r['paused']['eligibility']}" if r.get("paused") else ""
             print(f"  {_ICON.get(r['health'], ' ')} {r['health']:<15} {_name_cell(r):<22} "
-                  f"{r['wallet'][:10]}…  {_funded(r):>8}  [{(r['strategyId'] or '')[:8]}]{pos}{rt}")
+                  f"{r['wallet'][:10]}…  {_funded(r):>8}  [{(r['strategyId'] or '')[:8]}]{pos}{rt}{hold}")
     if any(r.get("name_source") != "strategyName" for r in rows):
         print("\nℹ `*` after a name means the strategy record carried NO name of its own — what's shown "
               "is its package id (every instance of that package renders the same), not a name this "
@@ -252,6 +295,22 @@ def main(argv):
         print("  Deliberately resuming/reinstalling one? That is `deploy.py runtime <id>` — it runs the "
               "deploy verb and can move money (install + start trading; create+fund with --budget). "
               "Triage first.")
+    if paused:
+        print("\n⏸ Entries paused by the strategy's OWN risk gate — by design, not a fault (health above is "
+              "unchanged; it manages what it holds and opens nothing until the gate lets go):")
+        for r in paused:
+            print(f"  - {_pkg_label(r)} {r['runtime'] or ''}: {_cli.describe_pause(r['paused'])}")
+        print("  Say it to the user as the strategy's rule. Never close/redeploy to clear it: a fresh wallet "
+              "market-exits the book and starts the same gate again from zero.")
+    if drifted:
+        print("\n✎ Running recipe differs from the package on disk — an edit that was never applied:")
+        for r in drifted:
+            d = r["config_drift"]
+            for x in d["diffs"]:
+                print(f"  - {_pkg_label(r)} {r['runtime']}: {x['field']} running {x['running']!r}, "
+                      f"on disk {x['on_disk']!r}")
+            print(f"    → apply it in place (plans first; nothing is closed): python3 deploy.py update "
+                  f"{d['package_dir']} --id {r['runtime']}   (add --apply to commit)")
     if unproven:
         print("\n❔ Unknown (fail-closed — not proven live: scanner not yet proven by a tick, or reporting disabled; verify, don't assume):")
         for r in unproven:

--- a/senpi-strategy-ops/tests/test_deploy_update.py
+++ b/senpi-strategy-ops/tests/test_deploy_update.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Hermetic tests for `deploy.py update` — the in-place edit path. No openclaw, no MCP, no network:
+`_cli.run_cli` is stubbed and the package is a plain namespace on a temp dir.
+
+What is pinned: the wrapper gates the package BEFORE the verb is called (a structurally broken
+package never reaches `senpi update`), resolves the instance dir from `--id`, sends a selector
+always, refuses `--apply` with no proof on disk naming the validate command, relays the verb's
+exit codes 0/1/2/3 and text verbatim, and — the one that matters most — on a runtime that has no
+`update` verb it stops with the edit left on disk and says NOT to close-and-redeploy.
+
+    python3 -m pytest senpi-strategy-ops/tests/test_deploy_update.py -q
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import contextlib
+import io
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import _cli    # noqa: E402
+import deploy  # noqa: E402
+
+
+def _args(**kw):
+    base = dict(package="/pkg/spider", runtime_id=None, address=None, apply=False, code_only=False, json=False)
+    base.update(kw)
+    return types.SimpleNamespace(**base)
+
+
+class UpdateHarness(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.calls = []
+        self.reply = (0, '{"plan": "ok"}\n', "")
+        self.gate = []
+        (self.tmp / "main").mkdir()
+        (self.tmp / "hedge").mkdir()
+        self.pkg = types.SimpleNamespace(
+            dir=self.tmp, id="spider", version="1.0.0",
+            instances=[types.SimpleNamespace(name="main", runtime_name="spider-main",
+                                             runtime_path=self.tmp / "main" / "runtime.yaml")])
+        self._saved = (deploy.local_pkg, deploy.full_validate, _cli.run_cli)
+        deploy.local_pkg = lambda arg: self.pkg
+        deploy.full_validate = lambda pkg: list(self.gate)
+
+        def run_cli(args, timeout=60):
+            self.calls.append(list(args))
+            return self.reply
+        _cli.run_cli = run_cli
+
+    def tearDown(self):
+        deploy.local_pkg, deploy.full_validate, _cli.run_cli = self._saved
+
+    def run_update(self, **kw):
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            rc = deploy.cmd_update(_args(**kw))
+        return rc, out.getvalue(), err.getvalue()
+
+
+class TestUpdate(UpdateHarness):
+    def test_plan_points_the_verb_at_the_instance_dir_with_a_selector(self):
+        rc, out, err = self.run_update()
+        self.assertEqual(rc, 0)
+        self.assertEqual(self.calls, [["openclaw", "senpi", "update", str(self.tmp / "main"), "--id", "spider-main"]])
+        self.assertIn('{"plan": "ok"}', out)                      # the verb's stdout, verbatim
+        self.assertIn("PLAN only — nothing changed", err)
+        self.assertIn("--apply", err)
+
+    def test_structural_errors_refuse_before_the_verb_is_called(self):
+        self.gate = ["instance main: set runtime `group: spider` (found None)"]
+        rc, _out, err = self.run_update()
+        self.assertEqual(rc, 2)
+        self.assertEqual(self.calls, [])
+        self.assertIn("nothing was changed", err)
+
+    def test_apply_without_a_proof_refuses_and_names_the_validate_command(self):
+        rc, _out, err = self.run_update(apply=True)
+        self.assertEqual(rc, 2)
+        self.assertEqual(self.calls, [])
+        self.assertIn(f"openclaw senpi validate {self.tmp / 'main'}", err)
+
+    def test_apply_with_a_proof_passes_apply_and_code_only_through(self):
+        (self.tmp / "main" / deploy.PROOF_FILE).write_text("{}")
+        rc, _out, err = self.run_update(apply=True, code_only=True)
+        self.assertEqual(rc, 0)
+        self.assertEqual(self.calls[0][-3:], ["spider-main", "--apply", "--code-only"])
+        self.assertIn("forward-only", err)
+
+    def test_json_is_passed_through_and_no_prose_note_rides_stdout(self):
+        rc, out, err = self.run_update(json=True)
+        self.assertEqual(rc, 0)
+        self.assertIn("--json", self.calls[0])
+        self.assertEqual(out.strip(), '{"plan": "ok"}')
+        self.assertNotIn("PLAN only", err)
+
+    def test_unknown_id_refuses_and_lists_the_runtime_ids(self):
+        rc, _out, err = self.run_update(runtime_id="spider-swing")
+        self.assertEqual(rc, 2)
+        self.assertEqual(self.calls, [])
+        self.assertIn("spider-main", err)
+
+    def test_multi_instance_package_needs_an_id(self):
+        self.pkg.instances.append(types.SimpleNamespace(
+            name="hedge", runtime_name="spider-hedge", runtime_path=self.tmp / "hedge" / "runtime.yaml"))
+        rc, _out, err = self.run_update()
+        self.assertEqual(rc, 2)
+        self.assertEqual(self.calls, [])
+        self.assertIn("--id", err)
+        rc, _out, _err = self.run_update(runtime_id="spider-hedge")
+        self.assertEqual(rc, 0)
+        self.assertEqual(self.calls[0][3:], [str(self.tmp / "hedge"), "--id", "spider-hedge"])
+
+    def test_the_verbs_refusal_is_relayed_with_its_code(self):
+        self.reply = (2, "", "[E_UPDATE_PROOF_MISMATCH] the proof covers other bytes — re-run validate\n")
+        rc, _out, err = self.run_update()
+        self.assertEqual(rc, 2)
+        self.assertIn("[E_UPDATE_PROOF_MISMATCH]", err)
+
+    def test_a_failed_apply_is_exit_1_with_the_message(self):
+        (self.tmp / "main" / deploy.PROOF_FILE).write_text("{}")
+        self.reply = (1, "", "[E_UPDATE_FAILED] apply failed after registering; restored previous recipe\n")
+        rc, _out, err = self.run_update(apply=True)
+        self.assertEqual(rc, 1)
+        self.assertIn("restored previous recipe", err)
+
+    def test_a_runtime_without_the_verb_stops_and_forbids_the_redeploy_fallback(self):
+        # What a pre-verb box really prints: Commander's root action swallows the subcommand.
+        self.reply = (1, "", "error: too many arguments for 'senpi'. Expected 0 arguments but got 2.\n")
+        rc, _out, err = self.run_update()
+        self.assertEqual(rc, 1)
+        self.assertIn("no `senpi update` verb", err)
+        self.assertIn("NOT applied", err)
+        self.assertIn("Do NOT close and redeploy", err)
+
+    def test_a_package_not_on_disk_is_refused_never_fetched(self):
+        deploy.local_pkg = lambda arg: None
+        rc, _out, err = self.run_update()
+        self.assertEqual(rc, 2)
+        self.assertEqual(self.calls, [])
+        self.assertIn("never fetches", err)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/senpi-strategy-ops/tests/test_status_risk.py
+++ b/senpi-strategy-ops/tests/test_status_risk.py
@@ -84,7 +84,21 @@ exit:
 """
 
 
+# Pinned IDENTICALLY in senpi-trading-runtime `src/runtime/__tests__/runtime-descriptor.test.ts`
+# (`AUTHORED` / `PARITY_DIGEST`). The runtime publishes `recipeHash` over its stored recipe and
+# `config_drift` compares it with `recipe_hash` over the file on disk: widen the drop regex or change
+# the join on ONE side and every runtime in the fleet reads "✎ an edit that was never applied". Both
+# constants must move together, so both suites assert the same digest.
+_PARITY_TEXT = ('name: kodiak-main\ngroup: kodiak\n# a comment the hash must ignore\ndescription: >\n'
+                '  SOL alpha hunter\nstrategy:\n  wallet: "${KODIAK_WALLET}"\n  slots: 2   \n\nexit:\n'
+                '  dsl_preset: balanced\n')
+_PARITY_DIGEST = "0ee8ddd8870febccca803a23bb959b98556dbbd93fc26fbeb80af522600fbbb4"
+
+
 class TestRecipeHashAndDrift(unittest.TestCase):
+    def test_recipe_hash_matches_the_digest_the_runtime_pins(self):
+        self.assertEqual(_cli.recipe_hash(_PARITY_TEXT), _PARITY_DIGEST)
+
     def test_hash_ignores_comments_blank_lines_trailing_space_and_the_wallet_line(self):
         rendered = _RECIPE.replace('"${SPIDER_WALLET}"', "0xabc").replace("# a comment the hash must ignore\n", "")
         rendered = rendered.replace("slots: 2", "slots: 2   ") + "\n\n"

--- a/senpi-strategy-ops/tests/test_status_risk.py
+++ b/senpi-strategy-ops/tests/test_status_risk.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Hermetic tests for the two facts status.py prints beside health — no MCP, no openclaw.
+
+`paused`: the runtime's OWN entry gate (`components.risk` of a `RuntimeHealthStatus`) holds
+entries while health stays `healthy` — the scanner ticks, the DSL runs, nothing opens. A status
+surface that prints ✅ and nothing else for that runtime is how "my strategy is dead" gets
+answered with a redeploy that market-exits the book and restarts the same gate from zero.
+
+`config_drift`: the recipe the runtime is RUNNING (its rendered descriptor) differs from the
+package on disk — an edit that was never applied, printed with the in-place fix.
+
+    python3 -m pytest senpi-strategy-ops/tests/test_status_risk.py -q
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import contextlib
+import io
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import _cli    # noqa: E402
+import status  # noqa: E402
+
+
+def _entry(eligibility="OPEN", gates=(), health="healthy"):
+    """A `RuntimeHealthStatus` record as `openclaw senpi status --json` prints it (runtime
+    src/health/types.ts): the verdict at the top, the risk component under `components`."""
+    return {"runtimeName": "spider-main", "health": health, "activePositions": 2,
+            "components": {"scanners": {"health": health},
+                           "risk": {"component": "risk", "enabled": True,
+                                    "eligibility": eligibility, "gates": list(gates)}}}
+
+
+_CAP = {"gateId": "max_entries_day", "gateName": "Max Entries/Day", "status": "CLOSED",
+        "reason": "Max entries: 4/4 entries today", "evaluationOk": True}
+_OPEN = {"gateId": "daily_loss_halt", "gateName": "Daily Loss Halt", "status": "OPEN"}
+_COOL = {"gateId": "per_asset_cooldown", "gateName": "Per-Asset Cooldown", "status": "COOLDOWN",
+         "reason": "HYPE closed 4m ago (cooldown 15m)"}
+
+
+class TestRiskPause(unittest.TestCase):
+    def test_closed_gate_is_reported_with_its_own_reason_and_reset(self):
+        p = _cli.risk_pause(_entry("CLOSED", [_OPEN, _CAP]))
+        self.assertEqual(p["eligibility"], "CLOSED")
+        self.assertEqual([g["gate"] for g in p["gates"]], ["Max Entries/Day"])   # OPEN gates are not listed
+        self.assertEqual(p["gates"][0]["reason"], "Max entries: 4/4 entries today")
+        self.assertEqual(p["gates"][0]["reset"], "resets at 00:00 UTC")
+
+    def test_cooldown_is_a_pause_too(self):
+        p = _cli.risk_pause(_entry("COOLDOWN", [_COOL]))
+        self.assertEqual(p["eligibility"], "COOLDOWN")
+        self.assertIn("expires on its own", p["gates"][0]["reset"])
+
+    def test_open_or_absent_is_none_not_paused(self):
+        self.assertIsNone(_cli.risk_pause(_entry("OPEN", [_OPEN])))
+        self.assertIsNone(_cli.risk_pause({"health": "healthy"}))          # older runtime: no risk component
+        self.assertIsNone(_cli.risk_pause({"components": {"risk": {"eligibility": "N_A"}}}))
+        self.assertIsNone(_cli.risk_pause(None))
+
+    def test_health_is_untouched_by_a_pause(self):
+        # The whole point: a paused runtime is HEALTHY. The pause is a second fact, never a downgrade.
+        self.assertEqual(_cli.health_verdict(_entry("CLOSED", [_CAP])), "healthy")
+
+    def test_describe_pause_quotes_the_gate(self):
+        line = _cli.describe_pause(_cli.risk_pause(_entry("CLOSED", [_CAP])))
+        self.assertEqual(line, "CLOSED — Max Entries/Day: Max entries: 4/4 entries today (resets at 00:00 UTC)")
+        self.assertEqual(_cli.describe_pause(None), "")
+
+
+_RECIPE = """\
+name: spider-main
+group: spider
+# a comment the hash must ignore
+description: >
+  SOL alpha hunter
+strategy:
+  wallet: "${SPIDER_WALLET}"
+  slots: 2
+exit:
+  dsl_preset: balanced
+"""
+
+
+class TestRecipeHashAndDrift(unittest.TestCase):
+    def test_hash_ignores_comments_blank_lines_trailing_space_and_the_wallet_line(self):
+        rendered = _RECIPE.replace('"${SPIDER_WALLET}"', "0xabc").replace("# a comment the hash must ignore\n", "")
+        rendered = rendered.replace("slots: 2", "slots: 2   ") + "\n\n"
+        self.assertEqual(_cli.recipe_hash(_RECIPE), _cli.recipe_hash(rendered))
+
+    def test_hash_changes_with_the_recipe(self):
+        self.assertNotEqual(_cli.recipe_hash(_RECIPE), _cli.recipe_hash(_RECIPE.replace("slots: 2", "slots: 3")))
+
+    def _doc(self, text):
+        import yaml
+        return yaml.safe_load(text)
+
+    def test_named_preset_and_description_drift_are_seen(self):
+        desc = {"name": "spider-main", "dslPreset": "balanced", "description": "SOL alpha hunter"}
+        edited = _RECIPE.replace("dsl_preset: balanced", "dsl_preset: scalp").replace("SOL alpha hunter", "SOL scalper")
+        diffs = _cli.config_drift(desc, edited, self._doc(edited))
+        self.assertEqual([d[0] for d in diffs], ["dsl_preset", "description"])
+        self.assertEqual(diffs[0][1:], ("balanced", "scalp"))
+
+    def test_agreeing_recipe_has_no_drift_and_no_descriptor_cannot_compare(self):
+        desc = {"name": "spider-main", "dslPreset": "balanced", "description": "SOL alpha hunter"}
+        self.assertEqual(_cli.config_drift(desc, _RECIPE, self._doc(_RECIPE)), [])
+        self.assertIsNone(_cli.config_drift(None, _RECIPE, self._doc(_RECIPE)))
+
+    def test_recipe_hash_from_the_runtime_wins_over_the_weak_fields(self):
+        # An inline-ladder edit under an unchanged preset name is invisible to the name/description
+        # compare; a runtime that publishes `recipeHash` makes it visible.
+        desc = {"name": "spider-main", "dslPreset": "balanced", "description": "SOL alpha hunter",
+                "recipeHash": _cli.recipe_hash(_RECIPE)}
+        edited = _RECIPE.replace("slots: 2", "slots: 3")
+        diffs = _cli.config_drift(desc, edited, self._doc(edited))
+        self.assertEqual([d[0] for d in diffs], ["recipe"])
+        self.assertEqual(_cli.config_drift(desc, _RECIPE, self._doc(_RECIPE)), [])
+
+
+def _row(**over):
+    row = {"package": "spider", "is_pkg": True, "name": "spider", "name_source": "strategyName",
+           "strategyId": "sid-0001", "wallet": "0xtest000000000000000000000000000000test1",
+           "status": "ACTIVE", "funded": "$300", "positions": 2, "runtime": "spider-main",
+           "health": "healthy", "paused": None, "config_drift": None}
+    row.update(over)
+    return row
+
+
+def _render(rows):
+    """status.py's default text output for `rows`, with `build` and the MCP client patched out."""
+    orig_build, orig_client = status.build, status.MCPClient
+    status.build = lambda *a, **k: (list(rows), [], True)
+    status.MCPClient = lambda *a, **k: None
+    buf = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(buf):
+            rc = status.main(["status.py"])
+    finally:
+        status.build, status.MCPClient = orig_build, orig_client
+    assert rc == 0, rc
+    return buf.getvalue()
+
+
+class TestTextRender(unittest.TestCase):
+    def test_paused_row_carries_the_hold_and_the_section_quotes_the_gate(self):
+        out = _render([_row(paused=_cli.risk_pause(_entry("CLOSED", [_CAP])))])
+        line = next(ln for ln in out.splitlines() if "0xtest0000" in ln)
+        self.assertIn("✅ healthy", line)                    # health is not downgraded…
+        self.assertIn("⏸ CLOSED", line)                     # …and the hold is on the same line
+        self.assertIn("1 paused by a risk gate", out)
+        self.assertIn("Max Entries/Day: Max entries: 4/4 entries today (resets at 00:00 UTC)", out)
+        self.assertIn("Never close/redeploy to clear it", out)
+
+    def test_drift_section_names_the_field_and_the_in_place_fix(self):
+        drift = {"diffs": [{"field": "dsl_preset", "running": "balanced", "on_disk": "scalp"}],
+                 "dir": "/data/workspace/strategies/spider", "package_dir": "/data/workspace/strategies/spider"}
+        out = _render([_row(config_drift=drift)])
+        self.assertIn("never applied", out)
+        self.assertIn("dsl_preset running 'balanced', on disk 'scalp'", out)
+        self.assertIn("deploy.py update /data/workspace/strategies/spider --id spider-main", out)
+        self.assertNotIn("close.py", out.split("never applied", 1)[1].split("\n\n")[0])
+
+    def test_quiet_rows_print_neither_section(self):
+        out = _render([_row()])
+        self.assertNotIn("⏸", out)
+        self.assertNotIn("✎", out)
+
+
+class TestBuildWiring(unittest.TestCase):
+    """`build(deep=True)` reads the fleet-wide status map ONCE and the descriptors ONCE, and each
+    row carries `paused` / `config_drift` off them."""
+
+    def test_deep_build_attaches_pause_from_the_fleet_status_map(self):
+        wallet = "0xtest000000000000000000000000000000test1"
+        payload = {"strategyId": "sid-0001", "status": "ACTIVE", "strategyWalletAddress": wallet,
+                   "totalFunded": 300, "strategyName": "spider",
+                   "strategyMetadata": {"skillName": "spider"}}
+        saved = (_cli.list_strategies_or_none, _cli.list_runtimes, status._openclaw_available,
+                 _cli.runtime_health_map, _cli.runtime_descriptors)
+        calls = {"health": 0, "desc": 0}
+
+        def health_map(*a, **k):
+            calls["health"] += 1
+            return {"spider-main": _entry("CLOSED", [_CAP])}
+
+        def descriptors(*a, **k):
+            calls["desc"] += 1
+            return {}
+        _cli.list_strategies_or_none = lambda *a, **k: [payload]
+        _cli.list_runtimes = lambda *a, **k: [{"name": "spider-main", "wallet": wallet,
+                                              "status": "running", "source": None}]
+        status._openclaw_available = lambda: True
+        _cli.runtime_health_map, _cli.runtime_descriptors = health_map, descriptors
+        try:
+            rows, _orphans, _ok = status.build(None, deep=True)
+        finally:
+            (_cli.list_strategies_or_none, _cli.list_runtimes, status._openclaw_available,
+             _cli.runtime_health_map, _cli.runtime_descriptors) = saved
+        self.assertEqual((calls["health"], calls["desc"]), (1, 1))
+        self.assertEqual(rows[0]["health"], "healthy")
+        self.assertEqual(rows[0]["paused"]["eligibility"], "CLOSED")
+        self.assertIsNone(rows[0]["config_drift"])      # no descriptor → cannot compare → nothing claimed
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/senpi-trading-runtime/SKILL.md
+++ b/senpi-trading-runtime/SKILL.md
@@ -95,9 +95,9 @@ openclaw senpi update ./pkg --apply               # commit (needs the same proof
 openclaw senpi update ./pkg --apply --code-only   # assert only scan.py changed; refuses if not
 ```
 
-It plans by default; `--apply` is the only way to commit. **Exit changes are forward-only** — a new
-`dsl_preset` governs new entries, while every open position keeps a snapshot of the preset it was
-opened under, so a tightened stop does not reach one already running. Refused outright, changing
+It plans by default; `--apply` is the only way to commit. **`dsl_preset` changes are forward-only** — new
+entries only, while every open position keeps a snapshot of the preset it was opened under (other `exit:`
+fields, e.g. `order_type`, are read live and DO reach open positions). Refused outright, changing
 nothing: a different `strategy.wallet` (that is a new deployment, and the old wallet's positions
 would be left unmanaged), an external scanner renamed or moved (state is keyed by name and position
 together, and inserting or removing one moves every external scanner below it — appending at the end

--- a/senpi-trading-runtime/SKILL.md
+++ b/senpi-trading-runtime/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "4.0.1"
+  version: "4.0.2"
   platform: senpi
   exchange: hyperliquid
 ---


### PR DESCRIPTION
> **Stacked on #546 + #549** (merged into this branch so the ops edit section is the `senpi update` one). Until those land, this PR's diff shows their commits too; after they land it is only the commits below. **Ship after the runtime release that carries `senpi update`** (senpi-trading-runtime #397 / #342) — same ordering caveat as #546.

## Why

Three things the churn analysis kept asking this skill for, and none of them needs the runtime to change:

1. **An edit path that cannot become a redeploy.** Agents routed to "apply the edit" had one tool that worked, delete-and-create, which market-exits the book and drops the stops — and on a box without the `update` verb the raw CLI answers with a Commander parse error that reads like nothing happened.
2. **"My strategy is dead" when it is paused.** A runtime held by its own daily cap reports `health: healthy` — it ticks, it manages what it holds, it opens nothing. `status.py` printed ✅ and nothing else, so the user's next move was a redeploy that restarts the same gate from zero.
3. **"Did my edit ever land?"** Nothing on the read surface compared what the runtime is *running* with what is on disk.

## What changed

**`deploy.py update <pkg> --id <runtime_id> [--apply] [--code-only] [--json]`** — plans by default, `--apply` commits. Around the verb: the structural preflight `create` runs (refused packages never reach the verb), the instance dir resolved from `--id` (required on multi-instance packages, implied on one-instance ones; a selector is always sent), `--apply` refused locally when no proof is on disk (names the exact `openclaw senpi validate <dir>`), the verb's stdout/stderr and exit codes relayed verbatim (0/1/2/3), and on a pre-verb runtime: exit 1, "the edit is on disk and NOT applied — do NOT close and redeploy". It fetches nothing and can never delete, create, fund or close.

**`status.py`** — two facts beside health on every deep row (`--fast` skips both):
- `paused` — `components.risk` of the fleet-wide `status --json` says `CLOSED`/`COOLDOWN`: the row shows `⏸ CLOSED`, a section quotes each gate's `reason` and when it lets go (daily gates: 00:00 UTC; cooldowns: on their own), and says never to redeploy over it. Health is untouched.
- `config_drift` — one `runtime list --json` for the rendered descriptors; compared with the package on disk (`dsl_preset` name, collapsed `description`, and the recipe hash when the runtime publishes `recipeHash`). Differences print with the `deploy.py update` fix. Fail-open: package not on disk / no descriptor → nothing claimed.

**`_cli.py`** — `risk_pause`, `describe_pause`, `runtime_descriptors`, `recipe_hash` (normalized: blank/comment lines out, trailing space off, `wallet`/`model`/`decision_model` lines out — deploy rewrites those), `config_drift`.

**`SKILL.md`** (body 297 ≤ 300 budget): How-it-runs gains the daily-cap line; Monitor names ⏸ paused and ✎ drift; the trade-approval rule (a trade tool the user does not approve in time is denied and returns **empty** — not executed, never "done", never re-issued in a loop); the edit section routes through the wrapper. `references/editing-a-live-strategy.md` + `lifecycle.md` updated.

**Versions** — `senpi-strategy-ops` 3.7.0 → 3.8.0; also `senpi-trading-runtime` skill 4.0.1 → 4.0.2 (its SKILL.md changed in #546 with no bump, so the fleet would not have picked it up). README table synced.

## Tests

`tests/test_deploy_update.py` (11): gate-before-verb, instance-dir + selector, no-proof refusal, apply/code-only/json passthrough, unknown `--id`, multi-instance needs `--id`, verb refusal/failed relay, the pre-verb box stop, not-on-disk never fetched.
`tests/test_status_risk.py` (14): pause parsing (CLOSED/COOLDOWN/OPEN/absent), health untouched, recipe hash normalization, drift on preset/description/hash, text render (row hold + section + fix command), and `build(deep=True)` making one health call and one descriptor call.

```
python3 -m pytest senpi-strategy-ops/tests senpi-strategy-author/tests senpi-trading-runtime/tests -q
576 passed, 1 skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
