### PR TITLE
phalanx: new template — proven-cohort rotation, delta-gated, divergence-boosted, let-winners-run exits (1.0.0)

### DIFF
--- a/senpi-strategy-discover/catalog.json
+++ b/senpi-strategy-discover/catalog.json
@@ -1,6 +1,6 @@
 {
   "_version": "2.1",
-  "_updated": "2026-09-08",
+  "_updated": "2026-09-11",
   "_generated": true,
   "_instructions": "GENERATED from each strategy package's strategy.yaml — do not hand-edit; run senpi-trading-runtime/scripts/gen_catalog.py. Agents read this via senpi-strategy-discover (scripts/discover.py). DECLARED fields (archetype, sub_style, asset_classes, asset_scope, risk_level, tier, belief_plain, direction) are author-set in strategy.yaml `catalog:`; DERIVED fields (assets, leverage_max, funding_split, instance_count, cadence_seconds, time_horizon, max_slots) are computed from instances/params. Labels/glosses come from senpi-strategy-discover/references/glossary.yaml. 'min_budget' is the machine-COMPUTED minimum total budget at which the design functions (min_budget.py) — the smallest budget where every wallet funds and its smallest slot clears the $12 bumped notional; 'wallet_count' + 'min_budget_binding_wallet' explain it. It is NOT authored — deleting an authored min_budget is a no-op; use min_budget_floor to RAISE it. Positions scale with budget above the min. A strategy is a deployable package; install via senpi-strategy-ops.",
   "skills": [
@@ -5263,6 +5263,56 @@
       "sort_order": 7
     },
     {
+      "id": "phalanx",
+      "name": "Phalanx — Proven-Cohort Rotation",
+      "emoji": "🛡️",
+      "tagline": "Follows the proven cohort's headcount flow — not the 4h leaderboard's state — with delta-gated entries, divergence boosting, and wide stops that let winners run.",
+      "belief_plain": "The 4h gain leaderboard is a consequence of price moves, not a predictor — by the time 58% of the board is long ETH, ETH already moved. Phalanx instead tracks the proven cohort (traders with >=$1M lifetime realized PnL) and follows where their headcount is shifting: long the assets they're crowding into, short the ones they're fleeing — but only when conviction is growing (delta gate), and with a divergence booster when the cohort disagrees with the 4h crowd. Wide stops and reachable profit locks on 3x leverage let winners run through noise to pay back losers.",
+      "version": "1.0.0",
+      "thesis": "Smart money doesn't just pick coins, it rotates capital across the whole board. But the 4h gain leaderboard — which state-based followers read — is mechanically biased toward whatever side of the trade is currently winning, making it a lagging indicator. Phalanx reads the proven cohort's actual positioning (headcount, not notional) and requires conviction to be growing (delta >= +2 since last tick), not just already high. A divergence booster multiplies conviction when the cohort disagrees with the 4h crowd (the proven cohort has historically been right when they disagree), and an overcrowding gate requires a 12h price breakout before entering trades that are >85% one-sided. Per-class hit-rate tracking auto-tunes the tilt threshold so the strategy learns which crowd to trust. The exit philosophy: on 3x leverage, a 15% margin stop (3.75% price) is wide enough to survive normal noise, and a first profit lock at +20% ROE (6.67% price) only engages on real moves — letting winners run far enough to pay for multiple losers.",
+      "tags": [
+        "smart-money",
+        "rotation",
+        "proven-cohort",
+        "headcount",
+        "delta-gated",
+        "divergence",
+        "cross-asset",
+        "long-short",
+        "let-winners-run",
+        "wide-stops"
+      ],
+      "group": "smart-money",
+      "archetype": "copy_trading",
+      "archetype_label": "Copy-Trader",
+      "sub_style": "sm_rotation",
+      "sub_style_label": "Follows where smart money is rotating across asset classes — long the crowded-into, short the fled.",
+      "asset_classes": [
+        "universe_crypto",
+        "xyz_equities",
+        "commodities",
+        "indices"
+      ],
+      "asset_scope": "follows_traders",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 4,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 30,
+      "wallet_count": 1,
+      "min_budget_binding_wallet": "main",
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 3,
+      "branch": "main",
+      "sort_order": 8
+    },
+    {
       "id": "raptor",
       "name": "Raptor — Hot-Streak Follower",
       "emoji": "🦅",
@@ -5303,7 +5353,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 8
+      "sort_order": 9
     },
     {
       "id": "remora",
@@ -5349,7 +5399,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 9
+      "sort_order": 10
     },
     {
       "id": "roach",
@@ -5395,7 +5445,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 10
+      "sort_order": 11
     },
     {
       "id": "shadow",
@@ -5439,7 +5489,7 @@
       ],
       "max_slots": 5,
       "branch": "main",
-      "sort_order": 11
+      "sort_order": 12
     },
     {
       "id": "stingray",
@@ -5488,7 +5538,7 @@
       ],
       "max_slots": 4,
       "branch": "main",
-      "sort_order": 12
+      "sort_order": 13
     },
     {
       "id": "whalehunter",
@@ -5533,7 +5583,7 @@
       ],
       "max_slots": 6,
       "branch": "main",
-      "sort_order": 13
+      "sort_order": 14
     },
     {
       "id": "osprey",

--- a/strategies/catalog.json
+++ b/strategies/catalog.json
@@ -1,6 +1,6 @@
 {
   "_version": "2.1",
-  "_updated": "2026-09-08",
+  "_updated": "2026-09-11",
   "_generated": true,
   "_instructions": "GENERATED from each strategy package's strategy.yaml — do not hand-edit; run senpi-trading-runtime/scripts/gen_catalog.py. Agents read this via senpi-strategy-discover (scripts/discover.py). DECLARED fields (archetype, sub_style, asset_classes, asset_scope, risk_level, tier, belief_plain, direction) are author-set in strategy.yaml `catalog:`; DERIVED fields (assets, leverage_max, funding_split, instance_count, cadence_seconds, time_horizon, max_slots) are computed from instances/params. Labels/glosses come from senpi-strategy-discover/references/glossary.yaml. 'min_budget' is the machine-COMPUTED minimum total budget at which the design functions (min_budget.py) — the smallest budget where every wallet funds and its smallest slot clears the $12 bumped notional; 'wallet_count' + 'min_budget_binding_wallet' explain it. It is NOT authored — deleting an authored min_budget is a no-op; use min_budget_floor to RAISE it. Positions scale with budget above the min. A strategy is a deployable package; install via senpi-strategy-ops.",
   "skills": [
@@ -5263,6 +5263,56 @@
       "sort_order": 7
     },
     {
+      "id": "phalanx",
+      "name": "Phalanx — Proven-Cohort Rotation",
+      "emoji": "🛡️",
+      "tagline": "Follows the proven cohort's headcount flow — not the 4h leaderboard's state — with delta-gated entries, divergence boosting, and wide stops that let winners run.",
+      "belief_plain": "The 4h gain leaderboard is a consequence of price moves, not a predictor — by the time 58% of the board is long ETH, ETH already moved. Phalanx instead tracks the proven cohort (traders with >=$1M lifetime realized PnL) and follows where their headcount is shifting: long the assets they're crowding into, short the ones they're fleeing — but only when conviction is growing (delta gate), and with a divergence booster when the cohort disagrees with the 4h crowd. Wide stops and reachable profit locks on 3x leverage let winners run through noise to pay back losers.",
+      "version": "1.0.0",
+      "thesis": "Smart money doesn't just pick coins, it rotates capital across the whole board. But the 4h gain leaderboard — which state-based followers read — is mechanically biased toward whatever side of the trade is currently winning, making it a lagging indicator. Phalanx reads the proven cohort's actual positioning (headcount, not notional) and requires conviction to be growing (delta >= +2 since last tick), not just already high. A divergence booster multiplies conviction when the cohort disagrees with the 4h crowd (the proven cohort has historically been right when they disagree), and an overcrowding gate requires a 12h price breakout before entering trades that are >85% one-sided. Per-class hit-rate tracking auto-tunes the tilt threshold so the strategy learns which crowd to trust. The exit philosophy: on 3x leverage, a 15% margin stop (3.75% price) is wide enough to survive normal noise, and a first profit lock at +20% ROE (6.67% price) only engages on real moves — letting winners run far enough to pay for multiple losers.",
+      "tags": [
+        "smart-money",
+        "rotation",
+        "proven-cohort",
+        "headcount",
+        "delta-gated",
+        "divergence",
+        "cross-asset",
+        "long-short",
+        "let-winners-run",
+        "wide-stops"
+      ],
+      "group": "smart-money",
+      "archetype": "copy_trading",
+      "archetype_label": "Copy-Trader",
+      "sub_style": "sm_rotation",
+      "sub_style_label": "Follows where smart money is rotating across asset classes — long the crowded-into, short the fled.",
+      "asset_classes": [
+        "universe_crypto",
+        "xyz_equities",
+        "commodities",
+        "indices"
+      ],
+      "asset_scope": "follows_traders",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 4,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 30,
+      "wallet_count": 1,
+      "min_budget_binding_wallet": "main",
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 3,
+      "branch": "main",
+      "sort_order": 8
+    },
+    {
       "id": "raptor",
       "name": "Raptor — Hot-Streak Follower",
       "emoji": "🦅",
@@ -5303,7 +5353,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 8
+      "sort_order": 9
     },
     {
       "id": "remora",
@@ -5349,7 +5399,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 9
+      "sort_order": 10
     },
     {
       "id": "roach",
@@ -5395,7 +5445,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 10
+      "sort_order": 11
     },
     {
       "id": "shadow",
@@ -5439,7 +5489,7 @@
       ],
       "max_slots": 5,
       "branch": "main",
-      "sort_order": 11
+      "sort_order": 12
     },
     {
       "id": "stingray",
@@ -5488,7 +5538,7 @@
       ],
       "max_slots": 4,
       "branch": "main",
-      "sort_order": 12
+      "sort_order": 13
     },
     {
       "id": "whalehunter",
@@ -5533,7 +5583,7 @@
       ],
       "max_slots": 6,
       "branch": "main",
-      "sort_order": 13
+      "sort_order": 14
     },
     {
       "id": "osprey",

--- a/strategies/phalanx/main/runtime.yaml
+++ b/strategies/phalanx/main/runtime.yaml
@@ -1,0 +1,143 @@
+# ── PHALANX · single instance — proven-cohort rotation ───────────────────────
+# Follows the PROVEN COHORT (>=$1M lifetime realized PnL) — not the 4h gain
+# leaderboard (which is a consequence of price, not a predictor). Reads the
+# cohort's headcount positioning per asset, requires conviction to be GROWING
+# (delta gate), boosts conviction when the cohort diverges from the 4h crowd,
+# and gates overcrowded trades on a 12h breakout. Wide stops + reachable locks
+# on 3x leverage so winners can run through noise to pay back losers.
+name: phalanx-main
+group: phalanx
+version: 3.0.0
+description: >
+  PHALANX — proven-cohort rotation. Reads the proven cohort (>=$1M lifetime
+  realized PnL via discovery_get_top_traders ALL_TIME) and tracks where their
+  headcount is shifting each tick. Goes LONG the assets the cohort is crowding
+  into (one_sidedness >= 65%, delta >= +2) and SHORT the ones they're fleeing,
+  with a divergence booster when the cohort disagrees with the 4h leaderboard
+  and an overcrowding breakout gate at 85%. 3x leverage with wide stops (15%
+  margin) and reachable profit locks (first at +20% ROE) so winners run through
+  noise to pay back losers. Per-class hit-rate tracking auto-tunes the tilt
+  threshold so the strategy learns which crowd to trust.
+
+strategy:
+  wallet: "${PHALANX_WALLET}"
+  slots: 3
+  margin_pct: 15
+  default_leverage: 3
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: phalanx_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300
+    timeout_seconds: 180
+    default_signal_validity_seconds: 600
+    state_history_max_count: 200
+    inputs:
+      tiltThreshold: 65
+      deltaMin: 2
+      overcrowdThreshold: 85
+      marginPctBase: 15
+      marginPctMax: 0
+      leverageDefault: 3
+      maxLong: 2
+      maxShort: 2
+      recentSignalTtlSeconds: 240
+      leaderboardLimit: 100
+      smartMinRealizedUsd: 1000000
+      cohortCap: 100
+      stateBatch: 50
+      pageSize: 1000
+      maxPages: 6
+    signal_data_schema:
+      score: { type: number }
+      direction: { type: string }
+      longRatio: { type: number, required: false }
+      netTilt: { type: number, required: false }
+      conviction: { type: number, required: false }
+      delta: { type: number, required: false }
+      divergence: { type: boolean, required: false }
+      oneSidedness: { type: number, required: false }
+      reasons: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: phalanx_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule
+    scanners: [phalanx_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      # Maker-first with taker fallback after 30s: gives a window for maker
+      # fills (lower fees) but guarantees execution so signals don't miss.
+      # (A pure maker-only entry — taker fallback off — passes validation and
+      # then fails every order at the executor; keep the fallback on.)
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: phalanx_main_signals
+
+# ── EXIT (DSL — wide stops, reachable locks, 48h outer bound) ─────────────────
+# Hard stop at 15% margin loss (3.75% price on 3x) — wide enough that normal
+# noise doesn't trigger it. First profit lock at +20% ROE (6.67% price on 3x),
+# floor at 25% of high-water (~+5% ROE). Escalating ladder with wide gaps so
+# a position at +25% that pulls back to +18% hits no floor and keeps running.
+# Weak-peak cut at 12h: only fires if peak ROE never cleared +5% AND price is
+# fading — a dead-position detector, not a "didn't move fast enough" cutter.
+# 48h hard timeout: outer bound, closes at market.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 60
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 2880       # 48h — outer bound for a swing rotation
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 720        # 12h — only cuts positions that never reached +5% ROE and are fading
+      min_value: 5.0
+    phase1:
+      enabled: false                  # trailing OFF — a floor below entry can ratchet a winner into a loss
+      max_loss_pct: 15.0              # 15% margin loss cap (3.75% price on 3x) — wide for noise
+      retrace_threshold: 15           # INERT while phase1.enabled is false
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:                          # trend-following ladder; first lock at +20% ROE (reachable)
+        - { trigger_pct: 20, lock_hw_pct: 25 }
+        - { trigger_pct: 35, lock_hw_pct: 45 }
+        - { trigger_pct: 60, lock_hw_pct: 65 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
+
+# ── RISK guard rails ──────────────────────────────────────────────────────────
+risk:
+  data_retention_seconds: 259200      # 72h
+  guard_rails:
+    daily_loss_limit_pct: 5            # tight — a bad regime day stops the book early
+    max_entries_per_day: 12
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_seconds: 43200            # 12h regime pause after 3 consecutive losses
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 14400  # 4h per-asset re-entry cooldown
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/phalanx/main/scanners/scan.py
+++ b/strategies/phalanx/main/scanners/scan.py
@@ -1,0 +1,596 @@
+"""PHALANX — supervised scanner (proven-cohort rotation, Runtime 3.0).
+
+THESIS — follow the PROVEN COHORT's flow, not the 4h leaderboard's state.
+A state-based follower reads leaderboard_get_markets (the 4h gain board), a
+*consequence* of price moves, not a predictor — by the time 58% of the
+4h board is long ETH, ETH already moved. Phalanx instead reads the
+proven cohort (>=$1M lifetime realized PnL, via discovery_get_top_traders
+ALL_TIME) and tracks their headcount positioning + tick-over-tick delta.
+
+Per tick:
+  1. Read account state + held positions (dual-DEX, read-sanity guard).
+  2. Refresh proven cohort daily (discovery_get_top_traders, cached in state).
+  3. Snapshot cohort positions (discovery_get_trader_state, batched 50).
+  4. Aggregate per-asset headcount: {ASSET: {long_n, short_n}}.
+  5. Read 4h leaderboard (leaderboard_get_markets) for divergence detection.
+  6. Evaluate past signal accuracy per asset class (price-based proxy).
+  7. For each asset passing gates (one_sidedness >= threshold + delta >= +2
+     + overcrowding breakout check), compute conviction with divergence
+     booster and price confirmation multiplier.
+  8. Emit up to maxLong longs + maxShort shorts, conviction-ranked, deduped.
+
+Read-only + single-pass. marginPct is a PERCENT in (0,100]. No daemon,
+no push_signal, no create_position. EVERY MCP call is read-guarded.
+"""
+
+import sys
+import time
+
+import scoring
+
+# ── defaults (overridable via runtime.yaml inputs) ───────────────────────────
+_DEFAULT_TILT_THRESHOLD = 65.0   # min one_sidedness to qualify
+_DEFAULT_DELTA_MIN = 2.0          # min directional delta since last tick
+_DEFAULT_OVERCROWD = 85.0         # one_sidedness above which breakout is required
+_DEFAULT_MARGIN_PCT = 15.0        # baseline % of withdrawable
+_DEFAULT_LEVERAGE = 3             # clamped to [1,4]
+_MIN_LEVERAGE = 1
+_MAX_LEVERAGE = 4
+_DEFAULT_MAX_LONG = 2
+_DEFAULT_MAX_SHORT = 2
+_DEFAULT_RECENT_TTL = 240         # signal-dedup TTL (s)
+_DEFAULT_COHORT_CAP = 100         # max proven traders to track
+_DEFAULT_SMART_MIN_REALIZED = 1_000_000  # >=$1M lifetime realized
+_DEFAULT_STATE_BATCH = 50         # discovery_get_trader_state batch size
+_DEFAULT_LEADERBOARD_LIMIT = 100
+_COHORT_REFRESH_S = 86400         # 24h cohort cache refresh
+
+def _read(ctx, name, args, label):
+    """Guarded MCP read — a transient error degrades, never crashes the tick."""
+    try:
+        raw = ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[phalanx.scan] {label} read failed: {exc!r}", file=sys.stderr)
+        return None
+    if not raw:
+        return None
+    return raw.get("data", raw) if isinstance(raw, dict) else raw
+
+def _dex_for(asset):
+    """XYZ (HIP-3) assets need dex='xyz' for market reads."""
+    return "xyz" if str(asset).lower().startswith("xyz:") else ""
+
+# ── ACCOUNT + HELD ASSETS ─────────────────────────────────────────────────────
+
+def _get_account(ctx):
+    """(account_value, [position_dicts]) from strategy_get_clearinghouse_state.
+
+    Dual-DEX equity collapse: account_value via max() across main/xyz
+    (two views of ONE cross-margined wallet — summing double-counts).
+    """
+    d = _read(ctx, "strategy_get_clearinghouse_state",
+              {"strategy_wallet": ctx.wallet}, "strategy_get_clearinghouse_state")
+    if not isinstance(d, dict):
+        return 0.0, []
+
+    positions, account_value = [], 0.0
+    for section in ("main", "xyz"):
+        s = d.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap) if isinstance(ap, dict) else {}
+            szi = scoring._f(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+            })
+
+    # read-sanity guard: margin in use but empty positions -> skip tick
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = d.get(_sec, {}) if isinstance(d, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring._f(_ms.get("totalMarginUsed", 0)),
+                   abs(scoring._f(_ms.get("totalNtlPos", 0))))
+    if _use > 1.0 and not positions:
+        print("[phalanx.scan] read-sanity guard: margin in use but empty positions — skipping",
+              file=sys.stderr)
+        return 0.0, []
+
+    return account_value, positions
+
+# ── PROVEN COHORT (daily cache) ───────────────────────────────────────────────
+
+def _traders_of(d):
+    """Unwrap discovery_get_top_traders response."""
+    if isinstance(d, list):
+        return d
+    if isinstance(d, dict):
+        for k in ("traders", "data", "results"):
+            if isinstance(d.get(k), list):
+                return d[k]
+    return []
+
+def _trader_address(t):
+    """Extract a lower-cased address from a trader record."""
+    if not isinstance(t, dict):
+        return ""
+    for k in ("traderAddress", "trader_address", "address", "wallet"):
+        v = t.get(k)
+        if v:
+            return str(v).lower()
+    return ""
+
+def _realized(t):
+    """Realized PnL from a top-trader record (tries every spelling)."""
+    for k in ("realizedProfitAndLoss", "realized_profit_and_loss",
+              "profit_and_loss_realized", "realizedPnl", "realized_pnl"):
+        v = t.get(k) if isinstance(t, dict) else None
+        if v is not None:
+            return scoring._f(v)
+    return 0.0
+
+def _refresh_cohort(ctx, inputs):
+    """Fetch proven cohort: discovery_get_top_traders ALL_TIME, >=$1M realized."""
+    smin = scoring._f(inputs.get("smartMinRealizedUsd"), _DEFAULT_SMART_MIN_REALIZED)
+    cap = int(scoring._f(inputs.get("cohortCap"), _DEFAULT_COHORT_CAP))
+    psize = int(scoring._f(inputs.get("pageSize"), 1000))
+    pages = int(scoring._f(inputs.get("maxPages"), 6))
+
+    smart, seen = [], set()
+    for page in range(pages):
+        d = _read(ctx, "discovery_get_top_traders",
+                  {"time_frame": "ALL_TIME", "sort_by": "PROFIT_AND_LOSS_REALIZED",
+                   "open_position_filter": False, "limit": psize, "offset": page * psize},
+                  f"discovery_get_top_traders(p{page})")
+        rows = _traders_of(d)
+        if not rows:
+            break
+        for t in rows:
+            if not isinstance(t, dict):
+                continue
+            a = _trader_address(t)
+            if not a or a in seen:
+                continue
+            if _realized(t) >= smin and len(smart) < cap:
+                smart.append(a)
+                seen.add(a)
+        if len(rows) < psize or len(smart) >= cap:
+            break
+    return smart
+
+def _get_cohort(ctx, inputs, prev_state):
+    """Return (addresses, refreshed_at). Refreshes daily, else carries forward."""
+    now = time.time()
+    prev_cohort = (prev_state or {}).get("cohort", {})
+    refreshed_at = scoring._f(prev_cohort.get("refreshed_at", 0))
+    addresses = prev_cohort.get("addresses", [])
+
+    if not addresses or (now - refreshed_at) >= _COHORT_REFRESH_S:
+        fresh = _refresh_cohort(ctx, inputs)
+        if fresh:
+            return fresh, now
+        # refresh failed — keep the old cohort (better than empty)
+        if addresses:
+            print("[phalanx.scan] cohort refresh failed — using cached cohort", file=sys.stderr)
+            return addresses, refreshed_at
+        print("[phalanx.scan] no cohort available (refresh failed, no cache)", file=sys.stderr)
+        return [], 0.0
+
+    return addresses, refreshed_at
+
+# ── COHORT POSITIONING (headcount per asset) ──────────────────────────────────
+
+def _state_wallet(st):
+    return str((st or {}).get("traderAddress") or (st or {}).get("trader_address")
+               or (st or {}).get("address") or (st or {}).get("wallet") or "").lower()
+
+def _positions_of(st):
+    if not isinstance(st, dict):
+        return []
+    pos = st.get("openPositions") or st.get("open_positions") or st.get("positions") or []
+    return pos if isinstance(pos, list) else []
+
+def _direction_of(pos):
+    """LONG / SHORT from szi sign."""
+    szi = scoring._f((pos or {}).get("szi"))
+    if szi > 0:
+        return "LONG"
+    if szi < 0:
+        return "SHORT"
+    return None
+
+def _cohort_headcount(ctx, cohort, inputs):
+    """Aggregate per-asset headcount from the cohort's open positions.
+
+    Returns {BARE_UPPER: {"long_n": int, "short_n": int, "raw_coin": str}}
+    where raw_coin carries the venue prefix (xyz:NVDA) for the first sighting.
+    """
+    batch = int(scoring._f(inputs.get("stateBatch"), _DEFAULT_STATE_BATCH))
+    states, any_ok = [], False
+    for i in range(0, len(cohort), batch):
+        d = _read(ctx, "discovery_get_trader_state",
+                  {"trader_addresses": cohort[i:i + batch]},
+                  f"discovery_get_trader_state(b{i // batch})")
+        if d is None:
+            continue
+        any_ok = True
+        # d might be a list of trader states or a dict wrapping one
+        if isinstance(d, list):
+            states.extend(d)
+        elif isinstance(d, dict):
+            for k in ("traders", "data", "results"):
+                if isinstance(d.get(k), list):
+                    states.extend(d[k])
+                    break
+            else:
+                states.append(d)  # single trader state
+
+    if not any_ok:
+        print("[phalanx.scan] all trader_state batches failed — no headcount this tick",
+              file=sys.stderr)
+        return {}
+
+    counts = {}
+    seen = set()  # (wallet, asset, direction) dedup across batches
+    for st in states:
+        if not isinstance(st, dict):
+            continue
+        wallet = _state_wallet(st)
+        for pos in _positions_of(st):
+            if not isinstance(pos, dict):
+                continue
+            coin = (pos.get("coin") or pos.get("asset") or "")
+            if not coin:
+                continue
+            direction = _direction_of(pos)
+            if direction is None:
+                continue
+            asset_key = scoring.bare_upper(coin)
+            wkey = wallet or f"_anon_{id(pos)}"
+            dkey = (wkey, asset_key, direction)
+            if dkey in seen:
+                continue
+            seen.add(dkey)
+            rec = counts.setdefault(asset_key, {
+                "long_n": 0, "short_n": 0, "raw_coin": coin,
+            })
+            if direction == "LONG":
+                rec["long_n"] += 1
+            else:
+                rec["short_n"] += 1
+            # prefer a prefixed raw_coin for venue correctness
+            if str(coin).lower().startswith("xyz:") and not str(rec["raw_coin"]).lower().startswith("xyz:"):
+                rec["raw_coin"] = coin
+
+    return counts
+
+# ── 4H LEADERBOARD (crowd read for divergence) ────────────────────────────────
+
+def _crowd_lean(ctx, limit):
+    """Per-asset long_ratio from the 4h gain leaderboard.
+
+    Returns {BARE_UPPER: long_ratio} where long_ratio is the 4h board's
+    long% (NOT smart money — this is the crowd/momentum read).
+    """
+    raw = _read(ctx, "leaderboard_get_markets",
+                {"limit": limit}, "leaderboard_get_markets")
+    if not isinstance(raw, list):
+        if isinstance(raw, dict):
+            for k in ("markets", "data", "results"):
+                if isinstance(raw.get(k), list):
+                    raw = raw[k]
+                    break
+            else:
+                return {}
+        else:
+            return {}
+
+    by_asset = {}
+    for m in raw:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", ""))))
+        if not token:
+            continue
+        dex = str(m.get("dex", "")).lower()
+        direction = str(m.get("direction", "")).lower()
+        pct = scoring._f(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        key = (token.upper(), dex)
+        row = by_asset.setdefault(key, {"long_pct": 0.0, "short_pct": 0.0})
+        if direction == "long":
+            row["long_pct"] += pct
+        elif direction == "short":
+            row["short_pct"] += pct
+
+    out = {}
+    for (tok, dex), row in by_asset.items():
+        lr, _ = scoring.net_tilt(row["long_pct"], row["short_pct"])
+        out[tok] = lr
+    return out
+
+# ── PRICE READS (trend + breakout + current price) ────────────────────────────
+
+def _asset_data(ctx, coin):
+    """Read 1h + 4h candles for an asset. Returns (candles_1h, candles_4h) or (None, None)."""
+    md = _read(ctx, "market_get_asset_data", {
+        "asset": coin,
+        "candle_intervals": ["1h", "4h"],
+        "include_funding": False,
+        "include_order_book": False,
+        "dex": _dex_for(coin),
+    }, f"market_get_asset_data({coin})")
+    if not isinstance(md, dict):
+        return None, None
+    candles = md.get("candles", {}) or {}
+    c1h = candles.get("1h", []) or []
+    c4h = candles.get("4h", []) or []
+    return c1h, c4h
+
+def _current_price(candles_1h):
+    """Latest close from 1h candles, or 0.0."""
+    if not candles_1h:
+        return 0.0
+    last = candles_1h[-1]
+    if isinstance(last, dict):
+        return scoring._f(last.get("c", last.get("close", 0)))
+    if isinstance(last, (list, tuple)) and len(last) >= 5:
+        return scoring._f(last[4])
+    return 0.0
+
+# ── SIGNAL EMIT ───────────────────────────────────────────────────────────────
+
+def _emit_side(candidates, direction, max_count, held_set, signaled, ttl, now):
+    """Filter + emit signals for one direction. Returns (emits, updated_signaled)."""
+    out = []
+    for c in candidates:
+        if len(out) >= max_count:
+            break
+        asset = c["asset"]
+        sig_key = f"{asset}_{direction}"
+        if scoring.bare_upper(asset) in held_set:
+            continue
+        if sig_key in signaled and (now - signaled[sig_key]) < ttl:
+            continue
+        out.append({
+            "asset": asset,
+            "direction": direction,
+            "marginPct": c["marginPct"],
+            "leverage": c["leverage"],
+            "data": {
+                "score": c["conviction"],
+                "direction": direction,
+                "longRatio": c.get("long_ratio"),
+                "netTilt": c.get("net_tilt"),
+                "conviction": c["conviction"],
+                "delta": c.get("delta"),
+                "divergence": c.get("divergence", False),
+                "oneSidedness": c.get("one_sidedness"),
+                "reasons": c.get("reasons", []),
+            },
+        })
+        signaled[sig_key] = now
+    return out, signaled
+
+# ── MAIN SCAN ─────────────────────────────────────────────────────────────────
+
+def scan(inputs, ctx):
+    now = time.time()
+
+    # ── tunables ──
+    tilt_threshold = scoring._f(inputs.get("tiltThreshold"), _DEFAULT_TILT_THRESHOLD)
+    delta_min = scoring._f(inputs.get("deltaMin"), _DEFAULT_DELTA_MIN)
+    overcrowd = scoring._f(inputs.get("overcrowdThreshold"), _DEFAULT_OVERCROWD)
+    base_margin = scoring._f(inputs.get("marginPctBase"), _DEFAULT_MARGIN_PCT)
+    margin_max = scoring._f(inputs.get("marginPctMax"), 0)
+    leverage = int(scoring._f(inputs.get("leverageDefault"), _DEFAULT_LEVERAGE))
+    leverage = max(_MIN_LEVERAGE, min(_MAX_LEVERAGE, leverage))
+    max_long = int(scoring._f(inputs.get("maxLong"), _DEFAULT_MAX_LONG))
+    max_short = int(scoring._f(inputs.get("maxShort"), _DEFAULT_MAX_SHORT))
+    ttl = scoring._f(inputs.get("recentSignalTtlSeconds"), _DEFAULT_RECENT_TTL)
+    lb_limit = int(scoring._f(inputs.get("leaderboardLimit"), _DEFAULT_LEADERBOARD_LIMIT))
+
+    # ── account + held ──
+    account_value, positions = _get_account(ctx)
+    if account_value <= 0:
+        print("[phalanx.scan] cannot read account value; skip tick", file=sys.stderr)
+        _persist_state(ctx, prev_state=None, signaled={}, result={"ts": now, "emitted": False, "gate": "no_account"})
+        return []
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {scoring.bare_upper(h) for h in held_assets}
+
+    # ── load previous state ──
+    prev = (ctx.state.last() or {}) if ctx.state else {}
+    prev_tilts = prev.get("prev_tilts", {})
+    accuracy_state = prev.get("accuracy", scoring.new_accuracy_state())
+    if not isinstance(accuracy_state, dict):
+        accuracy_state = scoring.new_accuracy_state()
+    signaled = prev.get("signaled", {})
+    if not isinstance(signaled, dict):
+        signaled = {}
+
+    # prune expired dedup entries
+    signaled = {k: v for k, v in signaled.items() if (now - v) < ttl * 3}
+
+    # ── proven cohort (daily cache) ──
+    cohort, cohort_refreshed = _get_cohort(ctx, inputs, prev)
+    if not cohort:
+        print("[phalanx.scan] no proven cohort; skip tick", file=sys.stderr)
+        _persist_state(ctx, prev, cohort_refreshed, cohort, prev_tilts,
+                       accuracy_state, signaled, {"ts": now, "emitted": False, "gate": "no_cohort"})
+        return []
+
+    # ── cohort positioning (headcount per asset) ──
+    headcount = _cohort_headcount(ctx, cohort, inputs)
+    if not headcount:
+        print("[phalanx.scan] empty headcount; skip tick", file=sys.stderr)
+        _persist_state(ctx, prev, cohort_refreshed, cohort, prev_tilts,
+                       accuracy_state, signaled, {"ts": now, "emitted": False, "gate": "no_headcount"})
+        return []
+
+    # ── 4h leaderboard (crowd read for divergence) ──
+    crowd_lean = _crowd_lean(ctx, lb_limit)
+
+    # ── evaluate past signal accuracy ──
+    def _price_lookup(asset):
+        c1h, _ = _asset_data(ctx, asset)
+        return _current_price(c1h)
+
+    for cls in ("crypto", "xyz"):
+        accuracy_state = scoring.update_accuracy(accuracy_state, cls, now, _price_lookup)
+
+    # ── build candidates ──
+    long_candidates, short_candidates = [], []
+    new_tilts = {}
+
+    for asset_key, rec in headcount.items():
+        long_n = rec["long_n"]
+        short_n = rec["short_n"]
+        raw_coin = rec.get("raw_coin", asset_key)
+
+        # store for next tick's delta
+        new_tilts[asset_key] = {"long_n": long_n, "short_n": short_n}
+
+        long_ratio, net_tilt = scoring.net_tilt(long_n, short_n)
+        sided = scoring.one_sidedness(long_n, short_n)
+
+        # direction: LONG if cohort is net long, SHORT otherwise
+        direction = "LONG" if long_n >= short_n else "SHORT"
+
+        # per-class threshold adjustment
+        cls = scoring.asset_class_for(raw_coin)
+        eff_threshold = scoring.adjusted_threshold(tilt_threshold, cls, accuracy_state)
+
+        # gate 1: one_sidedness >= threshold
+        if sided < eff_threshold:
+            continue
+
+        # gate 2: delta >= delta_min (conviction growing)
+        prev_rec = prev_tilts.get(asset_key, {})
+        delta = scoring.directional_delta(
+            prev_rec.get("long_n", 0), prev_rec.get("short_n", 0),
+            long_n, short_n, direction,
+        )
+        if delta < delta_min:
+            continue
+
+        # gate 3: overcrowding breakout check
+        reasons = []
+        if sided >= overcrowd:
+            c1h, c4h = _asset_data(ctx, raw_coin)
+            if not scoring.breakout_check(c1h, direction):
+                continue  # crowded but no breakout — move is exhausted
+            reasons.append(f"overcrowded ({sided:.0f}%) with breakout confirmation")
+        else:
+            # only read candles if we haven't already
+            c1h, c4h = _asset_data(ctx, raw_coin)
+
+        # trend structure (price confirmation)
+        trend_label, trend_strength = scoring.trend_structure(c4h or [])
+        price_mult = scoring.price_conviction_mult(trend_label, direction)
+
+        # divergence booster
+        crowd_lr = crowd_lean.get(asset_key, 50.0)
+        divergent = scoring.is_divergent(long_ratio, crowd_lr)
+        divergence_mult = 1.5 if divergent else 1.0
+
+        if divergent:
+            reasons.append(f"divergence: cohort {direction} vs 4h board {'LONG' if crowd_lr > 50 else 'SHORT'}")
+
+        if trend_label != "NEUTRAL":
+            reasons.append(f"4h trend {trend_label.lower()} ({trend_strength:.0%})")
+
+        reasons.append(f"cohort {long_n}L/{short_n}S ({sided:.0f}% one-sided), delta +{delta:.0f}")
+
+        # conviction = one_sidedness * price_mult * divergence_mult
+        conviction = sided * price_mult * divergence_mult
+
+        # margin sizing
+        margin_pct = scoring.margin_pct_for(conviction, base_margin, margin_max if margin_max > 0 else None)
+
+        candidate = {
+            "asset": raw_coin,
+            "direction": direction,
+            "conviction": round(conviction, 2),
+            "one_sidedness": round(sided, 1),
+            "long_ratio": round(long_ratio, 1),
+            "net_tilt": round(net_tilt, 1),
+            "delta": round(delta, 1),
+            "divergence": divergent,
+            "marginPct": round(margin_pct, 2),
+            "leverage": leverage,
+            "reasons": reasons,
+        }
+
+        if direction == "LONG":
+            long_candidates.append(candidate)
+        else:
+            short_candidates.append(candidate)
+
+    # ── rank + emit ──
+    long_candidates = scoring.rank_signals(long_candidates)
+    short_candidates = scoring.rank_signals(short_candidates)
+
+    long_emits, signaled = _emit_side(
+        long_candidates, "LONG", max_long, held_set, signaled, ttl, now)
+    short_emits, signaled = _emit_side(
+        short_candidates, "SHORT", max_short, held_set, signaled, ttl, now)
+
+    out = long_emits + short_emits
+
+    # ── record emitted signals for accuracy tracking ──
+    for e in out:
+        cls = scoring.asset_class_for(e["asset"])
+        c1h, _ = _asset_data(ctx, e["asset"])
+        entry_px = _current_price(c1h)
+        if entry_px > 0:
+            scoring.add_pending_signal(accuracy_state, cls, e["asset"], e["direction"], entry_px, now)
+
+    # ── log + persist state ──
+    if out:
+        print(f"[phalanx.scan] EMIT {len(long_emits)}L + {len(short_emits)}S "
+              f"| cohort={len(cohort)} assets={len(headcount)} "
+              f"| {[ (e['asset'], e['direction'], e['data'].get('conviction')) for e in out ]}",
+              file=sys.stderr)
+        result = {"ts": now, "emitted": True, "board": len(headcount),
+                  "emittedAssets": [(e["asset"], e["direction"]) for e in out],
+                  "held": held_assets}
+    else:
+        print(f"[phalanx.scan] WAITING — no emit | cohort={len(cohort)} assets={len(headcount)} "
+              f"long_cands={len(long_candidates)} short_cands={len(short_candidates)} "
+              f"held={held_assets} (threshold {tilt_threshold:.0f}, delta_min {delta_min:.0f})",
+              file=sys.stderr)
+        result = {"ts": now, "emitted": False, "gate": "no_signal", "board": len(headcount),
+                  "held": held_assets}
+
+    _persist_state(ctx, prev, cohort_refreshed, cohort, new_tilts,
+                   accuracy_state, signaled, result)
+
+    return out
+
+def _persist_state(ctx, prev, cohort_refreshed, cohort, new_tilts,
+                   accuracy_state, signaled, result):
+    """Persist the full state record for next tick."""
+    if ctx.state is None:
+        return
+    cohort_refreshed = cohort_refreshed if cohort_refreshed else (
+        scoring._f((prev or {}).get("cohort", {}).get("refreshed_at", 0)))
+    cohort_list = cohort if cohort else (
+        (prev or {}).get("cohort", {}).get("addresses", []))
+    record = {
+        "ts": result.get("ts", time.time()),
+        "cohort": {"addresses": cohort_list, "refreshed_at": cohort_refreshed},
+        "prev_tilts": new_tilts if new_tilts else (prev or {}).get("prev_tilts", {}),
+        "accuracy": accuracy_state,
+        "signaled": signaled,
+        "result": result,
+    }
+    try:
+        ctx.state.append(record)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[phalanx.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)

--- a/strategies/phalanx/main/scanners/scoring.py
+++ b/strategies/phalanx/main/scanners/scoring.py
@@ -1,0 +1,339 @@
+"""PHALANX — pure thesis math (no I/O, no MCP, no clock).
+
+Proven-cohort rotation scorer. Where a state-based follower reads the 4h gain
+leaderboard — a momentum/survivorship-biased read that's a *consequence* of
+price moves, not a predictor — Phalanx follows the PROVEN COHORT: traders
+with >=$1M lifetime realized PnL (discovery_get_top_traders ALL_TIME). Their
+positioning is based on track record, not 4h gains, so it's immune to the
+circularity that makes a leaderboard follower's directional calls lag.
+
+The unit of analysis is the BOARD, not one coin. Per tick the scanner
+aggregates the cohort's headcount per asset (long_n vs short_n among
+positioned traders), and this module scores:
+
+  - one_sidedness: how aligned the cohort is (50% = balanced, 90% = a rout).
+    Headcount-based, not notional — price can't change a headcount the way
+    it drifts notional bias. Below min_sample -> 0 (too thin to trust).
+  - directional_delta: change in net headcount in the signal direction since
+    last tick. Conviction must be GROWING (delta >= threshold), not stale.
+  - conviction: one_sidedness * multipliers (divergence booster, price
+    confirmation), gated by delta and overcrowding checks.
+  - margin_pct_for: conviction-tiered margin (1.0 / 1.25 / 1.5 x base).
+  - accuracy tracking: rolling hit rate per asset class (crypto vs xyz),
+    auto-adjusting the tilt threshold so the strategy learns which crowd
+    to trust.
+
+Pure: consumes already-normalized headcount dicts and candle lists; returns
+conviction-ranked signals. No I/O, no MCP, no clock — unit-testable.
+"""
+
+import math
+
+# ── numeric helpers ───────────────────────────────────────────────────────────
+
+def _f(v, d=0.0):
+    """Defensive numeric read: no-op on numbers, casts strings, d on None/garbage."""
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+# ── asset classification ──────────────────────────────────────────────────────
+
+def asset_class_for(asset):
+    """Return 'xyz' for HIP-3 assets (equities/commodities/indices), 'crypto' for main-DEX."""
+    return "xyz" if str(asset).lower().startswith("xyz:") else "crypto"
+
+def bare_upper(name):
+    """Bare, upper-cased asset key: strips any venue prefix ('xyz:NVDA' -> 'NVDA')."""
+    s = str(name)
+    return (s[4:] if s.lower().startswith("xyz:") else s).upper()
+
+def venue_asset(token, dex):
+    """Re-attach xyz: prefix for the venue. Bare token + dex='xyz' -> 'xyz:TOKEN'.
+    Already-prefixed tokens are rebuilt with lowercase 'xyz:' (canonical)."""
+    t = str(token)
+    if t.lower().startswith("xyz:"):
+        return "xyz:" + t[4:]
+    return f"xyz:{t}" if str(dex).lower() == "xyz" else t
+
+# ── headcount tilt + one-sidedness ────────────────────────────────────────────
+
+def net_tilt(long_n, short_n):
+    """Headcount-based net tilt.
+
+    long_ratio = long_n / (long_n + short_n) * 100  (50 = balanced)
+    net_tilt   = long_ratio - 50  (+ = cohort net long, - = net short)
+
+    Unlike notional bias (net/gross), headcount is a decision price can't
+    fake: a wallet either holds the position or it doesn't, regardless of
+    mark-to-market drift.
+    """
+    total = _f(long_n) + _f(short_n)
+    if total <= 0:
+        return 50.0, 0.0
+    long_ratio = (_f(long_n) / total) * 100.0
+    return long_ratio, long_ratio - 50.0
+
+def one_sidedness(long_n, short_n, min_sample=10):
+    """How one-sided is the positioned split? Returns the larger side's share (0-100).
+
+    13 long vs 7 short  -> 65.0  (one-sided enough to act)
+    43 short vs 4 long  -> 91.5  (a rout)
+    429 long vs 380 short -> 53.0 (noise — barely leans)
+    4 long vs 1 short   -> 0.0  (below min_sample, too thin to trust)
+
+    This is THE key conviction metric. Signals require one_sidedness >= the
+    tilt threshold (default 65), so a 53% lean never produces a trade.
+    """
+    total = _f(long_n) + _f(short_n)
+    if total < min_sample:
+        return 0.0
+    long_ratio = (_f(long_n) / total) * 100.0
+    return max(long_ratio, 100.0 - long_ratio)
+
+def directional_delta(prev_long_n, prev_short_n, curr_long_n, curr_short_n, direction):
+    """Change in net headcount in the signal direction since last tick.
+
+    For LONG:  delta = (curr_long - curr_short) - (prev_long - prev_short)
+    For SHORT: delta = (prev_long - prev_short) - (curr_long - curr_short)
+
+    Positive = conviction growing in the signal direction.
+    Negative = conviction fading (traders closing or flipping).
+    Zero = stale (no change — don't enter, the move is already priced in).
+    """
+    prev_net = _f(prev_long_n) - _f(prev_short_n)
+    curr_net = _f(curr_long_n) - _f(curr_short_n)
+    if direction == "LONG":
+        return curr_net - prev_net
+    else:  # SHORT
+        return prev_net - curr_net
+
+# ── conviction scoring ────────────────────────────────────────────────────────
+
+def price_conviction_mult(trend_label, direction):
+    """How much does the 4h price trend support the signal direction?
+
+    BULLISH trend + LONG  -> 1.2 (confirmed — ride it)
+    BEARISH trend + SHORT -> 1.2 (confirmed — ride it)
+    BULLISH trend + SHORT -> 0.7 (fighting price — risky)
+    BEARISH trend + LONG  -> 0.7 (fighting price — risky)
+    NEUTRAL               -> 1.0 (no confirmation, no contradiction)
+    """
+    if direction == "LONG":
+        if trend_label == "BULLISH":
+            return 1.2
+        if trend_label == "BEARISH":
+            return 0.7
+    else:  # SHORT
+        if trend_label == "BEARISH":
+            return 1.2
+        if trend_label == "BULLISH":
+            return 0.7
+    return 1.0
+
+def is_divergent(cohort_long_ratio, crowd_long_ratio):
+    """True if the proven cohort and the 4h leaderboard disagree on direction.
+
+    cohort_long_ratio: proven cohort's long% for the asset (headcount-based)
+    crowd_long_ratio: 4h leaderboard's long% for the asset (gain-weighted)
+
+    Divergence: cohort net LONG (>50) while crowd net SHORT (<=50), or vice versa.
+    This is where the alpha lives — the proven cohort has historically been
+    right when the crowd disagrees.
+    """
+    cohort_side = "LONG" if cohort_long_ratio > 50 else "SHORT"
+    crowd_side = "LONG" if crowd_long_ratio > 50 else "SHORT"
+    return cohort_side != crowd_side
+
+def margin_pct_for(conviction, base_pct, max_pct=None):
+    """Conviction-scaled margin PERCENT. Stronger conviction -> bigger size.
+
+    >= 80 conviction -> base * 1.5
+    >= 65 conviction -> base * 1.25
+    else             -> base
+
+    Returns a PERCENT in (0,100]; clamped to max_pct when supplied.
+    """
+    if conviction >= 80:
+        pct = base_pct * 1.5
+    elif conviction >= 65:
+        pct = base_pct * 1.25
+    else:
+        pct = base_pct
+    if max_pct is not None and max_pct > 0:
+        pct = min(pct, max_pct)
+    return pct
+
+# ── trend structure (4h price confirmation) ───────────────────────────────────
+
+def trend_structure(candles, lookback=6):
+    """Determine the 4h trend: BULLISH (higher lows) or BEARISH (lower highs).
+
+    Uses the last `lookback` candles. Higher lows in >= lookback-2 of them
+    -> BULLISH. Lower highs in >= lookback-2 -> BEARISH. Otherwise NEUTRAL.
+
+    Returns (label, strength) where strength is the fraction of matching bars.
+    """
+    if not candles or len(candles) < lookback:
+        return "NEUTRAL", 0.0
+
+    def _low(c):
+        if isinstance(c, dict):
+            return _f(c.get("l", c.get("low", 0)))
+        if isinstance(c, (list, tuple)) and len(c) >= 5:
+            return _f(c[3])
+        return 0.0
+
+    def _high(c):
+        if isinstance(c, dict):
+            return _f(c.get("h", c.get("high", 0)))
+        if isinstance(c, (list, tuple)) and len(c) >= 5:
+            return _f(c[2])
+        return 0.0
+
+    recent = candles[-lookback:]
+    lows = [_low(c) for c in recent]
+    highs = [_high(c) for c in recent]
+
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+
+    denom = max(1, lookback - 1)
+    if higher_lows >= lookback - 2:
+        return "BULLISH", higher_lows / denom
+    if lower_highs >= lookback - 2:
+        return "BEARISH", lower_highs / denom
+    return "NEUTRAL", 0.0
+
+# ── breakout check (overcrowding gate) ─────────────────────────────────────────
+
+def breakout_check(candles_1h, direction, lookback=12):
+    """Check if the latest close makes a new lookback-period high (LONG) or low (SHORT).
+
+    Used as the overcrowding gate: when one_sidedness >= 85%, the trade is
+    crowded. Require a breakout (new 12h high for longs, new 12h low for shorts)
+    before entering — no breakout means the move is exhausted, not accelerating.
+    """
+    if not candles_1h or len(candles_1h) < lookback:
+        return False
+
+    def _close(c):
+        if isinstance(c, dict):
+            return _f(c.get("c", c.get("close", 0)))
+        if isinstance(c, (list, tuple)) and len(c) >= 5:
+            return _f(c[4])
+        return 0.0
+
+    def _high(c):
+        if isinstance(c, dict):
+            return _f(c.get("h", c.get("high", 0)))
+        if isinstance(c, (list, tuple)) and len(c) >= 5:
+            return _f(c[2])
+        return 0.0
+
+    def _low(c):
+        if isinstance(c, dict):
+            return _f(c.get("l", c.get("low", 0)))
+        if isinstance(c, (list, tuple)) and len(c) >= 5:
+            return _f(c[3])
+        return 0.0
+
+    recent = candles_1h[-lookback:]
+    last_close = _close(recent[-1])
+    if last_close <= 0:
+        return False
+
+    prior = recent[:-1]
+    if direction == "LONG":
+        prior_highs = [_high(c) for c in prior]
+        return last_close >= max(prior_highs) if prior_highs else False
+    else:  # SHORT
+        prior_lows = [_low(c) for c in prior]
+        return last_close <= min(prior_lows) if prior_lows else False
+
+# ── accuracy tracking (per-class hit rate, auto-threshold tuning) ─────────────
+
+EVAL_DELAY_S = 3600  # 1h to evaluate a signal's direction
+MIN_EVAL_SAMPLES = 5  # need at least 5 evaluated signals before adjusting
+RECENT_WINDOW = 10  # rolling window of evaluated signals per class
+HIT_RATE_LOW = 0.40  # below this -> raise threshold by 4
+HIT_RATE_HIGH = 0.55  # above this -> lower threshold by 2
+THRESH_ADJ_UP = 4.0
+THRESH_ADJ_DOWN = -2.0
+THRESH_FLOOR = 52.0  # never lower the tilt threshold below this
+
+def new_accuracy_state():
+    """Fresh accuracy tracker."""
+    return {
+        "crypto": {"pending": [], "recent": [], "threshold_adj": 0.0},
+        "xyz": {"pending": [], "recent": [], "threshold_adj": 0.0},
+    }
+
+def add_pending_signal(accuracy_state, asset_class, asset, direction, entry_price, ts):
+    """Record a freshly-emitted signal for later evaluation."""
+    cls = accuracy_state.get(asset_class)
+    if cls is None:
+        return accuracy_state
+    cls["pending"].append({
+        "asset": asset, "direction": direction,
+        "entry_price": entry_price, "ts": ts,
+    })
+    return accuracy_state
+
+def update_accuracy(accuracy_state, asset_class, now, price_lookup):
+    """Evaluate pending signals whose eval delay has elapsed.
+
+    price_lookup: function(asset) -> current price (or 0.0 if unreadable).
+    Moves evaluated signals from pending -> recent, trims recent to
+    RECENT_WINDOW, and recomputes threshold_adj.
+    """
+    cls = accuracy_state.get(asset_class)
+    if cls is None:
+        return accuracy_state
+
+    still_pending = []
+    for sig in cls.get("pending", []):
+        if now - sig["ts"] < EVAL_DELAY_S:
+            still_pending.append(sig)
+            continue
+        entry = _f(sig.get("entry_price", 0))
+        curr = _f(price_lookup(sig["asset"]))
+        if entry <= 0 or curr <= 0:
+            still_pending.append(sig)  # can't evaluate, keep trying
+            continue
+        if sig["direction"] == "LONG":
+            correct = curr > entry
+        else:
+            correct = curr < entry
+        cls["recent"].append({"correct": correct, "ts": now})
+
+    cls["pending"] = still_pending
+    cls["recent"] = cls["recent"][-RECENT_WINDOW:]
+
+    if len(cls["recent"]) >= MIN_EVAL_SAMPLES:
+        hit_rate = sum(1 for r in cls["recent"] if r["correct"]) / len(cls["recent"])
+        if hit_rate < HIT_RATE_LOW:
+            cls["threshold_adj"] = THRESH_ADJ_UP
+        elif hit_rate > HIT_RATE_HIGH:
+            cls["threshold_adj"] = THRESH_ADJ_DOWN
+        else:
+            cls["threshold_adj"] = 0.0
+    else:
+        cls["threshold_adj"] = 0.0
+
+    return accuracy_state
+
+def adjusted_threshold(base_threshold, asset_class, accuracy_state):
+    """The tilt threshold for this asset class, adjusted by hit-rate learning."""
+    adj = 0.0
+    cls = accuracy_state.get(asset_class)
+    if cls is not None:
+        adj = _f(cls.get("threshold_adj", 0.0))
+    return max(THRESH_FLOOR, base_threshold + adj)
+
+# ── signal ranking ────────────────────────────────────────────────────────────
+
+def rank_signals(candidates):
+    """Sort candidates by conviction descending. Pure."""
+    return sorted(candidates, key=lambda c: _f(c.get("conviction", 0)), reverse=True)

--- a/strategies/phalanx/strategy.yaml
+++ b/strategies/phalanx/strategy.yaml
@@ -1,0 +1,44 @@
+# Phalanx — proven-cohort rotation. A single-instance PACKAGE: this manifest +
+# one self-contained runtime.yaml + scanners/. A NET-NEW Runtime 3.0 strategy:
+# follows the PROVEN COHORT (>=$1M lifetime realized PnL), not the 4h gain
+# leaderboard. Reads the cohort's headcount positioning per asset, requires
+# conviction to be GROWING (delta gate), boosts conviction on divergence with
+# the 4h crowd, and gates overcrowded trades on a 12h breakout. Wide stops +
+# reachable locks on 3x leverage so winners run through noise to pay back losers.
+# Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: phalanx
+version: "1.0.0"
+
+catalog:
+  name: "Phalanx — Proven-Cohort Rotation"
+  emoji: "🛡️"
+  tagline: "Follows the proven cohort's headcount flow — not the 4h leaderboard's state — with delta-gated entries, divergence boosting, and wide stops that let winners run."
+  belief_plain: "The 4h gain leaderboard is a consequence of price moves, not a predictor — by the time 58% of the board is long ETH, ETH already moved. Phalanx instead tracks the proven cohort (traders with >=$1M lifetime realized PnL) and follows where their headcount is shifting: long the assets they're crowding into, short the ones they're fleeing — but only when conviction is growing (delta gate), and with a divergence booster when the cohort disagrees with the 4h crowd. Wide stops and reachable profit locks on 3x leverage let winners run through noise to pay back losers."
+  thesis: "Smart money doesn't just pick coins, it rotates capital across the whole board. But the 4h gain leaderboard — which state-based followers read — is mechanically biased toward whatever side of the trade is currently winning, making it a lagging indicator. Phalanx reads the proven cohort's actual positioning (headcount, not notional) and requires conviction to be growing (delta >= +2 since last tick), not just already high. A divergence booster multiplies conviction when the cohort disagrees with the 4h crowd (the proven cohort has historically been right when they disagree), and an overcrowding gate requires a 12h price breakout before entering trades that are >85% one-sided. Per-class hit-rate tracking auto-tunes the tilt threshold so the strategy learns which crowd to trust. The exit philosophy: on 3x leverage, a 15% margin stop (3.75% price) is wide enough to survive normal noise, and a first profit lock at +20% ROE (6.67% price) only engages on real moves — letting winners run far enough to pay for multiple losers."
+  group: smart-money
+  archetype: copy_trading
+  sub_style: sm_rotation
+  asset_classes: [universe_crypto, xyz_equities, commodities, indices]
+  asset_scope: follows_traders
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  time_horizon: swing
+  leverage_max: 4
+  max_slots: 3
+  assets: []
+  tags: [smart-money, rotation, proven-cohort, headcount, delta-gated, divergence, cross-asset, long-short, let-winners-run, wide-stops]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml         # → runtime name phalanx-main, group phalanx
+    wallet_env: PHALANX_WALLET
+    funding_share: 1.0

--- a/strategies/phalanx/tests/test_scoring.py
+++ b/strategies/phalanx/tests/test_scoring.py
@@ -1,0 +1,235 @@
+"""Unit tests for Phalanx scoring math (pure, no I/O).
+Run: python3 -m pytest strategies/phalanx/tests -q  or  python3 strategies/phalanx/tests/test_scoring.py"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "main", "scanners"))
+
+import scoring
+
+def _approx(a, b, tol=0.01):
+    return abs(a - b) < tol
+
+def test_net_tilt_balanced():
+    lr, tilt = scoring.net_tilt(10, 10)
+    assert _approx(lr, 50.0), f"long_ratio={lr}"
+    assert _approx(tilt, 0.0), f"net_tilt={tilt}"
+
+def test_net_tilt_long_heavy():
+    lr, tilt = scoring.net_tilt(15, 5)
+    assert _approx(lr, 75.0), f"long_ratio={lr}"
+    assert _approx(tilt, 25.0), f"net_tilt={tilt}"
+
+def test_net_tilt_empty():
+    lr, tilt = scoring.net_tilt(0, 0)
+    assert _approx(lr, 50.0)
+    assert _approx(tilt, 0.0)
+
+def test_one_sidedness_rout():
+    # 43 short vs 4 long = 91.5% one-sided
+    s = scoring.one_sidedness(4, 43)
+    assert _approx(s, 91.5, 0.1), f"one_sidedness={s}"
+
+def test_one_sidedness_noise():
+    # 429 vs 380 = 53% — barely leans
+    s = scoring.one_sidedness(429, 380)
+    assert _approx(s, 53.0, 0.1), f"one_sidedness={s}"
+
+def test_one_sidedness_below_min_sample():
+    # 4 vs 1 = below min_sample (10) -> 0.0
+    s = scoring.one_sidedness(4, 1)
+    assert s == 0.0, f"one_sidedness={s} (should be 0 for small sample)"
+
+def test_one_sidedness_enough():
+    # 13 long vs 7 short = 65% — just enough
+    s = scoring.one_sidedness(13, 7)
+    assert _approx(s, 65.0, 0.1), f"one_sidedness={s}"
+
+def test_directional_delta_long_growing():
+    # prev: 13L/7S (net +6), curr: 15L/6S (net +9), delta = +3
+    d = scoring.directional_delta(13, 7, 15, 6, "LONG")
+    assert _approx(d, 3.0), f"delta={d}"
+
+def test_directional_delta_short_growing():
+    # prev: 4L/15S (net -11), curr: 3L/18S (net -15), SHORT delta = prev_net - curr_net = -11 - (-15) = +4
+    d = scoring.directional_delta(4, 15, 3, 18, "SHORT")
+    assert _approx(d, 4.0), f"delta={d}"
+
+def test_directional_delta_stale():
+    # no change
+    d = scoring.directional_delta(13, 7, 13, 7, "LONG")
+    assert _approx(d, 0.0), f"delta={d}"
+
+def test_directional_delta_fading():
+    # prev: 15L/5S (net +10), curr: 13L/7S (net +6), LONG delta = 6-10 = -4
+    d = scoring.directional_delta(15, 5, 13, 7, "LONG")
+    assert _approx(d, -4.0), f"delta={d}"
+
+def test_price_conviction_mult_confirmed():
+    assert scoring.price_conviction_mult("BULLISH", "LONG") == 1.2
+    assert scoring.price_conviction_mult("BEARISH", "SHORT") == 1.2
+
+def test_price_conviction_mult_fighting():
+    assert scoring.price_conviction_mult("BEARISH", "LONG") == 0.7
+    assert scoring.price_conviction_mult("BULLISH", "SHORT") == 0.7
+
+def test_price_conviction_mult_neutral():
+    assert scoring.price_conviction_mult("NEUTRAL", "LONG") == 1.0
+    assert scoring.price_conviction_mult("NEUTRAL", "SHORT") == 1.0
+
+def test_is_divergent_yes():
+    # cohort long (60), crowd short (40) -> divergent
+    assert scoring.is_divergent(60.0, 40.0) is True
+
+def test_is_divergent_no():
+    # both long -> not divergent
+    assert scoring.is_divergent(65.0, 70.0) is False
+
+def test_is_divergent_edge():
+    # cohort exactly 50 -> SHORT side; crowd 55 -> LONG side -> divergent
+    assert scoring.is_divergent(50.0, 55.0) is True
+
+def test_margin_pct_for_high_conviction():
+    assert _approx(scoring.margin_pct_for(85, 15), 22.5), "should be 15 * 1.5"
+
+def test_margin_pct_for_mid_conviction():
+    assert _approx(scoring.margin_pct_for(70, 15), 18.75), "should be 15 * 1.25"
+
+def test_margin_pct_for_low_conviction():
+    assert _approx(scoring.margin_pct_for(50, 15), 15.0), "should be base"
+
+def test_margin_pct_for_max_cap():
+    assert _approx(scoring.margin_pct_for(90, 15, max_pct=20), 20.0), "should cap at 20"
+
+def test_trend_structure_bullish():
+    # higher lows: 100, 102, 104, 106, 108, 110
+    candles = [{"l": l, "h": l + 5, "c": l + 2} for l in [100, 102, 104, 106, 108, 110]]
+    label, strength = scoring.trend_structure(candles)
+    assert label == "BULLISH", f"label={label}"
+    assert strength > 0.5
+
+def test_trend_structure_bearish():
+    # lower highs: 110, 108, 106, 104, 102, 100
+    candles = [{"l": h - 5, "h": h, "c": h - 2} for h in [110, 108, 106, 104, 102, 100]]
+    label, strength = scoring.trend_structure(candles)
+    assert label == "BEARISH", f"label={label}"
+    assert strength > 0.5
+
+def test_trend_structure_neutral():
+    # mixed: 100, 98, 105, 103, 100, 102
+    candles = [{"l": l, "h": l + 3, "c": l + 1} for l in [100, 98, 105, 103, 100, 102]]
+    label, _ = scoring.trend_structure(candles)
+    assert label == "NEUTRAL", f"label={label}"
+
+def test_trend_structure_too_few():
+    label, strength = scoring.trend_structure([{"l": 100, "h": 105}])
+    assert label == "NEUTRAL"
+    assert strength == 0.0
+
+def test_breakout_check_long_new_high():
+    # 12 candles, last close is the highest
+    candles = [{"c": 100 + i, "h": 100 + i + 1, "l": 100 + i - 1} for i in range(12)]
+    # make last close the highest
+    candles[-1]["c"] = 200
+    assert scoring.breakout_check(candles, "LONG") is True
+
+def test_breakout_check_long_no_breakout():
+    # last close is below the prior high — not a breakout
+    candles = [{"c": 100 + i, "h": 100 + i + 2, "l": 100 + i - 1} for i in range(12)]
+    candles[-1]["c"] = 90  # well below any prior high
+    assert scoring.breakout_check(candles, "LONG") is False
+
+def test_breakout_check_short_new_low():
+    candles = [{"c": 100 - i, "h": 100 - i + 1, "l": 100 - i - 1} for i in range(12)]
+    candles[-1]["c"] = 50
+    assert scoring.breakout_check(candles, "SHORT") is True
+
+def test_breakout_check_too_few():
+    assert scoring.breakout_check([{"c": 100, "h": 105, "l": 95}], "LONG") is False
+
+def test_asset_class_for():
+    assert scoring.asset_class_for("BTC") == "crypto"
+    assert scoring.asset_class_for("ETH") == "crypto"
+    assert scoring.asset_class_for("xyz:NVDA") == "xyz"
+    assert scoring.asset_class_for("xyz:JPY") == "xyz"
+
+def test_bare_upper():
+    assert scoring.bare_upper("xyz:NVDA") == "NVDA"
+    assert scoring.bare_upper("BTC") == "BTC"
+    assert scoring.bare_upper("xyz:jpy") == "JPY"
+
+def test_venue_asset():
+    assert scoring.venue_asset("NVDA", "xyz") == "xyz:NVDA"
+    assert scoring.venue_asset("BTC", "") == "BTC"
+    assert scoring.venue_asset("XYZ:NVDA", "xyz") == "xyz:NVDA"  # canonicalized
+
+def test_accuracy_threshold_adjustment():
+    """When hit rate is low, threshold goes up; when high, it goes down."""
+    acc = scoring.new_accuracy_state()
+    # Simulate 5 incorrect signals for crypto
+    cls = acc["crypto"]
+    cls["recent"] = [{"correct": False, "ts": 0} for _ in range(5)]
+    cls["pending"] = []
+    # recompute
+    acc = scoring.update_accuracy(acc, "crypto", 999999, lambda a: 0.0)
+    # hit rate 0% < 0.40 -> threshold_adj = +4
+    eff = scoring.adjusted_threshold(65.0, "crypto", acc)
+    assert eff == 69.0, f"threshold should be 65+4=69, got {eff}"
+
+def test_accuracy_threshold_lowered():
+    """When hit rate is high, threshold goes down (but floored at 52)."""
+    acc = scoring.new_accuracy_state()
+    cls = acc["crypto"]
+    cls["recent"] = [{"correct": True, "ts": 0} for _ in range(6)]
+    cls["pending"] = []
+    acc = scoring.update_accuracy(acc, "crypto", 999999, lambda a: 0.0)
+    eff = scoring.adjusted_threshold(65.0, "crypto", acc)
+    assert eff == 63.0, f"threshold should be 65-2=63, got {eff}"
+
+def test_accuracy_threshold_floor():
+    """Threshold never goes below 52."""
+    acc = scoring.new_accuracy_state()
+    cls = acc["crypto"]
+    cls["recent"] = [{"correct": True, "ts": 0} for _ in range(10)]
+    cls["pending"] = []
+    acc = scoring.update_accuracy(acc, "crypto", 999999, lambda a: 0.0)
+    eff = scoring.adjusted_threshold(50.0, "crypto", acc)
+    assert eff == 52.0, f"threshold floored at 52, got {eff}"
+
+def test_accuracy_no_adjustment_with_few_samples():
+    """With <5 evaluated signals, no adjustment."""
+    acc = scoring.new_accuracy_state()
+    cls = acc["crypto"]
+    cls["recent"] = [{"correct": False, "ts": 0} for _ in range(3)]
+    cls["pending"] = []
+    acc = scoring.update_accuracy(acc, "crypto", 999999, lambda a: 0.0)
+    eff = scoring.adjusted_threshold(65.0, "crypto", acc)
+    assert eff == 65.0, f"no adjustment with <5 samples, got {eff}"
+
+def test_rank_signals():
+    candidates = [
+        {"asset": "BTC", "conviction": 70},
+        {"asset": "ETH", "conviction": 90},
+        {"asset": "SOL", "conviction": 50},
+    ]
+    ranked = scoring.rank_signals(candidates)
+    assert ranked[0]["asset"] == "ETH"
+    assert ranked[1]["asset"] == "BTC"
+    assert ranked[2]["asset"] == "SOL"
+
+
+# ── run all tests without pytest ──────────────────────────────────────────────
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    passed, failed = 0, 0
+    for t in tests:
+        try:
+            t()
+            passed += 1
+        except AssertionError as e:
+            print(f"  FAIL  {t.__name__}: {e}")
+            failed += 1
+    print(f"{passed} passed, {failed} failed")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
## What

**Phalanx** 🛡️ — a net-new `smart-money` template, promoted from an authored strategy that is live and working. Advanced tier, moderate risk, swing horizon, cross-asset (crypto + xyz equities/commodities/indices), long/short, one wallet, 3 slots.

**Signal — follow the proven cohort's flow, not the 4h leaderboard's state.** The cohort is the traders with ≥ $1M lifetime realized PnL (`discovery_get_top_traders` ALL_TIME, cached daily, capped at 100), read by **headcount** per asset via `discovery_get_trader_state` — a decision price cannot fake, unlike notional bias or the 4h gain board (which is a consequence of the move). An entry needs: one-sidedness ≥ 65% among positioned proven traders (minimum sample 10) · conviction **growing** since the last tick (delta ≥ +2) · a 12h price breakout when the trade is ≥ 85% one-sided · 4h trend confirmation scaling conviction (1.2× with, 0.7× against) · a 1.5× boost when the cohort **diverges** from the 4h crowd. Conviction-tiered margin (15% base → 1.25× / 1.5×). Per-class (crypto vs xyz) hit-rate tracking auto-tunes the threshold (floor 52).

**Exit — let winners run, on 3×.** Fixed 15% ROE max-loss (3.75% of price), first profit lock only at +20% ROE, ladder 20/35/60/100 → 25/45/65/85% of high-water, a 12h weak-peak cut that fires only below +5% ROE, 48h hard timeout. Rails: 5% daily loss, 20% drawdown halt, 12 entries/day, 3 consecutive losses → 12h pause, 4h per-asset cooldown. Maker-first entries with a 30 s taker fallback — a pure maker-only entry passes validation and then fails every order at the executor; that was found live and the fix is kept as a comment.

## Package

- `strategy.yaml` (catalog facets + the `main` instance) · `main/runtime.yaml` · `main/scanners/scan.py` + `scoring.py` (pure math) · `tests/test_scoring.py` (37 tests).
- `python3 -m pytest strategies/phalanx/tests -q` → 37 passed · `validate_strategy.py` → clean · `validate_universe.py` → derived universe · `deploy.py validate` → structurally deploy-ready (the live-tick proof is written on the box by `senpi validate`, as for every package).
- `catalog.json` regenerated in both locations with `gen_catalog.py --branch main`: besides the new entry, only `_updated` and the `sort_order` of the six entries that now follow Phalanx in the ordering (+1 each) changed; no other field on any entry.
- Two lines adjusted for a public template: a budget-specific comment on the daily loss limit, and the thesis/docstrings no longer compare against another catalog template by name.

## Review notes

- `weak_peak_cut` is **enabled** here (12h, `min_value: 5`) by design as a dead-position detector; other followers in the catalog disable it. Worth a look from whoever owns the DSL conventions.
- Runtime `version: 3.0.0` follows WhaleHunter's convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

