### PR TITLE
portfolio: fees are read, never estimated — a P&L claim quotes the wallet's signed fees (MINOR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Every analytical skill follows the **hidden-engine pattern**: a vendored, stdlib
 | Skill | Ver | Role |
 |---|---|---|
 | **Analyze** | | |
-| [`senpi-portfolio`](senpi-portfolio/) | 1.19.0 | All-wallet portfolio, positions, DSL protection, per-strategy mandate reads |
+| [`senpi-portfolio`](senpi-portfolio/) | 1.20.0 | All-wallet portfolio, positions, DSL protection, per-strategy mandate reads |
 | [`senpi-market-pulse`](senpi-market-pulse/) | 1.3.0 | Daily cross-asset market read (crypto, equities, commodities, macro, funding regime) |
 | [`senpi-smart-money`](senpi-smart-money/) | 1.3.0 | Where the most-profitable wallets are positioned vs. the crowd |
 | [`senpi-trader-research`](senpi-trader-research/) | 1.4.0 | Rank + vet Hyperliquid traders before copying them (mirror-aware: copyability, min-budget, live book) |

--- a/senpi-portfolio/SKILL.md
+++ b/senpi-portfolio/SKILL.md
@@ -16,7 +16,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "1.19.0"
+  version: "1.20.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -295,6 +295,11 @@ scan error — both facts true at once. So read them as a grid, not a single ver
 
 **When the two disagree, say which one you are trusting and why.** If the money is moving, that is the
 headline and the field is the footnote — do not report the field and bury the evidence.
+
+**Fees are read, never estimated.** A P&L claim about a strategy — "it is up", "it is not losing" —
+quotes the wallet's **signed** fees from its fills (`totalFees` / the closed-trade history), net of
+them, with the fee figure beside the PnL. "About $7 on 41 trades" is a guess, and it once turned a −$3
+wallet into a +$1.69 one in the user's ear. If the fee read fails, say the number is gross and why.
 
 **Paper is not live.** A `senpi validate` tick, a scanner signal, a simulation or an estimate is not a
 trade; only a fill on the strategy wallet (`positions`, `closed`) is. Never narrate a shadow run as


### PR DESCRIPTION
One rule in `senpi-portfolio/SKILL.md`: a P&L claim about a strategy quotes the wallet's signed fees from its fills, net of them, with the fee figure beside the PnL — never an estimate. From the M371275 review, where an estimated fee figure turned a −$3.01 wallet into "not losing (+$1.69)". MINOR bump, README row synced, tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)