### PR TITLE
discover: a template is a starting point for the user's own strategy — ownership rule, fork name, cost classes (2.23.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Every analytical skill follows the **hidden-engine pattern**: a vendored, stdlib
 | [`senpi-improve-trades`](senpi-improve-trades/) | 1.9.0 | Retrospective review + health checks off the **telemetry event log**: exit quality, missed signals, leaks, crashes, "if I'd held" counterfactual |
 | [`senpi-account-status`](senpi-account-status/) | 1.2.0 | Points, loyalty tier, fees, referrals |
 | **Run a strategy** | | |
-| [`senpi-strategy-discover`](senpi-strategy-discover/) | 2.22.0 | Conversational picker — rank the catalog against your worldview |
+| [`senpi-strategy-discover`](senpi-strategy-discover/) | 2.23.0 | Conversational picker — rank the catalog against your worldview |
 | [`senpi-strategy-author`](senpi-strategy-author/) | 3.5.0 | Build/edit a DSL-protected strategy package, one decision at a time |
 | [`senpi-strategy-ops`](senpi-strategy-ops/) | 3.11.0 | Deploy / monitor / close a named strategy (`deploy.py`, `close.py`) |
 | [`senpi-trade`](senpi-trade/) | 1.3.0 | Direct trade or mirror a specific trader — manual positions + copy trading, one decision at a time |

--- a/senpi-strategy-discover/SKILL.md
+++ b/senpi-strategy-discover/SKILL.md
@@ -6,16 +6,18 @@ description: >-
   a strategy", "help me pick a strategy", "what's winning?", "set me up", "I have
   a view on the world (a war, the economy, one coin winning) — trade it", "run a
   hedge fund / all-weather / tail-risk book", or wants a strategy but has NOT
-  named a specific one. Surface the closest matching TEMPLATE first — the fastest
-  on-ramp, which the user can then fork/customize — passing their worldview as
-  `--theme` to rank the closest fits. You talk and RANK; a hidden engine
+  named a specific one. Surface the closest matching TEMPLATE first — the quick start
+  to the user's OWN strategy (every template deploys as `<User>'s <Template>` — or a
+  name of their own — as-is or with levers moved, after ops walks them through it) — passing their
+  worldview as `--theme` to rank the closest fits; offer building one as a peer with
+  its cost class, never a downsell. You talk and RANK; a hidden engine
   (scripts/discover.py) fetches data + filters. NOT for installing a NAMED
   strategy (that's senpi-strategy-ops), or building/designing one from scratch or
   with a custom DSL (that's senpi-strategy-author).
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.22.0"
+  version: "2.23.0"
   platform: senpi
   exchange: hyperliquid
 ---
@@ -38,6 +40,15 @@ they want, rank the eligible set, and recommend in a natural voice. It must neve
 
 ## Golden rules
 
+- **It's their strategy.** A template is a quick start to the user's own strategy, never "our strategy"
+  deployed for them. Say *"a starting point you can fork"*; never "our strategies", "Senpi's Starling",
+  "I'll deploy our template". Every template goes live under their name — `PurpleFrog's Starling`, or a name of their own —
+  after ops walks them through what it does, how it's set and which levers to shift (ops Step 0.75).
+  Building one from scratch is a peer route, not a downsell: state the four cost classes as facts —
+  template as-is ≈ the cheapest thing the agent does · a lever fork (values only) adds a little · a
+  bespoke edit of a template (a new universe, a different signal — author's edit path) adds more ·
+  scratch ≈ 2–3× a template — and let them choose. The same four rungs appear in ops, author and the
+  workspace guardrail; the menu must read identically everywhere.
 - **You talk and rank; the engine only filters.** Run `scripts/discover.py` for data + the eligible
   set — never fetch the catalog or filter strategies yourself.
 - **Only ever name strategies the engine returned** (in `MatchResult.candidates`). Copy the `id`/`name`
@@ -60,7 +71,7 @@ they want, rank the eligible set, and recommend in a natural voice. It must neve
 - **Don't re-ask what they've told you.** If they named an asset/direction, use it; only ask real gaps.
 - **Never say "safe."** Be honest about risk; surface **EVERY** entry in a candidate's `caveats[]`
   **verbatim** — never omit, merge, or soften them.
-- **Always offer build-custom; never dead-end.**
+- **Always offer build-custom as a peer; never dead-end, never downsell.** Say its cost class beside it.
 
 ## How to run the engine
 
@@ -97,7 +108,7 @@ python3 scripts/discover.py
   rank the thesis matches. Read `meta.theme_matches` first, then rank the rest. Add `--no-market` to keep
   early runs cheap.
 - The engine returns valid JSON even on bad input; if it ever errors/empties, fall back to a generic
-  "here are our strategies" message.
+  "here's what you can start from" message.
 
 ## What the engine returns (and how you use each field)
 
@@ -194,7 +205,9 @@ otherwise keep it in your head and rank on `archetype_label`/`belief_plain`/`the
   `--no-market`; say "give me a sec to read the market." **Never pre-fetch on entry.**
 - **Orient / browse** — a short plain-English menu of what's possible (the style families + the funds +
   the non-crypto markets); never force a pick. From here they pick a belief, read the market, or build custom.
-- **Build custom** — hand to **senpi-strategy-author** at any time; a real choice, not a dead-end.
+- **Build custom** — hand to **senpi-strategy-author** at any time; a peer route with its cost class
+  stated (a bespoke edit of a template adds more than a lever fork; scratch ≈ 2–3× a template), never a
+  dead-end and never a downsell.
 - **Mirror a specific trader** — to copy an individual Hyperliquid wallet (not a managed template), hand to
   **senpi-trader-research** (find + vet) → **senpi-trade** (mirror). It blends the windows so the user never
   picks proven-vs-hot; a wallet they name goes straight to `--trader`.
@@ -246,9 +259,10 @@ They lack the vocabulary; recommend *without* making them self-classify:
 🦏  Rhino — Tail-Risk / Crisis-Alpha   [{tier}]
     {thesis}.   Minimum ~${min_budget}{ + funding_split if multi-instance}
 {2nd / 3rd card}.   {caveats, verbatim}.
-"You've got ~${user_context.budget} free — set up {top} with ~$Y, add a hedge alongside it, or build something custom?"
+"You've got ~${user_context.budget} free — start from {top} (I'll walk you through how it's set and the levers before we fund it; it deploys as {user}'s {top} — or a name of your own), add a hedge alongside it, or build your own?"
 ```
-Show the STARTER badge iff `tier == "starter"`; show `archetype_label`; lead with `thesis` for the
+Every card is a starting point — say so once (*"each of these is a starting point you can fork"*), and
+never present a pick as our strategy the user adopts. Show the STARTER badge iff `tier == "starter"`; show `archetype_label`; lead with `thesis` for the
 worldview/fund picks; offer the stack on single-wallet picks only.
 
 ## Special paths
@@ -264,7 +278,9 @@ worldview/fund picks; offer the stack on single-wallet picks only.
 ## Handoffs
 
 - **Deploy** → **senpi-strategy-ops** with the chosen **`id` + `version`** (ops creates the wallet(s)
-  and runs the install; it re-reads `strategy.yaml` for budget/`funding_split`).
+  and runs the install; it re-reads `strategy.yaml` for budget/`funding_split`). **Ops owes the
+  walkthrough first** (its Step 0.75: what it does, how it's set, two levers, the fork name) — hand over
+  before any budget question, not after it.
 - **Build-custom** → **senpi-strategy-author** with a **structured intent brief** (the `meta.intent_echo`
   + a one-line summary of what they wanted, including the worldview if they gave one).
 


### PR DESCRIPTION
## What

- **New golden rule — it's their strategy.** A template is a quick start to the user's own strategy, never "our strategy" deployed for them. Say "a starting point you can fork"; never "our strategies" / "Senpi's Starling" / "I'll deploy our template". Every template goes live as `<User>'s <Template>` (or a name of the user's own) after ops' walkthrough (Step 0.75, in the companion ops PR).
- **Cost classes as facts, author as a peer.** Four rungs, identical to ops, author and the workspace guardrail: template as-is ≈ the cheapest thing the agent does · a lever fork adds a little · a bespoke edit of a template adds more · scratch ≈ 2–3× a template. Build-custom is a peer route, never a dead-end or a downsell.
- **Card format**: the closing question becomes "start from X (I'll walk you through how it's set and the levers before we fund it; it deploys as your X — or a name of your own), add a hedge, or build your own?", and every card is called a starting point once.
- **Handoff**: ops owes the walkthrough before any budget question.
- The engine fallback line "here are our strategies" → "here's what you can start from".

Docs only. 2.20.0 → 2.21.0, README row synced. **Merge order: #578 (ops) first or together** — this PR promises the walkthrough (ops Step 0.75) that #578 introduces. Pairs with the author PR (3.6.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


