### PR TITLE
author: four peer routes with cost classes, budget never before the build, let-winners-run exits, the user names it (3.6.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Every analytical skill follows the **hidden-engine pattern**: a vendored, stdlib
 | [`senpi-account-status`](senpi-account-status/) | 1.2.0 | Points, loyalty tier, fees, referrals |
 | **Run a strategy** | | |
 | [`senpi-strategy-discover`](senpi-strategy-discover/) | 2.23.0 | Conversational picker — rank the catalog against your worldview |
-| [`senpi-strategy-author`](senpi-strategy-author/) | 3.5.0 | Build/edit a DSL-protected strategy package, one decision at a time |
+| [`senpi-strategy-author`](senpi-strategy-author/) | 3.6.0 | Build/edit a DSL-protected strategy package, one decision at a time |
 | [`senpi-strategy-ops`](senpi-strategy-ops/) | 3.12.0 | Deploy / monitor / close a named strategy (`deploy.py`, `close.py`) |
 | [`senpi-trade`](senpi-trade/) | 1.3.0 | Direct trade or mirror a specific trader — manual positions + copy trading, one decision at a time |
 | [`senpi-trading-runtime`](senpi-trading-runtime/) | 4.1.0 | The runtime contract reference: `scan(inputs, ctx)`, `runtime.yaml`, DSL |

--- a/senpi-strategy-author/SKILL.md
+++ b/senpi-strategy-author/SKILL.md
@@ -10,12 +10,15 @@ description: >-
   runtime.yaml authored here is the ONLY way to carry a DSL; raw MCP
   strategy_create* / create_position calls cannot, and must never stand up a
   named or protected strategy. Offers the closest TEMPLATE first (via
-  senpi-strategy-discover), then fork-or-scratch as the user chooses. NOT for
+  senpi-strategy-discover) as the quick start to the user's OWN strategy, with
+  fork-before-deploy, bespoke edit and scratch as peers, each with its cost class;
+  never asks for a budget to build (it is asked once, at deploy); exits default to
+  letting winners run, stated in price at leverage; the user names what you build. NOT for
   installing (senpi-strategy-ops) or picking one to run (senpi-strategy-discover).
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "3.5.0"
+  version: "3.6.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -53,31 +56,35 @@ much risk). Your job is to draw those out, one question at a time, and compile t
 > "succeeds," the position is gone, and the user eats the round-trip. If the user hasn't said which of
 > (A)/(B) they want, **ask before placing anything** — and never route (B) into a managed wallet to save a step.
 
-## Start here — offer the fast path before building from scratch
+## Start here — templates first, as the quick start to THEIR strategy; the other routes are peers
 
-Building from scratch is powerful, but it's the **slow** path (the full interview + compile + smoke-test).
-Most users — especially new ones — are best served by starting from a **proven template** and tweaking it
-if they want. So **before the interview, offer three ways to go** — as peers, with the fast one recommended,
-never as a gate:
+A template is not "our strategy" the user adopts — it is the fastest way to launch **their** strategy, and
+every one deploys under their name (`PurpleFrog's Starling`, or a name of their own) after ops walks them through what it does,
+how it is set and which levers to shift (ops Step 0.75). So **before the interview, offer the routes as
+peers — template first, each with its cost class as a fact — never a gate, never a downsell:**
 
-1. **Start from a matching template** — *the fastest way to get running.* If the user gave any thesis hint,
-   **hand it to `senpi-strategy-discover`** with their words — that skill surfaces the closest matching
-   template(s), which you name in the offer (*"**Cougar** — equity long/short — is close to what you
-   described"*). Discover owns the catalog and the match (and picks + deploys via ops); don't reach into
-   its internals or rebuild the catalog here.
-2. **Start from that template and make it your own** — deploy the template, then **edit it** (this skill's
-   edit path — see "Editing an existing strategy") to change the universe / thresholds / sizing / DSL. The
-   bridge for *"close, but I want changes."*
-3. **Design your own from scratch** — first-class, fully supported; you run the interview below.
+1. **Start from a matching template** — *the quick start.* If the user gave any thesis hint, **hand it to
+   `senpi-strategy-discover`** with their words — that skill surfaces the closest matching template(s),
+   which you name in the offer (*"**Cougar** — equity long/short — is close to what you described"*).
+   Discover owns the catalog and the match; ops deploys it under the user's name, as-is or with levers
+   moved. Don't reach into its internals or rebuild the catalog here. Cost: the cheapest thing the agent does.
+2. **Fork it before it goes live** — the walkthrough's levers (ops Step 0.75): a threshold, the slots, the
+   leverage, the stop, the daily cap. Values only, no new code. Cost: a little more than as-is.
+3. **Make a bespoke edit to a template** — a new universe, a different signal, a changed exit shape: this
+   skill's edit path ("Editing an existing strategy") on the forked copy, **before** deploy. Cost: more than
+   a lever fork, still well under scratch.
+4. **Design your own from scratch** — first-class, fully supported; you run the interview below. Cost:
+   roughly two to three times a template. Worth it when nothing close exists, or when the user wants it.
 
-**Tone — encourage without discouraging:** template-first is *"the fastest way to get running,"* **never**
-*"the right way"* — scratch is a **peer**, not a downsell. **The user's choice is final**: if they pick scratch
-(or already gave a specific thesis), go straight into the interview — **never re-pitch or nag**. Calibrate to
-the signal (vague ask → lean template-first; clear custom thesis → surface the closest match **once**, then
-build). No close fit → say so and go straight to scratch; never force a bad-fit template.
+**Tone — even-handed, ownership first:** template-first is *"the quick start,"* **never** *"the right way"*;
+scratch is a **peer**, not a downsell, and it works — say so. **The user's choice is final**: if they pick
+scratch (or already gave a specific thesis), go straight into the interview — **never re-pitch or nag**.
+Calibrate to the signal (vague ask → lean template-first; clear custom thesis → surface the closest match
+**once**, then build). No close fit → say so and go straight to scratch; never force a bad-fit template.
+**Never ask for a budget to start building** — see the funding heads-up below; the number is asked once,
+at deploy.
 
-Everything below is the **scratch / customize** path — the interview you run once the user chooses to build
-(or to tweak a template they just deployed).
+Everything below is the **scratch / bespoke** path — the interview, once the user chooses to build or to change more than a lever.
 
 ## ⛔ Never guess syntax — get it from the source (your memory is NOT authoritative)
 
@@ -131,6 +138,9 @@ to exactly $10 still refuses with `[E_FUNDS_BELOW_FLOOR]`. That floor is also ho
   (deposit flow = the `senpi-deposit-withdraw-transfer` skill)
 - One heads-up total. NEVER hold the interview hostage on funding, never re-ask
   mid-interview, and never refuse to build.
+- **And never ask for the budget before the build.** "How much are you allocating?" is a deploy-time
+  question (Handoff step 1). The build costs nothing but tokens; a user who says "you don't need a budget
+  to start building" is right. Build, validate, then ask once.
 
 1. **One question at a time. Never dump all 7 decisions, never paste the guide.** Ask → wait for the
    answer → reflect it back → ask the next. A wall of seven questions is the failure mode this skill
@@ -139,6 +149,9 @@ to exactly $10 still refuses with `[E_FUNDS_BELOW_FLOOR]`. That floor is also ho
    *already* gave — including throwaway details ("rotate the cohort every 3 days" → that's the
    **Memory** decision, a 3-day cohort cache). Pre-fill those; only ask what's still open. **Losing a
    constraint from the first sentence is the #1 mistake** — write each one down as you hear it.
+   **Pre-fill from the thesis, not only from throwaway details.** A smart-money, cohort, divergence or copy
+   thesis has a **derived** universe by definition (Decision 1 = D) — never ask which tickers; "a trend on
+   one name" has its name; a fund has a basket. Ask only what the thesis leaves open.
 3. **Reflect every answer in plain language + name what it implies** ("Derived/copy strategy → we'll
    build the cohort from `discovery_get_top_traders`"). This confirms you understood and teaches the
    user what their choice means.
@@ -165,6 +178,11 @@ For each: ask the question, offer the options as plain choices, then map the ans
 2. **Data — "What does it read to decide?"**
    candles (`market_get_asset_data`) · funding/OI (`market_get_funding_*`) · smart-money
    (`leaderboard_*` / `discovery_*`) · cross-asset flow. → the `call_tool`s in `scan()`.
+   **A smart-money thesis reads the proven cohort, never the 4h board as its source of "who is smart":**
+   the 4h gain leaderboard is a consequence of the move (whoever was on the winning side is at the top),
+   so following it is circular. Use `discovery_get_top_traders` (ALL_TIME) + `discovery_get_trader_state`
+   — headcount and tick-over-tick change, the `senpi-smart-money` method — and name the template that
+   already does it (the Starling / WhaleHunter / Stingray family) as the fork option before writing a new one.
 3. **Edge — "What's the actual signal?"**
    trend-follow · mean-revert · breakout · relative-strength · copy/follow · **cohort-divergence**
    (smart money vs the crowd) · event/new-listing · macro-thesis. → the math in `scoring.py`.
@@ -192,6 +210,13 @@ For each: ask the question, offer the options as plain choices, then map the ans
    your way."* It is **a stop-loss that follows, not profit-taking**: nothing is sold on the way up and
    no rung ever closes a winner — a rung only raises the price at which a REVERSAL closes you. Users
    hear "lock 30% at +20%" as *sell 30% at +20%*. Say it every time.
+   **Default posture — let winners run.** On leverage a stop sized in ROE is a tiny price move: 6% of
+   margin at 4× is 1.5% of price, inside normal noise, and it stops winners out before they become
+   winners. So state every stop and every rung **in price terms at the chosen leverage**, keep the
+   max-loss floor wide enough that ordinary gyrations don't hit it (about 3% of price or more for a swing
+   book), let the first rung engage only on a real move, and **lower the leverage before you tighten the
+   stop**. Losers are the cost of the strategy; winners that run far enough pay for them.
+   `validate_strategy.py` warns on a stop that is too tight at the recipe's leverage — relay it.
 
 ## After the 7 — build it in STAGES, narrating as you go
 
@@ -207,7 +232,9 @@ is a *beat*, not a new turn — keep moving; you don't need the user to reply be
 for `<id>`, in order: the scoring math → the scanner → the runtime config (thesis + DSL + risk gates) →
 the catalog entry, then unit-test → lint → `senpi validate` → hand to ops."* Then tick through it, reporting each:
 
-1. **Confirm the spec.** Replay name + thesis + all 7 + opening constraints → get a "yes." *("You said
+1. **Confirm the spec.** Replay name + thesis + all 7 + opening constraints → get a "yes." **The name is
+   theirs**: ask what they want to call it — suggest one, take theirs; `id` is its lowercase slug and
+   `catalog.name` their words. The catalog's names are ours; the user's strategy carries the user's name. *("You said
    rotate the cohort every 3 days — that's in.")* Nothing is written before this yes.
    **Part of that replay is an EXIT PREVIEW — the ladder as outcomes, never as YAML.** Nobody reads
    `{trigger_pct: 50, lock_hw_pct: 60}`; everybody reads what it does to their money. Each rung is
@@ -358,9 +385,24 @@ makes one new wallet per instance). Authoring just designs the package; **concur
 
 ## Editing an existing strategy
 
+**An edit that removes a protection is a consent question, not a task.** Removing a daily-loss limit, a
+drawdown halt or a cap, or lowering a score / threshold you recommended earlier, gets one line of
+consequence in the user's own numbers ("this limit tripped three times in the last four days; without it
+the worst day would have run to the drawdown halt") and an explicit yes before you touch the file. Never
+"done". The same applies to deploying below the design budget: say the design number, say what degrades
+(fewer slots, smaller sizes, a strategy that cannot express its thesis), take the yes.
+
 Same references; usually no rebuild: tune `runtime.yaml` `inputs` (universe/thresholds/sizing), swap
 the `dsl_preset`, adjust `risk.guard_rails`, or change the `scoring.py` math. Re-validate, then
 re-smoke-test if you touched `scan.py`/`runtime.yaml` — on the runtime (`senpi validate`, or a floor-budget wallet), **never by scheduling agent turns to watch it**: an `openclaw cron` job is a model call every time it fires, and a 5-minute one is 288 a day — [`references/shadow-testing.md`](references/shadow-testing.md).
+
+**Forking a template before it goes live** (the bespoke-edit route): edit the copy ops made under the
+user's name at the durable root `deploy.py where` prints (`/data/workspace/strategies/<template>-<user>/`;
+`id` / `catalog.name` / `forked_from` / linkage already set — the mechanics are ops' walkthrough reference),
+never the template's own fetched directory and never a directory inside a skill; same gate, hand ops the
+directory. **Execution options are part of the edit:** `validate_strategy.py` refuses an entry the executor
+cannot place (`[exec]` — a maker-only entry, an order type the runtime does not know, a `LIMIT` open) and
+warns on fee options the order type ignores.
 
 ## Handoff & the live gate — deploy is `senpi-strategy-ops` (NEVER raw MCP); "done" means verified LIVE
 
@@ -371,14 +413,14 @@ loop every time:
 > **Was this an edit to a strategy that is ALREADY LIVE?** (you changed the scoring / scanner / DSL of a
 > deployed package — "make my live strategy more aggressive", re-tune, re-score) — then hand it to
 > **`senpi-strategy-ops`**, which applies it IN PLACE with `openclaw senpi update`: no close, no fresh
-> wallet, no market exit. **Re-running `create` will NOT apply it** — the deploy verb is idempotent, so it
+> wallet, no market exit — call it an **update**, never a "redeploy". **Re-running `create` will NOT apply it** — the deploy verb is idempotent, so it
 > adopts the existing wallet and leaves the deployed scanner as it is. Tell the user two things:
 > `dsl_preset` is **forward-only** — new entries only, never a position already open (other `exit:` fields
 > like `order_type` DO reach open ones); and a changed `strategy.wallet`, a renamed or moved external
 > scanner or a changed `action_type` still forces close-and-redeploy — a market exit. Below: the not-yet-live path.
 
 1. **Confirm with the user** — budget + "ready to deploy?" Funding a wallet is real money and one-way, so
-   this is an explicit yes, not an assumption.
+   this is an explicit yes, not an assumption. This is the first and only time the budget is asked.
 2. **Preflight** — you proved it runs at stage 9 (`senpi validate` → PASS). Nothing downstream
    re-establishes that a tick actually runs, so stage 9 is what stands between a broken scanner and a
    funded wallet. `deploy.py validate <path-to-package>` is the structural half — every fix in **one

--- a/senpi-strategy-author/scripts/validate_strategy.py
+++ b/senpi-strategy-author/scripts/validate_strategy.py
@@ -255,6 +255,44 @@ def validate(pkg: Path) -> list:
         # Deploy would fund a fresh wallet and install the strategy, exit engine included, against
         # the pinned one. The runtime refuses that (`E_VALIDATE_WALLET_UNBOUND`) off this same field,
         # so asking a weaker question here is how author-green stops meaning deploy-green.
+        # An OPEN_POSITION action with the taker fallback OFF is accepted by every static check and
+        # cannot be executed: the executor does not rest maker orders, so it fails every order or —
+        # worse — a partial maker fill is reconciled as a foreign position and DSL-closed, fees both
+        # ways for no position (five days on a live book, 68 of 79 signals). Decidable here, so it is
+        # an error here, not prose.
+        if isinstance(rt_doc, dict):
+            for act in rt_doc.get("actions") or []:
+                if not isinstance(act, dict) or act.get("action_type") != "OPEN_POSITION":
+                    continue
+                params = act.get("params") if isinstance(act.get("params"), dict) else {}
+                aname = act.get("name", "?")
+                ot = params.get("order_type")
+                # The action-path `params` is an open record in the runtime schema, so `order_type` is
+                # checked nowhere before the executor — and the executor does not refuse an unknown one,
+                # it falls back to MARKET with a warning: full taker fees on every entry while the recipe
+                # says otherwise. A LIMIT open needs a price the runtime's open action never supplies.
+                if ot is not None and (not isinstance(ot, str) or ot not in OPEN_ORDER_TYPES):
+                    errs.append(
+                        f"instance {name}: [exec] action {aname!r} has `params.order_type: {ot!r}` — not an "
+                        f"order type the runtime knows ({', '.join(OPEN_ORDER_TYPES)}). It would not fail: the "
+                        f"runtime logs a warning and falls back to MARKET, so every entry pays full taker fees "
+                        f"while the recipe says otherwise. Write `FEE_OPTIMIZED_LIMIT` (a maker window, then "
+                        f"taker) or `MARKET`")
+                elif ot == "LIMIT":
+                    errs.append(
+                        f"instance {name}: [exec] action {aname!r} opens with `params.order_type: LIMIT` — a "
+                        f"LIMIT order needs a `limitPrice`, and the runtime's open action never supplies one, "
+                        f"so the order cannot be placed as written. Use `FEE_OPTIMIZED_LIMIT` for a maker-first "
+                        f"entry, or `MARKET`")
+                folo = params.get("fee_optimized_limit_options")
+                if ot == "FEE_OPTIMIZED_LIMIT" and isinstance(folo, dict) and folo.get("ensure_execution_as_taker") is False:
+                    errs.append(
+                        f"instance {name}: [exec] action {aname!r} opens with "
+                        f"`ensure_execution_as_taker: false` — a maker-only entry. The executor cannot rest "
+                        f"a maker order: it fails every order, or a partial fill is reconciled as a foreign "
+                        f"position and closed (fees both ways, no position). Set "
+                        f"`ensure_execution_as_taker: true` and keep `execution_timeout_seconds` as the maker "
+                        f"window before the taker fallback")
         if not wenv:
             errs.append(f"instance {name}: missing wallet_env in strategy.yaml")
         elif isinstance(rt_doc, dict):
@@ -321,6 +359,15 @@ def validate(pkg: Path) -> list:
 # the user then reads a string of small losses as "the strategy is broken". `max_loss_pct` is ROE %,
 # so the price distance is max_loss_pct ÷ leverage — more leverage is a TIGHTER stop.
 WARN_STOP_PRICE_PCT = 1.0
+# [fees] — fee spend as % of the budget per DAY above which we warn. An ESTIMATE from the recipe's own
+# cadence / cap / slots / margin / leverage at an ASSUMED 0.05% per side (taker + builder, stated in the
+# message, never a quote): 1,314 fills on a $200 book paid $59 in fees against −$46 of PnL — fees, not
+# direction, took the money, and nothing said so before the user funded it.
+WARN_FEE_PCT_PER_DAY = 0.5
+# The order types the runtime's open path accepts (its constants/order-types.ts VALID_OPEN_ORDER_TYPES).
+# Anything else is not refused by the runtime: it logs a warning and falls back to MARKET.
+OPEN_ORDER_TYPES = ("MARKET", "LIMIT", "FEE_OPTIMIZED_LIMIT")
+FEE_RATE_PER_SIDE = 0.0005
 
 _PRESETS_FILE = Path(__file__).resolve().parent.parent / "references" / "dsl-presets.yaml"
 # The free-margin reads a multi-slot scanner makes before it emits (the camel `_get_positions` gate):
@@ -388,10 +435,43 @@ def max_leverage(rt_doc):
     for sc in (rt_doc.get("scanners") or []) if isinstance(rt_doc, dict) else []:
         inp = sc.get("inputs") if isinstance(sc, dict) else None
         if isinstance(inp, dict):
-            for k in ("leverage", "maxLeverage", "max_leverage", "leverageCap", "leverageTiers"):
+            for k in ("leverage", "maxLeverage", "max_leverage", "leverageCap"):
                 found += _nums(inp.get(k))
+            found += tier_leverages(inp.get("leverageTiers"))
     found = [v for v in found if v > 0]
     return max(found) if found else None
+
+
+def tier_leverages(tiers):
+    """The LEVERAGE column of `leverageTiers`, in the two shapes the catalog uses. A list of rows is
+    documented as `[[min_score, lev, margin_pct], ...]` (condor: `[[15, 10, 80], ...]`) — flattening it
+    reads a score threshold or a margin percentage as leverage (condor came out as 80x). A map is
+    `{apex: 5, good: 4, base: 3}` — every value is a leverage."""
+    if isinstance(tiers, dict):
+        return _nums(tiers)
+    if isinstance(tiers, list):
+        out = []
+        for row in tiers:
+            if isinstance(row, (list, tuple)) and len(row) >= 2:
+                v = _num(row[1])
+                if v is not None:
+                    out.append(v)
+            else:
+                out += _nums(row)
+        return out
+    return []
+
+
+def tier_margins(tiers):
+    """The MARGIN column (index 2) of row-shaped `leverageTiers`; a map carries no margin."""
+    out = []
+    if isinstance(tiers, list):
+        for row in tiers:
+            if isinstance(row, (list, tuple)) and len(row) >= 3:
+                v = _num(row[2])
+                if v is not None:
+                    out.append(v)
+    return out
 
 
 def slot_plan(rt_doc):
@@ -409,7 +489,7 @@ def slot_plan(rt_doc):
         if slots is None:
             slots = _num(inp.get("maxSlots"))
         if margin is None:
-            ms = _nums(inp.get("marginPct")) + _nums(inp.get("marginPctBase"))
+            ms = _nums(inp.get("marginPct")) + _nums(inp.get("marginPctBase")) + tier_margins(inp.get("leverageTiers"))
             margin = max(ms) if ms else None
     return (int(slots) if slots and slots >= 1 else 1), margin
 
@@ -418,6 +498,43 @@ def _daily_cap(rt_doc):
     risk = rt_doc.get("risk") if isinstance(rt_doc, dict) else None
     rails = risk.get("guard_rails") if isinstance(risk, dict) else None
     return _num(rails.get("max_entries_per_day")) if isinstance(rails, dict) else None
+
+
+def _interval_seconds(rt_doc):
+    """The fastest external scanner cadence in the recipe, or None."""
+    best = None
+    for sc in (rt_doc.get("scanners") or []) if isinstance(rt_doc, dict) else []:
+        if isinstance(sc, dict) and sc.get("type") == "external_scanner":
+            v = _num(sc.get("interval_seconds"))
+            if v and v > 0 and (best is None or v < best):
+                best = v
+    return best
+
+
+def fee_drag_pct_per_day(rt_doc):
+    """(pct_of_budget_per_day, entries_per_day, basis) or None — an ESTIMATE of fee spend:
+    entries/day × margin × leverage × 2 sides × FEE_RATE_PER_SIDE. Entries/day is the daily cap when
+    the recipe has one; else the slots turning 3×/day at a cadence ≤ 15 min, 1×/day up to 4 h, ½×/day
+    beyond. No margin or no leverage in the recipe → None (nothing to size)."""
+    slots, margin = slot_plan(rt_doc)
+    lev = max_leverage(rt_doc)
+    if not margin or not lev:
+        return None
+    cap, interval = _daily_cap(rt_doc), _interval_seconds(rt_doc)
+    if cap:
+        entries, basis = float(cap), "the daily cap"
+    elif interval:
+        turns = 3.0 if interval <= 900 else (1.0 if interval <= 4 * 3600 else 0.5)
+        entries = slots * turns
+        basis = "%d slot(s) turning %g×/day at a %s cadence" % (slots, turns, _cadence(interval))
+    else:
+        return None
+    pct = entries * (margin / 100.0) * lev * 2 * FEE_RATE_PER_SIDE * 100.0
+    return pct, entries, basis
+
+
+def _cadence(seconds):
+    return "%gm" % (seconds / 60) if seconds < 3600 else "%gh" % (seconds / 3600)
 
 
 def _instances(pkg: Path):
@@ -446,6 +563,22 @@ def warnings(pkg: Path) -> list:
         if not isinstance(rt_doc, dict):
             continue
         tag = f"instance {name}"
+
+        # [exec] fee options under an order type that never reads them: the runtime forwards
+        # `fee_optimized_limit_options` only for FEE_OPTIMIZED_LIMIT, so under MARKET (the default when
+        # order_type is absent) or LIMIT the maker window is configured and never used — every entry is
+        # a taker order while the recipe reads as maker-first.
+        for act in rt_doc.get("actions") or []:
+            if not isinstance(act, dict) or act.get("action_type") != "OPEN_POSITION":
+                continue
+            params = act.get("params") if isinstance(act.get("params"), dict) else {}
+            ot = params.get("order_type")
+            if isinstance(params.get("fee_optimized_limit_options"), dict) and ot != "FEE_OPTIMIZED_LIMIT":
+                out.append(
+                    f"{tag}: [exec] action {act.get('name', '?')!r} sets `fee_optimized_limit_options` under "
+                    f"`order_type: {ot if ot is not None else 'MARKET (the default)'}` — the runtime reads those "
+                    f"options only for FEE_OPTIMIZED_LIMIT, so the maker window is never used and every entry "
+                    f"is a taker order. Set `order_type: FEE_OPTIMIZED_LIMIT`, or drop the options")
 
         # [stop] the hard stop's distance in PRICE, at the leverage the recipe can reach
         ml, lev = resolved_max_loss_pct(rt_doc), max_leverage(rt_doc)
@@ -483,6 +616,17 @@ def warnings(pkg: Path) -> list:
         # [cap] a daily entry cap is normal practice (most catalog packages set one) and the How-it-runs
         # summary already says it; only a cap AT OR BELOW the slot count is worth a warning — the book
         # fills once, and every re-entry after a stop-out waits for UTC midnight.
+        # [fees] the recipe's own turnover, priced: what the book pays before direction earns anything
+        fd = fee_drag_pct_per_day(rt_doc)
+        if fd and fd[0] >= WARN_FEE_PCT_PER_DAY:
+            pct, entries, basis = fd
+            out.append(
+                f"{tag}: [fees] at {entries:g} entries/day ({basis}), {margin:g}% margin at {lev:g}x, fees "
+                f"run ≈{pct:.2f}% of the budget per day (≈{pct * 30:.0f}%/month) at an assumed 0.05% per "
+                f"side — direction has to beat that before the book makes anything, and on a small budget "
+                f"that is the whole edge. Lengthen the cadence, cut slots or leverage, or say the number to "
+                f"the user before they fund it")
+
         cap = _daily_cap(rt_doc)
         if cap and cap <= slots:
             out.append(

--- a/senpi-strategy-author/tests/test_validate_fees.py
+++ b/senpi-strategy-author/tests/test_validate_fees.py
@@ -1,0 +1,46 @@
+"""[fees] — the validator's turnover-cost advisory (an estimate, worded to be relayed)."""
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+import validate_strategy as vs  # noqa: E402
+
+
+def _package(tmp_path, interval, cap, slots, margin, leverage):
+    pkg = Path(tmp_path) / "churn"
+    (pkg / "scanners").mkdir(parents=True)
+    (pkg / "strategy.yaml").write_text('schema_version: 1\nid: churn\nversion: "1.0.0"\ncatalog:\n  name: "Churn"\n')
+    cap_line = "    max_entries_per_day: %d\n" % cap if cap else ""
+    (pkg / "runtime.yaml").write_text(
+        "name: churn-main\ngroup: churn\nversion: 1.0.0\ndescription: churn\n"
+        "strategy:\n  wallet: \"${CHURN_WALLET}\"\n  slots: %d\n  margin_pct: %g\n  default_leverage: %d\n"
+        "scanners:\n  - name: s\n    type: external_scanner\n    path: ./scanners\n    entrypoint: scan.py\n"
+        "    interval_seconds: %d\n    inputs: {}\n"
+        "actions:\n  - name: open\n    action_type: OPEN_POSITION\n    decision_mode: rule\n    scanners: [s]\n"
+        "exit:\n  engine: dsl\n  dsl_preset:\n    phase1:\n      enabled: false\n      max_loss_pct: 20\n"
+        "risk:\n  guard_rails:\n%s" % (slots, margin, leverage, interval, cap_line or "    drawdown_halt_pct: 20\n"))
+    (pkg / "scanners" / "scan.py").write_text("def scan(inputs, ctx):\n    withdrawable = 0\n    return []\n")
+    return pkg
+
+
+def test_a_ten_minute_scanner_with_a_daily_cap_warns_with_the_arithmetic(tmp_path):
+    # 12 entries/day × 20% × 3x × 2 sides × 0.05% = 0.72% of the budget per day
+    w = [x for x in vs.warnings(_package(tmp_path, 600, 12, 4, 20, 3)) if "[fees]" in x]
+    assert len(w) == 1 and "0.72%" in w[0] and "12 entries/day" in w[0] and "the daily cap" in w[0]
+
+
+def test_a_slow_low_leverage_book_does_not_warn(tmp_path):
+    # 2 slots × 1 turn/day at 6h × 10% × 2x × 2 × 0.05% = 0.04%/day
+    assert not [x for x in vs.warnings(_package(tmp_path, 21600, None, 2, 10, 2)) if "[fees]" in x]
+
+
+def test_no_cap_uses_the_cadence_turnover_assumption(tmp_path):
+    fd = vs.fee_drag_pct_per_day({"strategy": {"slots": 3, "margin_pct": 15, "default_leverage": 5},
+                                  "scanners": [{"type": "external_scanner", "interval_seconds": 300}],
+                                  "risk": {"guard_rails": {}}})
+    assert fd and abs(fd[0] - 3 * 3 * 0.15 * 5 * 2 * 0.0005 * 100) < 1e-9 and "3 slot(s) turning 3" in fd[2]
+
+
+def test_nothing_to_size_returns_none():
+    assert vs.fee_drag_pct_per_day({"strategy": {"slots": 2}}) is None

--- a/senpi-strategy-author/tests/test_validate_tiers_and_exec.py
+++ b/senpi-strategy-author/tests/test_validate_tiers_and_exec.py
@@ -1,0 +1,85 @@
+"""leverageTiers are read by COLUMN (not flattened); the executor-facing `[exec]` checks on OPEN_POSITION."""
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+import validate_strategy as vs  # noqa: E402
+
+
+def test_row_shaped_tiers_read_the_leverage_column_not_the_score_or_margin():
+    condor = {"strategy": {"default_leverage": 10},
+              "scanners": [{"type": "external_scanner", "inputs": {"marginPct": 50,
+                            "leverageTiers": [[15, 10, 80], [13, 10, 70], [11, 10, 50]]}}]}
+    assert vs.max_leverage(condor) == 10                      # not 80 (a margin) and not 15 (a score)
+    assert vs.slot_plan(condor) == (1, 80)                    # margin: the tiers' 80 beats the input's 50
+    grizzly = {"strategy": {"default_leverage": 7},
+               "scanners": [{"type": "external_scanner", "inputs": {"leverageTiers": [[14, 10], [12, 10]]}}]}
+    assert vs.max_leverage(grizzly) == 10                     # not 14
+
+
+def test_map_shaped_tiers_are_all_leverages():
+    starling = {"scanners": [{"type": "external_scanner", "inputs": {"leverageTiers": {"apex": 5, "good": 4, "base": 3}}}]}
+    assert vs.max_leverage(starling) == 5
+    assert vs.tier_margins({"apex": 5}) == []
+
+
+def _package(tmp_path, order_type="FEE_OPTIMIZED_LIMIT", taker_fallback=True, options=True):
+    pkg = Path(tmp_path) / "mk"
+    (pkg / "scanners").mkdir(parents=True)
+    (pkg / "strategy.yaml").write_text('schema_version: 1\nid: mk\nversion: "1.0.0"\ncatalog:\n  name: "Mk"\n')
+    params = "      order_type: %s\n" % order_type
+    if options:
+        params += ("      fee_optimized_limit_options:\n        ensure_execution_as_taker: %s\n"
+                   "        execution_timeout_seconds: 60\n" % ("true" if taker_fallback else "false"))
+    (pkg / "runtime.yaml").write_text(
+        "name: mk-main\ngroup: mk\nversion: 1.0.0\ndescription: mk\n"
+        "strategy:\n  wallet: \"${MK_WALLET}\"\n  slots: 1\n  margin_pct: 10\n  default_leverage: 2\n"
+        "scanners:\n  - name: s\n    type: external_scanner\n    path: ./scanners\n    entrypoint: scan.py\n    interval_seconds: 600\n    inputs: {}\n"
+        "actions:\n  - name: open\n    action_type: OPEN_POSITION\n    decision_mode: rule\n    scanners: [s]\n"
+        "    params:\n" + params +
+        "exit:\n  engine: dsl\n  dsl_preset:\n    phase1:\n      enabled: false\n      max_loss_pct: 20\n"
+        "risk:\n  guard_rails:\n    drawdown_halt_pct: 20\n")
+    (pkg / "scanners" / "scan.py").write_text("def scan(inputs, ctx):\n    return []\n")
+    (pkg / "scanners" / "scoring.py").write_text("")
+    return pkg
+
+
+def _exec_errors(pkg):
+    return [e for e in vs.validate(pkg) if "[exec]" in e]
+
+
+def _exec_warns(pkg):
+    return [w for w in vs.warnings(pkg) if "[exec]" in w]
+
+
+def test_a_maker_only_entry_is_an_error(tmp_path):
+    errs = _exec_errors(_package(tmp_path, taker_fallback=False))
+    assert len(errs) == 1 and "ensure_execution_as_taker: false" in errs[0] and "'open'" in errs[0]
+
+
+def test_a_maker_window_with_taker_fallback_is_not(tmp_path):
+    pkg = _package(tmp_path, taker_fallback=True)
+    assert not _exec_errors(pkg) and not _exec_warns(pkg)
+
+
+def test_an_order_type_the_runtime_does_not_know_is_an_error_naming_the_fallback(tmp_path):
+    errs = _exec_errors(_package(tmp_path, order_type="fee_optimized", options=False))
+    assert len(errs) == 1 and "falls back to MARKET" in errs[0] and "'fee_optimized'" in errs[0]
+
+
+def test_a_limit_open_is_an_error_the_runtime_cannot_price(tmp_path):
+    errs = _exec_errors(_package(tmp_path, order_type="LIMIT", options=False))
+    assert len(errs) == 1 and "limitPrice" in errs[0]
+
+
+def test_fee_options_under_market_warn_and_do_not_error(tmp_path):
+    pkg = _package(tmp_path, order_type="MARKET", taker_fallback=False)   # maker-only flag is inert here
+    assert not _exec_errors(pkg)
+    warns = _exec_warns(pkg)
+    assert len(warns) == 1 and "never" in warns[0] and "MARKET" in warns[0]
+
+
+def test_a_market_open_without_options_is_clean(tmp_path):
+    pkg = _package(tmp_path, order_type="MARKET", options=False)
+    assert not _exec_errors(pkg) and not _exec_warns(pkg)

--- a/senpi-strategy-ops/tests/test_skill_surface.py
+++ b/senpi-strategy-ops/tests/test_skill_surface.py
@@ -43,7 +43,13 @@ TAXONOMY = REPO / "docs" / "error-code-taxonomy.md"
 # the two consents (below the design budget; a guardrail removed), the post-live ownership line and
 # "update, never redeploy". The lever ranking, the name rules, the cost classes and the fork-on-disk
 # mechanics went to references/walkthrough.md. Set at the post-edit count with no slack.
-BODY_BUDGET = {"senpi-strategy-ops": 317, "senpi-strategy-author": 386}
+# author 386 -> 425 (2026-09-11): the four peer routes with cost classes (the product change — the route is
+# the user's choice, its cost class a fact, never a downsell), budget-never-before-build, pre-fill from the
+# thesis, the proven-cohort source rule, let-winners-run exits stated in price terms, the user names it,
+# protection removal as consent. Every one is a what-to-ASK / what-to-CLAIM rule that fires in the
+# interview, which this file says has nowhere else to live; the fork mechanics live in ops'
+# references/walkthrough.md and are named here, not repeated. Set at the post-edit count with no slack.
+BODY_BUDGET = {"senpi-strategy-ops": 317, "senpi-strategy-author": 425}
 
 
 def _skill_body(path):


### PR DESCRIPTION
## What

- **Start here → four peers, template first, each with its cost class**: template as-is · fork a lever before deploy (ops Step 0.75) · bespoke edit of a template on the forked copy · scratch (≈ 2–3× a template). Even-handed: scratch is a peer that works, never a downsell; the user's choice is final.
- **Budget is never asked to start building.** It is asked once, at deploy (Handoff step 1). The funding heads-up stays a one-liner.
- **Pre-fill from the thesis.** A smart-money / cohort / divergence / copy thesis has a derived universe by definition — never ask which tickers. Ask only what the thesis leaves open.
- **Smart-money data source.** The proven cohort (`discovery_get_top_traders` ALL_TIME + `discovery_get_trader_state`, headcount and change), never the 4h gain board as the source of "who is smart" (circular). Name the template that already does it before writing a new one.
- **Exit default — let winners run.** Every stop and rung stated in price at the chosen leverage; a swing floor around 3% of price; lower leverage before tightening the stop. The validator's stop-distance warn is relayed.
- **The name is the user's.** Ask what they want to call it; `id` is its slug, `catalog.name` their words.
- **Editing**: the pre-deploy fork is the copy ops made under the user's name at the durable root `deploy.py where` prints (never a CWD-relative `strategies/`); the mechanics are named as ops' walkthrough reference, not repeated. Execution options are part of the edit, and the validator refuses what the executor cannot place.
- **Removing a protection is a consent question** (daily-loss limit, halt, cap, or a threshold the agent recommended): one line of consequence in the user's numbers, an explicit yes, never "done". Same for deploying below the design budget. From the M371275 review.
- Live edits are called an **update**, never a "redeploy".

**Validator, code (every rule sourced from the runtime, cited in the code):**
- **`[fees]` advisory**: fee spend per day from the recipe's own cap or cadence, slots, margin and leverage at a stated 0.05% per side; warns above 0.5% of the budget per day with the arithmetic in the message (a 10-min scanner with a 12/day cap at 20% margin and 3x reads 0.72%/day, ≈22%/month).
- **`leverageTiers` read by column** (review): rows are `[min_score, leverage, margin_pct]`, maps are `{tier: leverage}`. `max_leverage()` reads the leverage column and `slot_plan()` the margin column; the old flatten read condor's score and margin as leverage (80x). Re-run over the 135 catalog instances on this branch: `[fees]` trips 46 → 45 (wolverine cleared; condor now reads 10x at 80% margin → 0.80%/day at its real numbers).
- **`[exec]` errors** (review): an `OPEN_POSITION` action the executor cannot place. (1) `params.order_type` not in the runtime's own open set `MARKET | LIMIT | FEE_OPTIMIZED_LIMIT` (`constants/order-types.ts`) — the runtime does not refuse it, it warns and falls back to MARKET (`resolve-order-type.ts`), full taker fees while the recipe reads maker-first; (2) `LIMIT` — the MCP requires a `limitPrice` and the open action's `createPosition` call never carries one; (3) `FEE_OPTIMIZED_LIMIT` with `ensure_execution_as_taker: false` — a maker-only entry the executor cannot rest (fails every order, or a partial fill is reconciled as foreign and closed).
- **`[exec]` warn**: `fee_optimized_limit_options` under MARKET or LIMIT — the action forwards the options only for FEE_OPTIMIZED_LIMIT (`open-position.action.ts`), so the maker window is configured and never used.
- Catalog: 0 errors, 0 warns across 110 packages. Twelve validator tests (fees ×4, tiers ×2, exec ×6). 207 pass.

**Body budget**: the author SKILL body goes 386 → 425; `BODY_BUDGET` set at the post-edit count with no slack and the dated rationale in the test (same pattern as the 368 → 386 bump): every added line is a what-to-ask / what-to-claim rule that fires in the interview; the fork mechanics live in ops' `references/walkthrough.md`. Note: #578 changes the same `BODY_BUDGET` line for ops — whichever merges second gets a one-line rebase.

Otherwise docs; 3.5.0 → 3.6.0, README row synced. Rebased on main. Pairs with the ops (3.12.0) and discover (2.23.0) PRs; each stands alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
