### PR TITLE
phalanx: min-budget golden entry (main CI red since #581)

### DIFF
--- a/senpi-trading-runtime/tests/fixtures/min_budget_golden.json
+++ b/senpi-trading-runtime/tests/fixtures/min_budget_golden.json
@@ -72,6 +72,7 @@
   "ox": 275,
   "oxpecker": 30,
   "pangolin": 20,
+  "phalanx": 30,
   "pilotfish": 50,
   "piranha": 25,
   "polar": 10,


### PR DESCRIPTION
The golden min-budget test had no phalanx entry after #581, so the `test_min_budget_golden.py` CI step has failed on main and on every open PR since. This adds the test's own computed value (30) and nothing else; the exact CI steps pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)