### PR TITLE
chore: bump the three skills #546 edited so the update-routing guidance auto-updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ Every analytical skill follows the **hidden-engine pattern**: a vendored, stdlib
 | [`senpi-account-status`](senpi-account-status/) | 1.2.0 | Points, loyalty tier, fees, referrals |
 | **Run a strategy** | | |
 | [`senpi-strategy-discover`](senpi-strategy-discover/) | 2.20.0 | Conversational picker — rank the catalog against your worldview |
-| [`senpi-strategy-author`](senpi-strategy-author/) | 3.4.0 | Build/edit a DSL-protected strategy package, one decision at a time |
-| [`senpi-strategy-ops`](senpi-strategy-ops/) | 3.10.0 | Deploy / monitor / close a named strategy (`deploy.py`, `close.py`) |
+| [`senpi-strategy-author`](senpi-strategy-author/) | 3.5.0 | Build/edit a DSL-protected strategy package, one decision at a time |
+| [`senpi-strategy-ops`](senpi-strategy-ops/) | 3.11.0 | Deploy / monitor / close a named strategy (`deploy.py`, `close.py`) |
 | [`senpi-trade`](senpi-trade/) | 1.2.0 | Direct trade or mirror a specific trader — manual positions + copy trading, one decision at a time |
-| [`senpi-trading-runtime`](senpi-trading-runtime/) | 4.0.3 | The runtime contract reference: `scan(inputs, ctx)`, `runtime.yaml`, DSL |
+| [`senpi-trading-runtime`](senpi-trading-runtime/) | 4.1.0 | The runtime contract reference: `scan(inputs, ctx)`, `runtime.yaml`, DSL |
 | **Move money / positioning** | | |
 | [`senpi-deposit-withdraw-transfer`](senpi-deposit-withdraw-transfer/) | 1.1.0 | The money-movement rails (funds in via embedded wallet or in-app USDC purchase; out via the app) |
 | [`senpi-why`](senpi-why/) | 1.1.0 | "Why Senpi / vs. other tools" — the positioning answer |

--- a/senpi-strategy-author/SKILL.md
+++ b/senpi-strategy-author/SKILL.md
@@ -15,7 +15,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "3.4.0"
+  version: "3.5.0"
   platform: senpi
   exchange: hyperliquid
   requires:

--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -24,7 +24,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "3.10.0"
+  version: "3.11.0"
   platform: senpi
   exchange: hyperliquid
   requires:

--- a/senpi-trading-runtime/SKILL.md
+++ b/senpi-trading-runtime/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "4.0.3"
+  version: "4.1.0"
   platform: senpi
   exchange: hyperliquid
 ---


### PR DESCRIPTION
#546 merged without a version bump, so the skills-manager has nothing to auto-update to and no installed copy gets the new guidance. This bumps the three skills it edited — minor bumps, since the change is guidance rather than contract:

| skill | from | to |
|---|---|---|
| `senpi-strategy-author` | 3.4.0 | 3.5.0 |
| `senpi-strategy-ops` | 3.10.0 | 3.11.0 |
| `senpi-trading-runtime` | 4.0.3 | 4.1.0 |

README catalog rows updated to match (same shape as `ec3d4f42`).

**Runtime compatibility:** the guidance tells agents to use `openclaw senpi update`. That verb ships in `@senpi/runtime` `latest` (3.0.103) — verified live on a funded strategy. A runtime older than the verb would answer "unknown command"; the #373 hardening that merged with #398 (stop/rebuild serialisation, registry lock, wallet binding) reaches the fleet with the next runtime release from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DRM9WcaXBuG49KgNrDPqt5
