### PR TITLE
ops: the walkthrough before the budget question; every template deploys as `<User>'s <Template>` (3.12.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Every analytical skill follows the **hidden-engine pattern**: a vendored, stdlib
 | **Run a strategy** | | |
 | [`senpi-strategy-discover`](senpi-strategy-discover/) | 2.22.0 | Conversational picker — rank the catalog against your worldview |
 | [`senpi-strategy-author`](senpi-strategy-author/) | 3.5.0 | Build/edit a DSL-protected strategy package, one decision at a time |
-| [`senpi-strategy-ops`](senpi-strategy-ops/) | 3.11.0 | Deploy / monitor / close a named strategy (`deploy.py`, `close.py`) |
+| [`senpi-strategy-ops`](senpi-strategy-ops/) | 3.12.0 | Deploy / monitor / close a named strategy (`deploy.py`, `close.py`) |
 | [`senpi-trade`](senpi-trade/) | 1.3.0 | Direct trade or mirror a specific trader — manual positions + copy trading, one decision at a time |
 | [`senpi-trading-runtime`](senpi-trading-runtime/) | 4.1.0 | The runtime contract reference: `scan(inputs, ctx)`, `runtime.yaml`, DSL |
 | **Move money / positioning** | | |

--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -19,12 +19,15 @@ description: >-
   create <id> --budget <usd>` takes a package live end to end (it gates the package,
   then runs the runtime's detached deploy job; watch with `senpi deploy status`);
   close.py tears down (stop runtime + strategy_close → flattens positions,
-  returns funds). The id (spider, polar, kodiak) is the package folder. NOT for choosing WHICH strategy
+  returns funds). Before the budget question ops runs THE WALKTHROUGH (Step 0.75):
+  what the template does, how it is set, the two levers worth shifting, and its
+  name — every template deploys as the user's own version
+  (`PurpleFrog's Starling`, or a name of their own), as-is or with levers moved. The id (spider, polar, kodiak) is the package folder. NOT for choosing WHICH strategy
   (senpi-strategy-discover) or authoring / editing the strategy files themselves (senpi-strategy-author).
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "3.11.0"
+  version: "3.12.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -92,8 +95,24 @@ fresh `openclaw senpi validate` before the next `create`. **`UNPROVEN` (exit 2) 
 `deploy.py validate <id>` answers the other question, **is the package well formed**. Do not deploy a
 package that has not returned `PASS`. The proof: [`references/lifecycle.md`](references/lifecycle.md).
 
+**Step 0.75 — the walkthrough (REQUIRED before the budget question).** The package is on disk (Step 0.5).
+Before you ask for a dollar, read `strategy.yaml` (`catalog:`) and each instance's `runtime.yaml` and say —
+plain language, no YAML — **what it does and how it is set** (the post-live block's four lines, before the
+money moves), **two levers** worth a look (one for `tier: starter`; each with default, range and effect),
+the **fee load and the design budget**, and **the name**: every template deploys under the user's name,
+levers moved or not — propose **`<User>'s <Template>`** (`PurpleFrog's Starling`); their own word wins.
+Then one question: *"Run it as-is, or shift one of these and make it yours?"* One word skips it; never a
+gate, never re-asked; the budget question comes after the answer. Cost class is a fact beside the choice,
+never a discouragement; named installs get the walkthrough too. Below the design budget, a guardrail
+removed or a threshold lowered: the consequence in one line and an explicit yes — never "done". Which
+levers, the name rules, and **making the fork on disk** — a copy at `<strategies root>/<template>-<user-slug>/`
+(`deploy.py where` prints the root, never a CWD-relative `strategies/`; `.deploy-state.json` left out;
+`id`, `catalog.name`, `forked_from`, linkage, the mandate prefix; then the unchanged gate on the
+**directory**): [`references/walkthrough.md`](references/walkthrough.md).
+
 **Step 1 — start the deploy.** Budget splits across instances by `funding_share`, **min $10 each** (the
-platform wallet floor) — **confirm the amount with the user first**. Two tiers, and only the first
+platform wallet floor) — **ask for the amount now — after the walkthrough, never before it — and confirm
+it**. Two tiers, and only the first
 stops anything: below the $10/wallet floor the deploy **refuses**; a wallet left with less than **its
 own** sizing needs still **deploys**, with a `[W_BUDGET_BELOW_STRATEGY_MIN]` warn to relay.
 ```
@@ -250,8 +269,10 @@ The user just funded a strategy; the last thing they see must explain **how the 
 - **Protection — the DSL exit ladder.** From `exit.dsl_preset`: the hard stop (`phase1.max_loss_pct`), the profit-lock ladder (`phase2.tiers`: first `trigger_pct` → top `lock_hw_pct`), and any time cut (`weak_peak_cut`/`hard_timeout`). State whether it has a manual close action or is **DSL-only** (no `CLOSE_POSITION` action → "no manual exits — the stop does all the selling"). e.g. "hard stop at −18% from entry; as a winner runs, a trailing floor ratchets up, locking profit from +8% to +80%; a stalled position is cut at 48h."
 
 - **Cap — how many entries a day.** From `risk.guard_rails.max_entries_per_day`: say the number, and that once it is hit the runtime logs `Runtime paused: Max Entries/Day` and opens nothing until 00:00 UTC — its own rule, not a fault. While it holds, `status.py` shows the row as **⏸ paused** (health stays ✅).
+- **Ownership — one line.** *"This is your strategy — `PurpleFrog's Starling`, saved at `/data/workspace/strategies/starling-purplefrog/`.
+  Say 'widen the stop' any time; it applies in place — no close, no new wallet."* (the update path below).
 
-Keep it to ~4 short lines per strategy. Multi-instance packages whose legs differ (e.g. a long book vs a short book, core vs ballast) get one block each **or** a shared block that names the per-side difference. This is what turns "it's live" into "here's exactly how it trades" — required even when the user didn't ask.
+Keep it to ~5 short lines per strategy. Multi-instance packages whose legs differ (e.g. a long book vs a short book, core vs ballast) get one block each **or** a shared block that names the per-side difference. This is what turns "it's live" into "here's exactly how it trades" — required even when the user didn't ask.
 
 ## Monitor — what am I running? / is it actually live?
 
@@ -313,7 +334,8 @@ the deployed scanner as it is.
 scanner stores and action history survive. `senpi validate <instance-dir>` writes the proof `--apply`
 needs; `python3 senpi-strategy-ops/scripts/deploy.py update <pkg> --id <runtime_id>` PLANS (the structural preflight, then the verb; add `--apply` to commit — it stops if the box has no `update` verb yet: then STOP too, never close-and-redeploy). **Read the
 plan out first**: `dsl_preset` is **forward-only** — new entries only, never one already open (other `exit:`
-fields, e.g. `order_type`, DO reach open positions) — never let "tighter" be heard as "my open trades are tighter".
+fields, e.g. `order_type`, DO reach open positions) — never let "tighter" be heard as "my open trades are tighter". Call it an **update** to the user, never a
+"redeploy" — that word is the market-exit path below; an edit that closes nothing must never sound like one.
 
 **Only a changed `strategy.wallet`, a renamed or moved external scanner, or a changed `action_type` still need
 close-and-redeploy**, which market-exits every open position and drops any custom ratchet ladder — take

--- a/senpi-strategy-ops/references/walkthrough.md
+++ b/senpi-strategy-ops/references/walkthrough.md
@@ -1,0 +1,93 @@
+# The walkthrough (Step 0.75) — what to say before the budget question, and how to make the fork
+
+The resident rule is in SKILL.md: before a dollar is asked for, ops reads the package and says what it does,
+two levers, the fee load and design budget, and the name; asks as-is-or-fork once; the budget question comes
+after the answer. This file is the depth: which levers, the name rules, the cost classes, the consent
+sentences, and the mechanics of the fork on disk.
+
+## 1. What it does and how it is set by default
+
+The same four lines as the post-live "How it runs" block (cadence · scoring and the entry bar · protection
+as outcomes · daily cap), read from `strategy.yaml` (`catalog:`) and each instance's `runtime.yaml` — plain
+language, no YAML. Say it here, before the money moves, then again after it is live.
+
+## 2. Two levers (one for a `tier: starter` template)
+
+Each with its default, a sensible range, and what moving it changes. Pick the two that matter for THIS
+template from `scanners[].inputs` (the template-specific knobs: an agreement bar, a threshold, a cohort
+size, a basket) and from the universal ones every runtime.yaml has — **read these keys first, they are in
+100% of the catalog**:
+
+| Lever | Key | Say it as |
+|---|---|---|
+| Max positions | `strategy.slots` | "up to N open at once" |
+| Leverage | `strategy.default_leverage` | "N×" |
+| Risk per trade | `exit.dsl_preset.phase1.max_loss_pct` | in ROE **and** in price at the leverage: 15% ROE at 5× is 3% of price |
+| Daily entry cap, drawdown halt | `risk.guard_rails` | "at most N entries a day; halts at −X%" |
+| Cadence | the scanner's `interval_seconds` | "looks every N minutes" |
+
+Position size (`strategy.margin_pct`, present in about half the catalog) is the biggest *felt* lever after
+the stop — offer it where it exists. Scanner-side `maxSlots` / `maxLeverage` / `leverageTiers` exist in a
+minority of templates: read them where present, never look for them first. A static universe is a lever
+where there is one. Name the rest in one line.
+
+## 3. The name
+
+Every template deploys under the user's name, moved levers or not. Propose the possessive —
+**`<User>'s <Template>`**, `PurpleFrog's Starling` — and invite their own name in the same sentence; their
+word wins. `<User>` is the name they use with you or their Senpi username (`user_get_me`), never an id or
+an email; ask once if you don't have it. A second fork of the same template needs a name that tells them
+apart — ask.
+
+## 4. The question
+
+*"Run it as-is, or shift one of these and make it yours? Either way it deploys as PurpleFrog's Starling — or
+give it a name of your own."* One word skips it — "as-is" means the defaults, still under their name. Never
+a gate, never re-asked; the budget question comes after the answer.
+
+## 5. Fee load and the design budget
+
+Say what the cadence, slots, margin and leverage cost in fees at the budget on the table — a 10-minute
+scanner turning a $200 book pays more in fees than it wins or loses on direction — and say the design
+budget (`min_budget` is the floor; the catalog card says what the design assumes). **Deploying below the
+design budget needs the user's explicit yes after hearing what degrades**; the `[W_BUDGET_*]` warn after
+the fact is not that consent.
+
+## 6. Guardrails are consent, both ways
+
+Removing a guardrail (a daily-loss limit, a cap) or lowering a threshold you just recommended gets a
+one-line consequence and an explicit yes — never "done". "It tripped three times in four days" is the
+sentence, not an afterthought.
+
+## The cost class — a fact beside the choice
+
+State it once, never as a discouragement: as-is is the cheapest thing the agent does; a lever fork adds a
+little; a bespoke edit (a new universe, a different signal — `senpi-strategy-author`'s edit path) adds
+more; a strategy written from scratch is roughly two to three times a template. Named installs ("just
+install spider") get the walkthrough too — one turn, skippable — the user who names a strategy is the one
+most likely to fork it.
+
+## Making the fork on disk (until a `fork` verb ships)
+
+Copy the fetched package to `<strategies root>/<template>-<user-slug>/`. The root is what
+`python3 senpi-strategy-ops/scripts/deploy.py where` prints — `SENPI_STRATEGIES_DIR`, else
+`$OPENCLAW_WORKSPACE_DIR/strategies`, else `/data/workspace/strategies` — e.g.
+`/data/workspace/strategies/starling-purplefrog/`. **Never a CWD-relative `strategies/`**: the
+skills-manager wipes that on the next version bump (the 2026-07-30 incident). Copy the package files only:
+leave out `.deploy-state.json` (a legacy marker that would make the fresh fork look like a previously
+deployed package) and any `__pycache__`. Then:
+
+- `strategy.yaml` → `id: starling-purplefrog`, `catalog.name: "PurpleFrog's Starling"` (or the user's own
+  words), add `forked_from: { id: starling, version: "1.3.0" }` — the loader ignores keys it doesn't know;
+  this one is the lineage.
+- every instance `runtime.yaml` → `group: starling-purplefrog`, `name: starling-purplefrog-<instance>` (the
+  schema's linkage rule), and prefix its `description` with `PurpleFrog's Starling — forked from Starling
+  1.3.0. ` (the mandate `senpi-portfolio` reads back).
+- apply the moved levers with `edit` — values only, never structure; `wallet_env` names stay as they are.
+- the normal gate: `python3 senpi-strategy-author/scripts/validate_strategy.py <dir>` (it warns on a stop
+  that is too tight at the leverage, sizing with no free-margin gate, a daily cap at or below the slots, a
+  fee load above 0.5% of the budget a day, and refuses a maker-only entry — relay every warn),
+  `openclaw senpi validate <recipe-dir>`, `deploy.py validate <dir>`, then
+  `deploy.py create <dir> --budget <usd>` — pass the **directory**, not the template id.
+
+A fork is a copy: a later fix to the template does not reach it — say so if asked.

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -1642,6 +1642,8 @@ def main(argv):
     # `status` reports the agent's LAST deploy job — one record, not package-addressed — so it needs
     # no package and never resolves (or fetches) one. An id may still be given: it is checked against
     # the job, so a mismatch refuses instead of printing another package's verdict under it.
+    sub.add_parser("where", help="Print the durable strategies root — where fetched packages and forks live "
+                                  "(SENPI_STRATEGIES_DIR > $OPENCLAW_WORKSPACE_DIR/strategies > /data/workspace/strategies).")
     ps = sub.add_parser("status", help="Show the last deploy job for this agent.")
     ps.add_argument("package", nargs="?", default=None,
                     help="Optional: the package you expect this job to be. A mismatch is refused.")
@@ -1671,6 +1673,14 @@ def main(argv):
     pu.add_argument("--json", action="store_true", help="The verb's report as one JSON document on stdout.")
 
     a = ap.parse_args(argv[1:])
+
+    # `where` answers one question — the durable strategies root, the only directory a fork or a
+    # fetched package may be written to — and takes no flags, so it is answered before the flag-
+    # reading code below (which assumes every other verb declared --json).
+    if a.cmd == "where":
+        print(_pkg.strategies_root())
+        return 0
+
     log = (lambda m: None) if a.json else (lambda m: print(m))
 
     if getattr(a, "dry_run", False) and a.json:

--- a/senpi-strategy-ops/tests/test_deploy_where.py
+++ b/senpi-strategy-ops/tests/test_deploy_where.py
@@ -1,0 +1,22 @@
+"""`deploy.py where` prints the durable strategies root — the one place a fork may be written."""
+import os
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+DEPLOY = os.path.join(HERE, "..", "scripts", "deploy.py")
+
+
+def test_where_prints_the_env_root_verbatim(tmp_path):
+    env = dict(os.environ, SENPI_STRATEGIES_DIR=str(tmp_path))
+    out = subprocess.run([sys.executable, DEPLOY, "where"], env=env, capture_output=True, text=True, timeout=60)
+    assert out.returncode == 0, out.stderr
+    assert out.stdout.strip() == str(tmp_path)
+
+
+def test_where_falls_back_to_the_workspace_root(tmp_path):
+    env = {k: v for k, v in os.environ.items() if k != "SENPI_STRATEGIES_DIR"}
+    env["OPENCLAW_WORKSPACE_DIR"] = str(tmp_path)
+    out = subprocess.run([sys.executable, DEPLOY, "where"], env=env, capture_output=True, text=True, timeout=60)
+    assert out.returncode == 0, out.stderr
+    assert out.stdout.strip() == os.path.join(str(tmp_path), "strategies")

--- a/senpi-strategy-ops/tests/test_skill_surface.py
+++ b/senpi-strategy-ops/tests/test_skill_surface.py
@@ -36,7 +36,14 @@ TAXONOMY = REPO / "docs" / "error-code-taxonomy.md"
 # profit-taking" sentence, the instruction to render the ladder as outcomes, and the four
 # doesn't-fit checks. The worked example, the template and the per-mismatch wording went to
 # references/explaining-the-exit.md, which is where this budget says depth belongs.
-BODY_BUDGET = {"senpi-strategy-ops": 300, "senpi-strategy-author": 386}
+# ops 300 -> 317 (2026-09-11): the walkthrough-before-the-budget rule (Step 0.75). The resident lines are
+# what must fire on EVERY template deploy before money moves and cannot be deferred to a pay-per-read
+# file: that the walkthrough comes before the budget question, the four things it says (what it does, two
+# levers, fee load and design budget, the name — `<User>'s <Template>`), the one as-is-or-fork question,
+# the two consents (below the design budget; a guardrail removed), the post-live ownership line and
+# "update, never redeploy". The lever ranking, the name rules, the cost classes and the fork-on-disk
+# mechanics went to references/walkthrough.md. Set at the post-edit count with no slack.
+BODY_BUDGET = {"senpi-strategy-ops": 317, "senpi-strategy-author": 386}
 
 
 def _skill_body(path):


### PR DESCRIPTION
## What

**Step 0.75 — the walkthrough**, required before the budget question. After `deploy.py validate <id>` has fetched the package, ops reads `strategy.yaml` and each `runtime.yaml` and tells the user, in plain language: what it does and how it is set (the same four lines as the post-live "How it runs" block, moved *before* the money moves), **two levers** worth a look, the **fee load and the design budget**, and **the name**: every template deploys as `<User>'s <Template>` (`PurpleFrog's Starling`, or a name of the user's own), as-is or with levers moved. Then one question: as-is, or make it yours? One word skips it; never a gate; cost classes stated as facts, never as discouragement. Named installs get it too.

**Resident vs reference.** The rule is 14 resident lines in SKILL.md; the depth is `references/walkthrough.md`: the lever table ranked by catalog coverage — `strategy.slots`, `strategy.default_leverage`, `exit.dsl_preset.phase1.max_loss_pct` (ROE *and* price at leverage), `risk.guard_rails`, `interval_seconds` first (100% of the catalog), `strategy.margin_pct` as the biggest felt lever after the stop (about half), scanner-side `maxSlots`/`maxLeverage`/`leverageTiers` read where present and never looked for first — the name rules (possessive, username never an id, a second fork asks), the cost classes, the two consent sentences, and **the fork on disk** (until a `fork` verb ships): copy to `<strategies root>/<template>-<user-slug>/` — the root `deploy.py where` prints, never a CWD-relative `strategies/` — leaving `.deploy-state.json` and `__pycache__` out, then `id`, `catalog.name`, `forked_from` lineage, `group`/`name` linkage, the mandate prefix, values-only lever edits, and the unchanged gate on the **directory**.

**`deploy.py where`** (new verb, review): prints `_pkg.strategies_root()` — `SENPI_STRATEGIES_DIR`, else `$OPENCLAW_WORKSPACE_DIR/strategies`, else `/data/workspace/strategies` — so the fork destination is read, never composed. Dispatched before the flag-reading code (it takes no flags). Two subprocess tests.

**Consent rules** (from the M371275 review): the fee load and the design budget are said in the walkthrough, deploying below the design budget takes an explicit yes, and removing a guardrail or lowering a threshold just recommended gets a one-line consequence and a yes — never "done".

**Post-live**: one ownership line ("this is your strategy, saved at `/data/workspace/strategies/starling-purplefrog/` … tune it any time, it applies in place"). **Live edits**: say *update*, never *redeploy*.

**Body budget**: the ops SKILL body goes 298 → 317 lines; `BODY_BUDGET` set 300 → 317 at the post-edit count with no slack and the dated rationale in the test (the same pattern as the author 368 → 386 bump): the resident lines are what must fire on every template deploy before money moves; everything deferrable went to the reference.

3.11.0 → 3.12.0, README row synced. 407 tests pass.

## Why

Users hear "I deployed Starling for you" and feel they are running our strategy. The walkthrough puts the explanation and the fork before the wallet is funded, and the name makes the version theirs from the first deploy. Author is offered as a peer with its cost class, not a downsell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
