### PR TITLE
portfolio: one fleet status call for runtime health + risk-gate pause beside health (1.18.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Every analytical skill follows the **hidden-engine pattern**: a vendored, stdlib
 | Skill | Ver | Role |
 |---|---|---|
 | **Analyze** | | |
-| [`senpi-portfolio`](senpi-portfolio/) | 1.17.0 | All-wallet portfolio, positions, DSL protection, per-strategy mandate reads |
+| [`senpi-portfolio`](senpi-portfolio/) | 1.18.0 | All-wallet portfolio, positions, DSL protection, per-strategy mandate reads |
 | [`senpi-market-pulse`](senpi-market-pulse/) | 1.2.0 | Daily cross-asset market read (crypto, equities, commodities, macro, funding regime) |
 | [`senpi-smart-money`](senpi-smart-money/) | 1.2.0 | Where the most-profitable wallets are positioned vs. the crowd |
 | [`senpi-trader-research`](senpi-trader-research/) | 1.4.0 | Rank + vet Hyperliquid traders before copying them (mirror-aware: copyability, min-budget, live book) |

--- a/senpi-portfolio/SKILL.md
+++ b/senpi-portfolio/SKILL.md
@@ -16,7 +16,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "1.17.0"
+  version: "1.18.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -273,6 +273,12 @@ strategy and per group. Narrate it honestly — a registered runtime is not auto
   `running_blind` (up, no entry scanners). This is the one that always deserved the warning. Say
   **"⚠ runtime degraded — running but not healthy,"** not a clean all-clear. Flagged in `meta.warnings`.
 - **`not_running`** — no runtime at all (above). ⛔ NOT RUNNING / UNPROTECTED.
+- **`risk_pause`** (beside `runtime_health`, never instead of it) — the runtime's OWN entry gate says
+  `CLOSED` or `COOLDOWN`: the strategy is **healthy and paused by its own rule** (daily entry cap, daily
+  loss halt, drawdown halt, a cooldown). Name the gate and quote its `reason` verbatim ("Max Entries/Day —
+  Max entries: 4/4 entries today"), say when it lets go (`reset`: daily gates at 00:00 UTC, cooldowns on
+  their own), and that nothing is broken. **Never send the user to redeploy over it** — a fresh wallet
+  market-exits the book and starts the same gate again from zero. `meta.paused_by_risk_gate` lists them.
 
 #### Corroborate the verdict before you assert it — in either direction
 
@@ -289,6 +295,10 @@ scan error — both facts true at once. So read them as a grid, not a single ver
 
 **When the two disagree, say which one you are trusting and why.** If the money is moving, that is the
 headline and the field is the footnote — do not report the field and bury the evidence.
+
+**Paper is not live.** A `senpi validate` tick, a scanner signal, a simulation or an estimate is not a
+trade; only a fill on the strategy wallet (`positions`, `closed`) is. Never narrate a shadow run as
+"live", "running" or "a trade" — the user then manages a position that does not exist.
 
 #### When it IS genuinely broken, act — don't hand the user a to-do
 
@@ -626,6 +636,8 @@ minutes, blow the `exec` timeout, and push you to raw MCP — which loses every 
 **fast, resumable STEPS** and **narrate each slice the moment it returns** (this mirrors
 `senpi-improve-trades` / `senpi-strategy-ops` — short steps over a shared state file, the skill narrates
 between). Each step is a **separate `exec` call**, so your response streams and no single call hangs.
+Runtime health inside `strategies` is **one** `openclaw senpi status --json` for the whole fleet (a
+progress line goes to stderr), so that step's cost does not grow with the number of runtimes.
 
 ```sh
 python3 scripts/portfolio.py money        # 1. the FAST money map: embedded idle + each wallet's value → the three buckets (narrate FIRST)

--- a/senpi-portfolio/scripts/portfolio.py
+++ b/senpi-portfolio/scripts/portfolio.py
@@ -345,7 +345,12 @@ def _fleet_statuses(meta):
     flaky-empty, so it is retried once) — the caller then falls back to the per-id read for that
     runtime, so a box where the fleet call misbehaves loses nothing it had before. Fixture-driven
     runs never come here (the per-id fixture keeps its contract). Progress goes to stderr, flushed,
-    so a streaming exec shows what the step is waiting on."""
+    so a streaming exec shows what the step is waiting on.
+
+    Reached only for a runtime the registry lists, so a user with no runtimes never pays for the call.
+    An EMPTY `statuses[]` while the registry lists runtimes is the gateway's known flaky-empty answer
+    (see `senpi-strategy-ops/scripts/_cli.py` `list_runtimes`), not "no runtimes" — that is what the
+    single retry is for, and after it the per-id read gets its own chance at each runtime."""
     if "_fleet_statuses" in meta:
         return meta["_fleet_statuses"]
     meta["_fleet_statuses"] = None
@@ -368,11 +373,13 @@ def _fleet_statuses(meta):
 
 
 def _record_is(rec, runtime_id):
-    """Does this fleet record describe `runtime_id`? The `-r` address is the registry's `id`;
-    a record carries it as `runtimeId` (optional) and `runtimeName` (always)."""
+    """Does this fleet record describe `runtime_id`? A `RuntimeHealthStatus` carries the registry id as
+    `runtimeId` (optional) and its name as `runtimeName` (always) — senpi-trading-runtime
+    src/health/types.ts. Only those two keys: this decides a FUNDED strategy's health, and a looser
+    match (`id`, `name`) would let an unrelated record shaped `{name: …}` claim it."""
     want = str(runtime_id)
     return isinstance(rec, dict) and any(
-        str(rec.get(k)) == want for k in ("runtimeId", "runtimeName", "id", "name") if rec.get(k) is not None)
+        str(rec.get(k)) == want for k in ("runtimeId", "runtimeName") if rec.get(k) is not None)
 
 
 def _fetch_runtime_status(runtime_id, meta):

--- a/senpi-portfolio/scripts/portfolio.py
+++ b/senpi-portfolio/scripts/portfolio.py
@@ -62,6 +62,10 @@ RUNTIME_BLIND_MARK = "NO ENTRY SCANNERS"
 # fail-open + fixture pattern as senpi-improve-trades' event-log read. Offline test hook: a JSON file at
 # $SENPI_STATUS_FIXTURE keyed {"<runtime_id>": {status payload}} is read instead of shelling out.
 STATUS_FIXTURE_ENV = "SENPI_STATUS_FIXTURE"
+# ONE call for every runtime's health — the document `senpi-strategy-ops/scripts/_cli.py`'s
+# `runtime_health_map` reads. A per-runtime `status -r <id>` costs a plugin start each (~2-3 s) and
+# ran sequentially, so the `strategies` step grew with the runtime count and blew the exec window.
+FLEET_STATUS_CMD = ["openclaw", "senpi", "status", "--json"]
 
 CATALOG_REF = os.environ.get("SENPI_SKILLS_REF", "main")
 CATALOG_URL = f"https://raw.githubusercontent.com/Senpi-ai/senpi-skills/{CATALOG_REF}/strategies/catalog.json"
@@ -335,6 +339,42 @@ def _note_telemetry_unavailable(meta, msg):
         meta["_telemetry_warned"] = True
 
 
+def _fleet_statuses(meta):
+    """Every `RuntimeHealthStatus` the runtime publishes, from ONE `openclaw senpi status --json`,
+    cached on `meta` for the run. `None` = the read failed or answered nothing (the gateway is
+    flaky-empty, so it is retried once) — the caller then falls back to the per-id read for that
+    runtime, so a box where the fleet call misbehaves loses nothing it had before. Fixture-driven
+    runs never come here (the per-id fixture keeps its contract). Progress goes to stderr, flushed,
+    so a streaming exec shows what the step is waiting on."""
+    if "_fleet_statuses" in meta:
+        return meta["_fleet_statuses"]
+    meta["_fleet_statuses"] = None
+    if meta.get("_telemetry_dead"):
+        return None
+    print("reading runtime health (one status call for the whole fleet)…", file=sys.stderr, flush=True)
+    for _ in range(2):
+        rc, out, err = _run_cli(FLEET_STATUS_CMD, timeout=30)
+        if rc != 0:
+            head = (err or "")[:200]
+            if head.startswith(SPAWN_FAILED_PREFIX) or "unknown method" in head.lower():
+                return None                        # a dead host; the per-id path says so once and stops
+            continue
+        data = _extract_json(out)
+        recs = _status_entries(data) if isinstance(data, dict) else []
+        if recs:
+            meta["_fleet_statuses"] = recs
+            return recs
+    return None
+
+
+def _record_is(rec, runtime_id):
+    """Does this fleet record describe `runtime_id`? The `-r` address is the registry's `id`;
+    a record carries it as `runtimeId` (optional) and `runtimeName` (always)."""
+    want = str(runtime_id)
+    return isinstance(rec, dict) and any(
+        str(rec.get(k)) == want for k in ("runtimeId", "runtimeName", "id", "name") if rec.get(k) is not None)
+
+
 def _fetch_runtime_status(runtime_id, meta):
     """`openclaw senpi status -r <id> --json` → parsed dict or None. FAIL-OPEN: no `openclaw` / a
     fork-or-exec failure / timeout / non-zero exit / unknown method / parse error → None + a one-time
@@ -355,6 +395,13 @@ def _fetch_runtime_status(runtime_id, meta):
         except Exception as e:  # noqa — a bad fixture is fail-open too
             _note_telemetry_unavailable(meta, f"status fixture unreadable ({e})")
             return None
+    fleet = _fleet_statuses(meta)
+    if fleet:
+        # The per-runtime slice of the fleet document, in the shape the `-r <id>` call prints, so
+        # `_liveness_from_status` / `_risk_pause_from_status` read both paths identically. An id the
+        # fleet document does not list gets an EMPTY `statuses` — the same answer the per-id call
+        # gives for a runtime that is registered but not running — which maps to 'unknown'.
+        return {"ok": True, "statuses": [r for r in fleet if _record_is(r, runtime_id)]}
     rc, out, err = _run_cli(["openclaw", "senpi", "status", "-r", str(runtime_id), "--json"], timeout=20)
     if rc != 0:
         err = (err or "")[:200]
@@ -500,6 +547,51 @@ def _liveness_from_status(status):
 
 
 # ──────────────────────────────────────────────────────────────── strategy profile (catalog enrichment)
+# The runtime's own entry-gate vocabulary (senpi-trading-runtime src/health/types.ts: `RiskGateStatus`,
+# `RiskGateId`). When each gate lets entries resume is the reader's next question, so it rides the field.
+_RISK_PAUSED = ("CLOSED", "COOLDOWN")
+_RISK_GATE_RESET = {
+    "max_entries_day": "resets at 00:00 UTC",
+    "daily_loss_halt": "resets at 00:00 UTC",
+    "drawdown_halt": "holds until PnL recovers from its peak (or the day rollover, if configured)",
+    "consecutive_loss": "expires on its own after the cooldown",
+    "per_asset_cooldown": "expires on its own, for that asset",
+}
+
+
+def _risk_pause_from_status(status):
+    """The runtime's OWN entry gate, read off the same document `_liveness_from_status` reads:
+    `{"eligibility": "CLOSED"|"COOLDOWN", "gates": [{gate, id, reason, reset}]}` while a guard rail
+    holds entries, else None — OPEN, or no risk component at all ("cannot tell" is not "paused").
+
+    NOT a health downgrade, and that is the whole point: a runtime held by its daily entry cap reports
+    `health: healthy` — it ticks, it manages what it holds, it opens nothing. Reported only as `live`,
+    that quiet reads as a dead strategy and the user's next move is a redeploy that market-exits the
+    book and starts the same gate again from zero. Worst pause wins across records (CLOSED > COOLDOWN)."""
+    if not isinstance(status, dict) or status.get("ok") is False:
+        return None
+    found = None
+    for rec in _status_entries(status):
+        comps = rec.get("components") if isinstance(rec, dict) else None
+        risk = comps.get("risk") if isinstance(comps, dict) else None
+        if not isinstance(risk, dict):
+            continue
+        elig = str(risk.get("eligibility") or "").upper()
+        if elig not in _RISK_PAUSED:
+            continue
+        gates = []
+        for g in risk.get("gates") or []:
+            if not isinstance(g, dict) or str(g.get("status") or "").upper() not in _RISK_PAUSED:
+                continue
+            gid = str(g.get("gateId") or "") or None
+            gates.append({"gate": g.get("gateName") or gid or "risk gate", "id": gid,
+                          "reason": g.get("reason"), "reset": _RISK_GATE_RESET.get(gid or "")})
+        cand = {"eligibility": elig, "gates": gates}
+        if found is None or (elig == "CLOSED" and found["eligibility"] != "CLOSED"):
+            found = cand
+    return found
+
+
 def _catalog_facets(rec):
     """The OPTIONAL template-only enrichment facets, pulled from a strategy's catalog record (its
     strategy.yaml). None if the strategy isn't in the catalog (e.g. a user-authored/custom strategy)."""
@@ -918,7 +1010,15 @@ def fetch_strategies(client, meta):
             s["runtime_health"] = "degraded"       # the inventory itself says the process is stopped
         else:
             rid = runtime_id_map.get(str(s.get("wallet")).lower())
-            s["runtime_health"] = _liveness_from_status(_fetch_runtime_status(rid, meta) if rid else None)
+            doc = _fetch_runtime_status(rid, meta) if rid else None
+            s["runtime_health"] = _liveness_from_status(doc)
+            # A second fact off the same document, never a downgrade of the first (see the reader).
+            s["risk_pause"] = _risk_pause_from_status(doc)
+    for s in strategies:
+        s.setdefault("risk_pause", None)     # mirror / unverified / not_running rows: not asked, not paused
+    paused = [s["name"] for s in strategies if s.get("risk_pause")]
+    if paused:
+        meta["paused_by_risk_gate"] = paused
     # Roll up any strategy reported ACTIVE but holding $0 (empty wallet) — status/clearinghouse mismatch.
     dormant = [s["name"] for s in strategies if s.get("empty")]
     if dormant:
@@ -1386,6 +1486,9 @@ def group_strategies(strategies, meta):
             # recovering+live pair reports a clean 'live'.
             "runtime_health": next((v for v in _GROUP_HEALTH_WORST_FIRST
                                     if any(s.get("runtime_health") == v for s in insts)), "unknown"),
+            # risk_pause: ANY sleeve held by its own risk gate → the strategy is (partly) paused by its
+            # rule. The first paused sleeve's gate is carried; per-sleeve detail is on each instance.
+            "risk_pause": next((s.get("risk_pause") for s in insts if s.get("risk_pause")), None),
             "flat_instances": flat_instances,
             "profile_source": prof.get("source"),
         })

--- a/senpi-portfolio/tests/test_portfolio.py
+++ b/senpi-portfolio/tests/test_portfolio.py
@@ -1456,3 +1456,85 @@ if __name__ == "__main__":
         print(f"\n{len(fns)}/{len(fns)} passed")
     finally:
         _restore_path()
+
+
+# ─────────────────────────────────────────── fleet status: one call, and the risk-gate pause
+
+_CAP_GATE = {"gateId": "max_entries_day", "gateName": "Max Entries/Day", "status": "CLOSED",
+             "reason": "Max entries: 4/4 entries today", "evaluationOk": True}
+
+
+def _paused_record(health="healthy"):
+    return {"runtimeName": "kodiak-main", "health": health, "activePositions": 1,
+            "components": {"risk": {"component": "risk", "enabled": True, "eligibility": "CLOSED",
+                                    "gates": [{"gateId": "daily_loss_halt", "gateName": "Daily Loss Halt",
+                                               "status": "OPEN"}, _CAP_GATE]}}}
+
+
+def _run_with_cli(reply_for):
+    """Run the engine against the kodiak fixture with `portfolio._run_cli` replaced by `reply_for(args)`
+    — the ONE place a status read leaves the process — and return (result, the argv list of every call)."""
+    calls = []
+    orig = portfolio._run_cli
+
+    def fake(args, timeout=60):
+        calls.append(list(args))
+        return reply_for(list(args))
+    portfolio._run_cli = fake
+    try:
+        res = run_engine(status_fixture=None, mcp_fixture=_kodiak_only_fixture())
+    finally:
+        portfolio._run_cli = orig
+    return res, calls
+
+
+def test_runtime_health_is_one_fleet_status_call_not_one_per_runtime():
+    """The `strategies` step used to shell out `status -r <id>` per runtime, sequentially, at a plugin
+    start each — the step's cost grew with the runtime count until it blew the exec window. One
+    `status --json` now serves every runtime; the per-id form is never called when it answers."""
+    fleet = json.dumps(status_doc({"runtimeName": "kodiak-main", "health": "healthy", "activePositions": 0}))
+    res, calls = _run_with_cli(lambda a: (0, fleet, "") if a[:4] == ["openclaw", "senpi", "status", "--json"]
+                               else (1, "", "unexpected call"))
+    assert by_wallet(res, KODIAK_WALLET)["runtime_health"] == "live"
+    assert [c for c in calls if "-r" in c] == [], calls           # never the per-runtime form
+    assert sum(1 for c in calls if c[:4] == ["openclaw", "senpi", "status", "--json"]) == 1
+
+
+def test_a_failed_fleet_read_falls_back_to_the_per_id_read():
+    """The gateway is flaky-empty and older builds may not answer the fleet form at all; a box that
+    cannot answer it loses nothing it had — the per-id read still runs for that runtime."""
+    per_id = json.dumps(status_doc({"runtimeName": "kodiak-main", "health": "healthy"}))
+    res, calls = _run_with_cli(lambda a: (0, per_id, "") if "-r" in a else (1, "", "no fleet form here"))
+    assert by_wallet(res, KODIAK_WALLET)["runtime_health"] == "live"
+    assert any("-r" in c and "kodiak-main" in c for c in calls)
+
+
+def test_a_runtime_the_fleet_document_does_not_list_is_unknown_never_live():
+    fleet = json.dumps(status_doc({"runtimeName": "someone-else", "health": "healthy"}))
+    res, _calls = _run_with_cli(lambda a: (0, fleet, ""))
+    assert by_wallet(res, KODIAK_WALLET)["runtime_health"] == "unknown"
+
+
+def test_risk_gate_pause_is_reported_beside_health_never_instead_of_it():
+    """A runtime held by its own daily cap is HEALTHY and opens nothing. Reported only as `live`, the
+    quiet reads as a dead strategy; reported as broken, the user redeploys over a rule. So it is a
+    second field: the gate, its reason verbatim, and when it lets go."""
+    res = _run_with_status({"kodiak-main": status_doc(_paused_record())})
+    strat = by_wallet(res, KODIAK_WALLET)
+    assert strat["runtime_health"] == "live"
+    assert strat["risk_pause"]["eligibility"] == "CLOSED"
+    assert [g["gate"] for g in strat["risk_pause"]["gates"]] == ["Max Entries/Day"]   # OPEN gates are not listed
+    assert strat["risk_pause"]["gates"][0]["reason"] == "Max entries: 4/4 entries today"
+    assert strat["risk_pause"]["gates"][0]["reset"] == "resets at 00:00 UTC"
+    assert res["strategy_groups"][0]["risk_pause"]["eligibility"] == "CLOSED"
+    assert res["meta"]["paused_by_risk_gate"] == ["kodiak"]
+    assert "degraded_runtimes" not in res["meta"]
+
+
+def test_open_gates_and_older_runtimes_are_not_paused():
+    res = _run_with_status({"kodiak-main": status_doc({"health": "healthy", "components": {
+        "risk": {"eligibility": "OPEN", "gates": [{"gateId": "max_entries_day", "status": "OPEN"}]}}})})
+    assert by_wallet(res, KODIAK_WALLET)["risk_pause"] is None
+    res = _run_with_status({"kodiak-main": status_doc({"health": "healthy"})})      # no risk component
+    assert by_wallet(res, KODIAK_WALLET)["risk_pause"] is None
+    assert "paused_by_risk_gate" not in res["meta"]


### PR DESCRIPTION
## Why

Two things the `strategies` step got wrong for a user with several runtimes:

1. **It could not finish inside the exec window.** Runtime health was one `openclaw senpi status -r <id> --json` per runtime, sequentially, at a plugin start each (~2-3 s). The step's cost grew with the runtime count, the exec timed out, and the SKILL's own warning came true: the agent fell back to raw MCP and lost every guardrail.
2. **A paused strategy read as a dead one.** A runtime held by its own daily entry cap reports `health: healthy` — it ticks, it manages what it holds, it opens nothing. Narrated as `live`, the quiet reads as broken; the user's next move was a redeploy that market-exits the book and restarts the same gate from zero.

## What changed

**One fleet call.** `_fleet_statuses(meta)` reads `openclaw senpi status --json` once per run (retried once — the gateway is flaky-empty; a progress line goes to stderr, flushed, so a streaming exec shows what it is waiting on). `_fetch_runtime_status` slices it per runtime **in the shape the per-id call prints**, so `_liveness_from_status` is untouched. A failed fleet read falls back to the per-id read for that runtime — a box where the fleet form misbehaves loses nothing it had. The `SENPI_STATUS_FIXTURE` per-id contract is unchanged.

**`risk_pause`** on each strategy and each `strategy_groups[]` entry, read off the same document as liveness: `{"eligibility": "CLOSED"|"COOLDOWN", "gates": [{gate, id, reason, reset}]}` while the runtime's own guard rail holds entries, else `null`. Never a health downgrade. `meta.paused_by_risk_gate` lists them.

**SKILL.md** — the `risk_pause` narration rule (name the gate, quote its reason, say when it lets go, never redeploy over it), "paper is not live" (a validate tick / signal / estimate is not a trade), and the one-call note. `senpi-portfolio` 1.17.0 → 1.18.0 (frontmatter + README).

## Tests

Five new cases in `tests/test_portfolio.py`: the per-runtime form is never called when the fleet call answers (exactly one `status --json`); a failed fleet read falls back to `-r`; a runtime the fleet document does not list is `unknown`, never `live`; a CLOSED gate is reported beside `live` (OPEN gates not listed, reason + reset carried, group roll-up, meta list); OPEN gates and runtimes without a risk component are not paused.

```
python3 -m pytest senpi-portfolio/tests -q
84 passed
```

Pairs with #573 (`status.py` prints the same pause as ⏸) and #571 (the approval-gate rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
