### PR TITLE
whalehunter: chunk the cohort refresh across ticks so it never times out forever (MINOR)

### DIFF
--- a/senpi-strategy-discover/catalog.json
+++ b/senpi-strategy-discover/catalog.json
@@ -5546,7 +5546,7 @@
       "emoji": "🐋",
       "tagline": "Buckets Hyperliquid traders by lifetime realized PnL into a smart-money cohort and a crowd, then positions WITH the smartest money — and against the crowd — wherever the smart cohort is heavily net-directional and adding to it daily.",
       "belief_plain": "Looks at where the most profitable traders on Hyperliquid are putting their money as a group, and copies that lean — going long what they're loading up on and short what they're dumping, especially when the average crowd is on the other side.",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "thesis": "You trust the aggregate of proven winners over any single guru or your own read. When the >$1M-realized crowd is piling into a coin day after day while the small accounts fade it, that divergence is the edge — so follow the smart cohort, not one whale, and hedge the book with a separate short sleeve.",
       "tags": [
         "smart-money",

--- a/strategies/catalog.json
+++ b/strategies/catalog.json
@@ -5546,7 +5546,7 @@
       "emoji": "🐋",
       "tagline": "Buckets Hyperliquid traders by lifetime realized PnL into a smart-money cohort and a crowd, then positions WITH the smartest money — and against the crowd — wherever the smart cohort is heavily net-directional and adding to it daily.",
       "belief_plain": "Looks at where the most profitable traders on Hyperliquid are putting their money as a group, and copies that lean — going long what they're loading up on and short what they're dumping, especially when the average crowd is on the other side.",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "thesis": "You trust the aggregate of proven winners over any single guru or your own read. When the >$1M-realized crowd is piling into a coin day after day while the small accounts fade it, that divergence is the edge — so follow the smart cohort, not one whale, and hedge the book with a separate short sleeve.",
       "tags": [
         "smart-money",

--- a/strategies/whalehunter/long/runtime.yaml
+++ b/strategies/whalehunter/long/runtime.yaml
@@ -28,7 +28,7 @@ scanners:
     path: ./scanners
     entrypoint: scan.py
     interval_seconds: 300                  # v2 cohort cadence (5 min); ~10 trader_state reads/tick
-    timeout_seconds: 180
+    timeout_seconds: 240                   # under the 300 s interval (a timeout >= the interval regenerates a wedge)
     default_signal_validity_seconds: 1800
     state_history_max_count: 12            # holds the cohort cache + daily ledger + dedup map
     inputs:
@@ -38,7 +38,8 @@ scanners:
       crowdMaxRealizedUsd: 100000
       cohortFetchLimit: 1000
       cohortMaxPages: 6
-      cohortSampleCap: 250
+      cohortPagesPerTick: 2                # the refresh is chunked: 2 pages per tick, progress carried in the cache
+      cohortSampleCap: 150                # 3 state batches per cohort per tick instead of 5
       cohortRefreshHours: 24
       cohortMinMembers: 5
       biasThreshold: 0.5

--- a/strategies/whalehunter/long/scanners/scan.py
+++ b/strategies/whalehunter/long/scanners/scan.py
@@ -6,7 +6,8 @@ passes direction=SHORT. Each sleeve runs on its OWN wallet and its OWN ctx.state
 the cohort cache + daily ledger are per-sleeve (the v2 daemon shared them on disk;
 3.0 instances are isolated — signals are identical, only the cache is duplicated).
 
-Per tick: refresh the smart/crowd cohorts (cached daily in ctx.state), aggregate each
+Per tick: refresh the smart/crowd cohorts (cached daily in ctx.state, built a few pages
+per tick so the refresh never has to fit one timeout), aggregate each
 cohort's net positioning (discovery_get_trader_state), update the daily ledger to get
 the 'adding daily' growth, score the divergences for THIS direction, and emit a
 conviction-scaled marginPct INTENT (the runtime sizes, owns slots/dedup, trails DSL).
@@ -18,7 +19,7 @@ import time
 
 import scoring
 
-CACHE_VERSION = 1     # bump if the cohort-BUILDING logic changes (busts a stale cache)
+CACHE_VERSION = 2     # bump if the cohort-BUILDING logic changes (busts a stale cache) — 2: chunked build
 _DEFAULT_TTL = 3600   # 60m signal-dedup: don't re-fire a coin while a signal is in flight
 
 
@@ -36,10 +37,21 @@ def _read(ctx, name, args):
 def _build_cohorts(ctx, cached, inputs, now):
     """Smart cohort (lifetime realized >= smartMinRealizedUsd) + crowd cohort
     (crowdMin..crowdMax) from the ALL_TIME realized-PnL ranking, PAGED by offset to
-    reach the deep crowd band, each capped. Cached daily in ctx.state."""
+    reach the deep crowd band, each capped. Cached daily in ctx.state.
+
+    The build is CHUNKED across ticks: at most `cohortPagesPerTick` pages are read per
+    tick and the progress (pages done, members so far) is carried in the cache under
+    `build`, so a refresh that cannot fit one tick's timeout completes over several ticks
+    instead of timing out on every tick forever — and a tick killed mid-build loses only
+    that tick's pages. While a build is in progress the LAST COMPLETE cohort is served."""
     refresh_h = float(inputs.get("cohortRefreshHours", 24))
-    if (cached.get("smart") and cached.get("cache_version") == CACHE_VERSION
-            and (now - cached.get("refreshed_at", 0)) / 3600 < refresh_h):
+    pages_per_tick = max(1, int(inputs.get("cohortPagesPerTick", 2)))
+    fresh = bool(cached.get("smart")) and cached.get("cache_version") == CACHE_VERSION \
+        and (now - cached.get("refreshed_at", 0)) / 3600 < refresh_h
+    build = cached.get("build") if isinstance(cached.get("build"), dict) else None
+    if build and (now - float(build.get("started_at", now))) / 3600 >= refresh_h:
+        build = None                                        # a build older than a refresh: start over
+    if fresh and not build:
         return cached                                       # fresh cache — no fetch
     smin = float(inputs.get("smartMinRealizedUsd", 1_000_000))
     cmin = float(inputs.get("crowdMinRealizedUsd", 10_000))
@@ -47,17 +59,23 @@ def _build_cohorts(ctx, cached, inputs, now):
     cap = int(inputs.get("cohortSampleCap", 250))
     page_size = int(inputs.get("cohortFetchLimit", 1000))
     max_pages = int(inputs.get("cohortMaxPages", 6))
-    smart, crowd, seen = [], [], set()
-    for page in range(max_pages):
+    if build is None:
+        build = {"started_at": now, "next_page": 0, "smart": [], "crowd": [], "seen": []}
+    smart, crowd, seen = list(build["smart"]), list(build["crowd"]), set(build["seen"])
+    page = int(build["next_page"])
+    done, fetched = page >= max_pages, 0
+    while page < max_pages and fetched < pages_per_tick:
         resp = _read(ctx, "discovery_get_top_traders", {
             "time_frame": "ALL_TIME", "sort_by": "PROFIT_AND_LOSS_REALIZED",
             "open_position_filter": False, "limit": page_size, "offset": page * page_size})
+        fetched += 1
         if not resp:
-            break
+            break                                           # transient: keep progress, resume next tick
         raw = resp.get("data", resp) if isinstance(resp, dict) else resp
         if isinstance(raw, dict):
             raw = raw.get("traders", raw.get("data", []))
         if not isinstance(raw, list) or not raw:
+            done = True
             break
         page_top = None
         for t in raw:
@@ -76,13 +94,26 @@ def _build_cohorts(ctx, cached, inputs, now):
                 if len(crowd) < cap:
                     crowd.append(addr)
                     seen.add(addr)
+        page += 1
         if len(smart) >= cap and len(crowd) >= cap:
+            done = True
             break
         if page_top is not None and page_top < cmin:        # whole page below the crowd floor
+            done = True
             break
-    if not smart and not crowd:
-        return cached                                       # failed refresh — keep the old cache
-    return {"refreshed_at": now, "cache_version": CACHE_VERSION, "smart": smart, "crowd": crowd}
+    if page >= max_pages:
+        done = True
+    if done:
+        if not smart and not crowd:                         # failed refresh — keep the old cache
+            return {k: v for k, v in cached.items() if k != "build"}
+        return {"refreshed_at": now, "cache_version": CACHE_VERSION, "smart": smart, "crowd": crowd}
+    out = {k: v for k, v in cached.items() if k != "build"}
+    out["build"] = {"started_at": build["started_at"], "next_page": page,
+                    "smart": smart, "crowd": crowd, "seen": sorted(seen)}
+    if fetched:
+        print(f"[whalehunter.scan] cohort build in progress: page {page}/{max_pages}, "
+              f"smart={len(smart)} crowd={len(crowd)} — serving the last complete cohort", file=sys.stderr)
+    return out
 
 
 def _fetch_states(ctx, addrs):

--- a/strategies/whalehunter/short/runtime.yaml
+++ b/strategies/whalehunter/short/runtime.yaml
@@ -28,7 +28,7 @@ scanners:
     path: ./scanners
     entrypoint: scan.py
     interval_seconds: 300
-    timeout_seconds: 180
+    timeout_seconds: 240                   # under the 300 s interval (a timeout >= the interval regenerates a wedge)
     default_signal_validity_seconds: 1800
     state_history_max_count: 12
     inputs:
@@ -38,7 +38,8 @@ scanners:
       crowdMaxRealizedUsd: 100000
       cohortFetchLimit: 1000
       cohortMaxPages: 6
-      cohortSampleCap: 250
+      cohortPagesPerTick: 2                # the refresh is chunked: 2 pages per tick, progress carried in the cache
+      cohortSampleCap: 150                # 3 state batches per cohort per tick instead of 5
       cohortRefreshHours: 24
       cohortMinMembers: 5
       biasThreshold: 0.5

--- a/strategies/whalehunter/short/scanners/scan.py
+++ b/strategies/whalehunter/short/scanners/scan.py
@@ -6,7 +6,8 @@ passes direction=SHORT. Each sleeve runs on its OWN wallet and its OWN ctx.state
 the cohort cache + daily ledger are per-sleeve (the v2 daemon shared them on disk;
 3.0 instances are isolated — signals are identical, only the cache is duplicated).
 
-Per tick: refresh the smart/crowd cohorts (cached daily in ctx.state), aggregate each
+Per tick: refresh the smart/crowd cohorts (cached daily in ctx.state, built a few pages
+per tick so the refresh never has to fit one timeout), aggregate each
 cohort's net positioning (discovery_get_trader_state), update the daily ledger to get
 the 'adding daily' growth, score the divergences for THIS direction, and emit a
 conviction-scaled marginPct INTENT (the runtime sizes, owns slots/dedup, trails DSL).
@@ -18,7 +19,7 @@ import time
 
 import scoring
 
-CACHE_VERSION = 1     # bump if the cohort-BUILDING logic changes (busts a stale cache)
+CACHE_VERSION = 2     # bump if the cohort-BUILDING logic changes (busts a stale cache) — 2: chunked build
 _DEFAULT_TTL = 3600   # 60m signal-dedup: don't re-fire a coin while a signal is in flight
 
 
@@ -36,10 +37,21 @@ def _read(ctx, name, args):
 def _build_cohorts(ctx, cached, inputs, now):
     """Smart cohort (lifetime realized >= smartMinRealizedUsd) + crowd cohort
     (crowdMin..crowdMax) from the ALL_TIME realized-PnL ranking, PAGED by offset to
-    reach the deep crowd band, each capped. Cached daily in ctx.state."""
+    reach the deep crowd band, each capped. Cached daily in ctx.state.
+
+    The build is CHUNKED across ticks: at most `cohortPagesPerTick` pages are read per
+    tick and the progress (pages done, members so far) is carried in the cache under
+    `build`, so a refresh that cannot fit one tick's timeout completes over several ticks
+    instead of timing out on every tick forever — and a tick killed mid-build loses only
+    that tick's pages. While a build is in progress the LAST COMPLETE cohort is served."""
     refresh_h = float(inputs.get("cohortRefreshHours", 24))
-    if (cached.get("smart") and cached.get("cache_version") == CACHE_VERSION
-            and (now - cached.get("refreshed_at", 0)) / 3600 < refresh_h):
+    pages_per_tick = max(1, int(inputs.get("cohortPagesPerTick", 2)))
+    fresh = bool(cached.get("smart")) and cached.get("cache_version") == CACHE_VERSION \
+        and (now - cached.get("refreshed_at", 0)) / 3600 < refresh_h
+    build = cached.get("build") if isinstance(cached.get("build"), dict) else None
+    if build and (now - float(build.get("started_at", now))) / 3600 >= refresh_h:
+        build = None                                        # a build older than a refresh: start over
+    if fresh and not build:
         return cached                                       # fresh cache — no fetch
     smin = float(inputs.get("smartMinRealizedUsd", 1_000_000))
     cmin = float(inputs.get("crowdMinRealizedUsd", 10_000))
@@ -47,17 +59,23 @@ def _build_cohorts(ctx, cached, inputs, now):
     cap = int(inputs.get("cohortSampleCap", 250))
     page_size = int(inputs.get("cohortFetchLimit", 1000))
     max_pages = int(inputs.get("cohortMaxPages", 6))
-    smart, crowd, seen = [], [], set()
-    for page in range(max_pages):
+    if build is None:
+        build = {"started_at": now, "next_page": 0, "smart": [], "crowd": [], "seen": []}
+    smart, crowd, seen = list(build["smart"]), list(build["crowd"]), set(build["seen"])
+    page = int(build["next_page"])
+    done, fetched = page >= max_pages, 0
+    while page < max_pages and fetched < pages_per_tick:
         resp = _read(ctx, "discovery_get_top_traders", {
             "time_frame": "ALL_TIME", "sort_by": "PROFIT_AND_LOSS_REALIZED",
             "open_position_filter": False, "limit": page_size, "offset": page * page_size})
+        fetched += 1
         if not resp:
-            break
+            break                                           # transient: keep progress, resume next tick
         raw = resp.get("data", resp) if isinstance(resp, dict) else resp
         if isinstance(raw, dict):
             raw = raw.get("traders", raw.get("data", []))
         if not isinstance(raw, list) or not raw:
+            done = True
             break
         page_top = None
         for t in raw:
@@ -76,13 +94,26 @@ def _build_cohorts(ctx, cached, inputs, now):
                 if len(crowd) < cap:
                     crowd.append(addr)
                     seen.add(addr)
+        page += 1
         if len(smart) >= cap and len(crowd) >= cap:
+            done = True
             break
         if page_top is not None and page_top < cmin:        # whole page below the crowd floor
+            done = True
             break
-    if not smart and not crowd:
-        return cached                                       # failed refresh — keep the old cache
-    return {"refreshed_at": now, "cache_version": CACHE_VERSION, "smart": smart, "crowd": crowd}
+    if page >= max_pages:
+        done = True
+    if done:
+        if not smart and not crowd:                         # failed refresh — keep the old cache
+            return {k: v for k, v in cached.items() if k != "build"}
+        return {"refreshed_at": now, "cache_version": CACHE_VERSION, "smart": smart, "crowd": crowd}
+    out = {k: v for k, v in cached.items() if k != "build"}
+    out["build"] = {"started_at": build["started_at"], "next_page": page,
+                    "smart": smart, "crowd": crowd, "seen": sorted(seen)}
+    if fetched:
+        print(f"[whalehunter.scan] cohort build in progress: page {page}/{max_pages}, "
+              f"smart={len(smart)} crowd={len(crowd)} — serving the last complete cohort", file=sys.stderr)
+    return out
 
 
 def _fetch_states(ctx, addrs):

--- a/strategies/whalehunter/strategy.yaml
+++ b/strategies/whalehunter/strategy.yaml
@@ -5,7 +5,7 @@
 schema_version: 1
 
 id: whalehunter
-version: "1.1.0"
+version: "1.2.0"
 
 catalog:
   name: "WhaleHunter — Smart-Money Cohort Divergence"

--- a/strategies/whalehunter/tests/test_cohort_build.py
+++ b/strategies/whalehunter/tests/test_cohort_build.py
@@ -1,0 +1,96 @@
+"""WhaleHunter cohort build is CHUNKED across ticks (no network; fake ctx).
+Run: python3 -m pytest strategies/whalehunter/tests -q"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "long", "scanners"))
+import scan  # noqa: E402
+
+
+class _State:
+    def __init__(self):
+        self.records = []
+
+    def last(self):
+        return self.records[-1] if self.records else None
+
+    def append(self, rec):
+        self.records.append(rec)
+
+
+class _Ctx:
+    """6 pages of 1,000 traders: realized PnL descends 6,000,000 → 1 so smart (>= $1M) fills from the
+    first pages and crowd ($10k–$100k) from the deep pages. Records every MCP call."""
+    def __init__(self, fail_on_call=None):
+        self.calls = []
+        self.state = _State()
+        self.wallet = "0xwallet"
+        self.fail_on_call = fail_on_call
+        self.senpi_mcp = self
+
+    def call_tool(self, name, args):
+        self.calls.append((name, args))
+        if self.fail_on_call is not None and len(self.calls) == self.fail_on_call:
+            raise RuntimeError("simulated transport failure")
+        if name == "discovery_get_top_traders":
+            off = int(args["offset"])
+            rows = []
+            for i in range(off, off + int(args["limit"])):
+                v = 6_000_000 - i * 1000
+                rows.append({"address": "0x%040x" % (i + 1), "realizedPnl": v, "realized_pnl": v,
+                             "realizedProfitAndLoss": v, "profit_and_loss_realized": v})
+            return {"data": rows}
+        if name == "discovery_get_trader_state":
+            return {"data": {"traders": [{"traderAddress": a, "openPositions": []} for a in args["trader_addresses"]]}}
+        return {}
+
+
+_INPUTS = {"cohortMaxPages": 6, "cohortPagesPerTick": 2, "cohortSampleCap": 5000, "cohortFetchLimit": 1000,
+           "cohortRefreshHours": 24, "smartMinRealizedUsd": 1_000_000, "crowdMinRealizedUsd": 10_000,
+           "crowdMaxRealizedUsd": 100_000}
+
+
+def _pages(ctx):
+    return sum(1 for n, _ in ctx.calls if n == "discovery_get_top_traders")
+
+
+def test_a_six_page_refresh_completes_over_three_ticks_serving_nothing_stale():
+    ctx = _Ctx()
+    c1 = scan._build_cohorts(ctx, {}, _INPUTS, now=1000)
+    assert c1.get("build", {}).get("next_page") == 2 and not c1.get("smart") and _pages(ctx) == 2
+    c2 = scan._build_cohorts(ctx, c1, _INPUTS, now=1300)
+    assert c2["build"]["next_page"] == 4 and _pages(ctx) == 4
+    c3 = scan._build_cohorts(ctx, c2, _INPUTS, now=1600)
+    assert "build" not in c3 and c3["refreshed_at"] == 1600 and _pages(ctx) == 6
+    assert len(c3["smart"]) == 5001 and len(c3["crowd"]) == 91   # 6,000,000..1,000,000 step 1000 ; 100,000..10,000
+    # fresh now: no further reads
+    c4 = scan._build_cohorts(ctx, c3, _INPUTS, now=1900)
+    assert c4 is c3 and _pages(ctx) == 6
+
+
+def test_a_killed_tick_loses_only_its_own_pages_and_never_double_counts():
+    ctx = _Ctx(fail_on_call=3)                      # the 3rd page read raises (tick 2, first page)
+    c1 = scan._build_cohorts(ctx, {}, _INPUTS, now=1000)
+    c2 = scan._build_cohorts(ctx, c1, _INPUTS, now=1300)  # read fails → progress kept at page 2
+    assert c2["build"]["next_page"] == 2
+    ctx.fail_on_call = None
+    c3 = scan._build_cohorts(ctx, c2, _INPUTS, now=1600)
+    c4 = scan._build_cohorts(ctx, c3, _INPUTS, now=1900)
+    assert "build" not in c4 and len(set(c4["smart"])) == len(c4["smart"]) == 5001
+
+
+def test_the_last_complete_cohort_is_served_while_a_new_build_runs():
+    old = {"refreshed_at": 0, "cache_version": scan.CACHE_VERSION, "smart": ["0xold"] * 6, "crowd": ["0xc"]}
+    ctx = _Ctx()
+    c1 = scan._build_cohorts(ctx, old, _INPUTS, now=48 * 3600)   # stale → refresh starts, chunked
+    assert c1["smart"] == old["smart"] and c1["build"]["next_page"] == 2
+
+
+def test_scan_persists_the_build_and_resumes_it_next_tick():
+    ctx = _Ctx()
+    inputs = dict(_INPUTS, direction="LONG", cohortMinMembers=5)
+    out1 = scan.scan(inputs, ctx)
+    assert out1 == [] and ctx.state.last()["cohorts"]["build"]["next_page"] == 2
+    scan.scan(inputs, ctx)
+    scan.scan(inputs, ctx)
+    assert "build" not in ctx.state.last()["cohorts"] and len(ctx.state.last()["cohorts"]["smart"]) == 5001


### PR DESCRIPTION
The daily cohort refresh (six 1,000-trader pages + the state batches) could not fit a 180 s tick, and a tick killed by the timeout never wrote its cache, so every following tick restarted the same refresh: 44 hours of timeouts and zero signals on a user's book, then a sleeve marked wedged in three daily reports.

`_build_cohorts` now reads at most `cohortPagesPerTick` (2) pages per tick, carries progress in the cache under `build`, serves the last complete cohort meanwhile, restarts a build older than a refresh, and a tick killed mid-build loses only its own pages. Sample cap 250 → 150, timeout 180 → 240 s (under the 300 s interval — a timeout ≥ interval regenerates a wedge), `CACHE_VERSION` 2. Both sleeves share the scanner byte-for-byte. Four fake-ctx tests; validator clean; catalog regenerated.

Runtime side of the same failure (bounded MCP calls, session rebuild after a transport failure, mcp_error in scanner health): #380 / #381 / #382 / #389 / #395.

🤖 Generated with [Claude Code](https://claude.com/claude-code)